### PR TITLE
context: Refactor and fix duplicate key

### DIFF
--- a/internal/context/errors.go
+++ b/internal/context/errors.go
@@ -1,0 +1,11 @@
+package context
+
+import "fmt"
+
+type MissingContextErr struct {
+	CtxKey *contextKey
+}
+
+func (e *MissingContextErr) Error() string {
+	return fmt.Sprintf("missing context: %s", e.CtxKey)
+}

--- a/internal/context/signal_cancel.go
+++ b/internal/context/signal_cancel.go
@@ -1,0 +1,32 @@
+package context
+
+import (
+	"context"
+	"log"
+	"os"
+	"os/signal"
+)
+
+func WithSignalCancel(ctx context.Context, l *log.Logger, sigs ...os.Signal) (
+	context.Context, context.CancelFunc) {
+	ctx, cancelFunc := context.WithCancel(ctx)
+
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, sigs...)
+
+	go func() {
+		select {
+		case sig := <-sigChan:
+			l.Printf("Cancellation signal (%s) received", sig)
+			cancelFunc()
+		case <-ctx.Done():
+		}
+	}()
+
+	f := func() {
+		signal.Stop(sigChan)
+		cancelFunc()
+	}
+
+	return ctx, f
+}


### PR DESCRIPTION
Fixes #79

This addresses the problem of potentially conflicting keys by turning keys into pointers, which will always be unique, even if the string-based internal name is the same (either intentionally or by accident).