### PR TITLE
build: Sign archives checksum

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,12 +30,16 @@ jobs:
         env:
           VERSION: v0
       -
+        name: Import PGP key for archive signing
+        run: echo -e "${{ secrets.PGP_SIGNING_KEY }}" | gpg --import
+      -
         name: Release
         uses: goreleaser/goreleaser-action@v1
         with:
           version: latest
-          args: release --skip-sign
+          args: release
         env:
+          PGP_USER_ID: ${{ secrets.PGP_USER_ID }}
           CODESIGN_IMAGE: ${{ steps.codesign.outputs.image }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ARTIFACTORY_TOKEN: ${{ secrets.ARTIFACTORY_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -50,5 +50,10 @@ checksum:
   name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
   algorithm: sha256
 
+signs:
+  -
+    args: ["-u", "{{ .Env.PGP_USER_ID }}", "--output", "${signature}", "--detach-sign", "${artifact}"]
+    artifacts: checksum
+
 changelog:
   skip: true


### PR DESCRIPTION
This is in preparation for https://github.com/hashicorp/terraform-ls/issues/49 as we can't publish any artifacts to releases.hashicorp.com without the signature.

cc @aeschright - FYI we could also verify the signature when installing the LS in VSCode. I'm just not sure what's the best workflow there and whether to bundle the pubkey (probably more secure, less convenient for potential updates) or pull it down from somewhere on demand (theoretically less secure, but more convenient for updates).