### PR TITLE
Update installation & contribution instructions & add Makefile

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Reporting Feedback
 
-Terraform Language Server is an open source project and we appreciate
+Terraform language server is an open source project and we appreciate
 contributions of various kinds, including bug reports and fixes,
 enhancement proposals, documentation updates, and user experience feedback.
 
@@ -18,7 +18,7 @@ communication channels is subject to
 
 ## Scope
 
-This repository contains the source code only for Terraform Language Server,
+This repository contains the source code only for Terraform language server,
 which in turn relies on other projects that have their own repositories.
 
 [Terraform CLI/core has its own repository.](https://github.com/hashicorp/terraform)
@@ -41,7 +41,7 @@ If you wish to work on the source code, you'll first need to install
 [Git](https://git-scm.com/).
 
 Refer to the file [`.go-version`](.go-version) to see which version of Go
-the Language Server is currently built with. Other versions will often work,
+the language server is currently built with. Other versions will often work,
 but if you run into any build or testing problems please try with the specific
 Go version indicated. You can optionally simplify the installation of multiple
 specific versions of Go on your system by installing
@@ -53,11 +53,11 @@ are tracked via [Go Modules](https://blog.golang.org/using-go-modules),
 and so you should _not_ clone it inside your `GOPATH`.
 
 Switch into the root directory of the cloned repository and build
-the Language Server using the Go toolchain in the standard way:
+the language server
 
 ```
 cd terraform-ls
-go install .
+make build
 ```
 
 Once the compilation process succeeds, you can find a `terraform-ls` executable in
@@ -128,7 +128,7 @@ than some other change types to become conflicted with other proposed changes
 during the code review process. For that reason, and to make dependency changes
 more visible in the change history, we prefer to record dependency changes as
 separate commits that include only the results of the above commands and the
-minimal set of changes to the Language Server's own code for compatibility
+minimal set of changes to the language server's own code for compatibility
 with the new version:
 
 ```

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+VERSION?=$$(curl -s "https://api.github.com/repos/hashicorp/terraform-ls/releases/latest" | jq -r .name)
+
+default: test
+
+test:
+	go test -mod=vendor ./...
+
+build:
+ifeq (,$(VERSION))
+	@echo "ERROR: Set VERSION to a valid semver version. For example,";
+	@echo " VERSION=0.1.0";
+	@exit 1;
+endif
+	$(eval LDFLAGS := "-s -w -X github.com/hashicorp/terraform-ls/version.Version="$$(VERSION))
+	go install -ldflags $(LDFLAGS) .
+
+.PHONY: test build

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Terraform Language Server
 
-Experimental version of [Terraform](https://www.terraform.io) Language Server.
+Experimental version of [Terraform](https://www.terraform.io) language server.
 
 ## What is LSP
 
@@ -22,14 +22,15 @@ This is not an officially supported HashiCorp product.
 
 ## Installation
 
-```
-go install .
-```
-
-This should produce a binary called `terraform-ls` in `$GOBIN/terraform-ls`.
-
-Putting `$GOBIN` in your `$PATH` may save you from having to specify
-absolute path to the binary.
+1. [Download for the latest version](https://github.com/hashicorp/terraform-ls/releases/latest)
+  of the language server relevant for your operating system and architecture.
+2. The language server is distributed as a single binary.
+  Install it by unzipping it and moving it to a directory
+  included in your system's `PATH`.
+3. You can verify integrity by comparing the SHA256 checksums
+  which are part of the release (called `terraform-ls_<VERSION>_SHA256SUMS`).
+4. Check that you have installed the server correctly via `terraform-ls -v`.
+  You should see the latest version printed to your terminal.
 
 ## Usage
 

--- a/version/version.go
+++ b/version/version.go
@@ -2,12 +2,13 @@ package version
 
 import (
 	"fmt"
+	"errors"
 
 	version "github.com/hashicorp/go-version"
 )
 
 // The main version number that is being run at the moment.
-var Version = "0.0.0"
+var Version = "_"
 
 // A pre-release marker for the version. If this is "" (empty string)
 // then it means that it is a final release. Otherwise, this is a pre-release
@@ -20,7 +21,11 @@ var Prerelease = "dev"
 var SemVer *version.Version
 
 func init() {
-	SemVer = version.Must(version.NewVersion(Version))
+	var err error
+	SemVer, err = version.NewVersion(Version)
+	if err != nil {
+		panic(errors.New("Please use 'make build' to compile and install"))
+	}
 }
 
 // ServerName is the name used to send to clients as a way


### PR DESCRIPTION
This change effectively enforces developers to build through the make target
and prevents server of version `0.0.0` from ever appearing in the wild.

As for the makefile logic:
 - if the version is not provided we source the latest one from GitHub API
 - in the "happy path" (being online and GitHub's API working correctly) `make build` "just works"
 - otherwise (e.g. when offline) we can still build e.g. via `VERSION=0.1.0 make build`