### PR TITLE
terraform: Report uninitialized workspace

### DIFF
--- a/internal/terraform/errors/errors.go
+++ b/internal/terraform/errors/errors.go
@@ -28,3 +28,24 @@ func (utv *UnsupportedTerraformVersion) Error() string {
 
 	return msg
 }
+
+type NotInitializedErr struct {
+	Dir string
+}
+
+func (e *NotInitializedErr) Is(err error) bool {
+	_, ok := err.(*NotInitializedErr)
+	if !ok {
+		return false
+	}
+
+	return true
+}
+
+func (e *NotInitializedErr) Error() string {
+	if e.Dir != "" {
+		return fmt.Sprintf("workspace %s not initialized", e.Dir)
+	}
+
+	return fmt.Sprintf("workspace not initialized")
+}

--- a/internal/terraform/schema/watcher.go
+++ b/internal/terraform/schema/watcher.go
@@ -89,6 +89,11 @@ func (w *Watcher) AddWorkspace(dir string) error {
 
 	hash, err := fileHashSum(lockPath)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return &errors.NotInitializedErr{
+				Dir: dir,
+			}
+		}
 		return fmt.Errorf("unable to calculate hash: %w", err)
 	}
 


### PR DESCRIPTION
This improves the UX a little bit when user tries to open a directory which has not been `terraform init`'d.

## Before

```
2020/05/05 10:05:46 service.go:56: Preparing new service ...
2020/05/05 10:05:46 langserver.go:65: Starting server (pid 69133) ...
...
2020/05/05 10:05:46 exec.go:114: Running /usr/local/bin/terraform ["version"] in "/Users/jamesbayer/Documents/workspace/terraform-getting-started"...
2020/05/05 10:05:46 exec.go:140: terraform run (/usr/local/bin/terraform ["version"], in "/Users/jamesbayer/Documents/workspace/terraform-getting-started", pid 69135) finished with exit code 0
2020/05/05 10:05:46 initialize.go:85: Found compatible Terraform version (0.12.24) at /usr/local/bin/terraform
2020/05/05 10:05:46 schema_storage.go:266: Adding workspace for watching: "/Users/jamesbayer/Documents/workspace/terraform-getting-started"
2020/05/05 10:05:46 watcher.go:88: Adding "/Users/jamesbayer/Documents/workspace/terraform-getting-started/.terraform/plugins/darwin_amd64/lock.json" for watching...
2020/05/05 10:05:46 schema_storage.go:107: Acquiring semaphore before retrieving schema for "/Users/jamesbayer/Documents/workspace/terraform-getting-started" ...
2020/05/05 10:05:46 schema_storage.go:116: Retrieving schemas for "/Users/jamesbayer/Documents/workspace/terraform-getting-started" ...
2020/05/05 10:05:46 exec.go:114: Running /usr/local/bin/terraform ["providers" "schema" "-json"] in "/Users/jamesbayer/Documents/workspace/terraform-getting-started"...
2020/05/05 10:05:46 rpc_logger.go:45: Error for "initialize" (ID 0): [-32098] unable to calculate hash: open /Users/jamesbayer/Documents/workspace/terraform-getting-started/.terraform/plugins/darwin_amd64/lock.json: no such file or directory
2020/05/05 10:05:46 server.go:204: Completed 1 requests [50.043298ms elapsed]
[Error - 10:05:46 AM] Server initialization failed.
  Message: unable to calculate hash: open /Users/jamesbayer/Documents/workspace/terraform-getting-started/.terraform/plugins/darwin_amd64/lock.json: no such file or directory
  Code: -32098 
```

## After

The log messages differ slightly as this build also includes some other patches.

```
2020/05/06 14:11:54 service.go:59: Preparing new session ...
...
2020/05/06 14:11:54 exec.go:180: Starting /usr/local/bin/terraform ["terraform" "version"] in "/var/folders/fb/k_9ystyd08j934qcxmyv0wjc0000gp/T/"...
2020/05/06 14:11:54 exec.go:146: Waiting for command to finish ...
2020/05/06 14:11:54 exec.go:172: terraform run (/usr/local/bin/terraform ["terraform" "version"], in "/var/folders/fb/k_9ystyd08j934qcxmyv0wjc0000gp/T/", pid 68828) finished with exit code 0
2020/05/06 14:11:54 initialize.go:90: Found compatible Terraform version (0.12.24) at /usr/local/bin/terraform
2020/05/06 14:11:54 schema_storage.go:327: Adding workspace for watching: "/private/var/workspace/tf-test/github"
2020/05/06 14:11:54 watcher.go:88: Adding "/private/var/workspace/tf-test/github/.terraform/plugins/darwin_amd64/lock.json" for watching...
2020/05/06 14:11:54 schema_storage.go:120: Acquiring semaphore before retrieving schema for "/private/var/workspace/tf-test/github" ...
2020/05/06 14:11:54 schema_storage.go:129: Retrieving schemas for "/private/var/workspace/tf-test/github" ...
2020/05/06 14:11:54 rpc_logger.go:45: Error for "initialize" (ID 1): [-32098] Workspace not initialized. Please run `terraform init` in /private/var/workspace/tf-test/github
2020/05/06 14:11:54 server.go:204: Completed 1 requests [117.794116ms elapsed]
2020/05/06 14:11:54 exec.go:180: Starting /usr/local/bin/terraform ["terraform" "providers" "schema" "-json"] in "/private/var/workspace/tf-test/github"...
2020/05/06 14:11:54 server.go:469: Received 1 new requests
2020/05/06 14:11:54 server.go:165: Processing 1 requests
2020/05/06 14:11:54 server.go:223: Checking request for "shutdown":
2020/05/06 14:11:54 rpc_logger.go:29: Incoming request for "shutdown" (ID 2):
2020/05/06 14:11:54 rpc_logger.go:50: Response to "shutdown" (ID 2): null
2020/05/06 14:11:54 server.go:204: Completed 1 requests [144.872µs elapsed]
2020/05/06 14:11:54 server.go:469: Received 1 new requests
2020/05/06 14:11:54 server.go:165: Processing 1 requests
2020/05/06 14:11:54 server.go:223: Checking request for "exit":
2020/05/06 14:11:54 rpc_logger.go:29: Incoming notification for "exit":
2020/05/06 14:11:54 exec.go:146: Waiting for command to finish ...
2020/05/06 14:11:54 schema_storage.go:112: error obtaining schemas: Unable to retrieve schemas: failed to get schemas: Execution of ["terraform" "providers" "schema" "-json"] canceled.
```

--- 

How and whether the error from `initialize` is surfaced on the client depends on client implementation and we could in theory [publish diagnostics](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_publishDiagnostics) to inform the user that way. 

Regardless though I think we first need change the reporting of such errors to avoid blocking initialization and still provide reduced functionality - then perhaps we can publish warning informing the user of reduced functionality.
https://github.com/hashicorp/terraform-ls/issues/83