### PR TITLE
Add GitHub workflow & GoReleaser

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,30 @@
+name: release
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Unshallow
+        run: git fetch --prune --unshallow
+      -
+        name: Set up Go
+        uses: actions/setup-go@v1
+        with: # Ideally this should be picked up from .go-version rather than hard-coded
+          go-version: 1.13.8
+      -
+        name: Release
+        uses: goreleaser/goreleaser-action@v1
+        with:
+          version: latest
+          args: release --skip-sign
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,38 @@
+before:
+  hooks:
+    - go test ./...
+
+builds:
+  - 
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      - '-s -w -X "github.com/hashicorp/terraform-ls/version.Version={{ .Version }}" -X "github.com/hashicorp/terraform-ls/version.Prerelease="'
+    targets:
+      - darwin_amd64
+      - freebsd_386
+      - freebsd_amd64
+      - freebsd_arm
+      - linux_386
+      - linux_amd64
+      - linux_arm
+      - openbsd_386
+      - openbsd_amd64
+      - solaris_amd64
+      - windows_386
+      - windows_amd64
+
+archives:
+  -
+    format: zip
+    name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+    wrap_in_directory: false
+    files: # Avoid packaging any extra (default) files
+      - none*
+
+checksum:
+  name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
+  algorithm: sha256
+
+changelog:
+  skip: true


### PR DESCRIPTION
Releases can be triggered just by push a tag which follows semver convention (`v1.2.3`).

--- 

I did not set up notarization (yet), so the darwin binaries on 10.15 (Catalina) will prompt the popup, such as:

![Screenshot 2020-03-24 at 21 57 36](https://user-images.githubusercontent.com/287584/77480908-82bf4680-6e1a-11ea-975f-961b27cab21c.png)

Additionally it seems that Mac will show this warning after downloading the darwin ZIP file:

![Screenshot 2020-03-24 at 20 49 53](https://user-images.githubusercontent.com/287584/77480979-9d91bb00-6e1a-11ea-83f3-4299d31adffe.png)

We can look into notarization as part of a separate PR.

--- 

Closes #31 