### PR TITLE
Partial update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 dist/
+.idea/

--- a/internal/filesystem/file.go
+++ b/internal/filesystem/file.go
@@ -47,8 +47,8 @@ func (f *file) Version() int {
 	return f.version
 }
 
-func (f *file) IncrementVersion() {
-	f.version += 1
+func (f *file) SetVersion(version int) {
+	f.version = version
 }
 
 func (f *file) Lines() source.Lines {

--- a/internal/filesystem/file.go
+++ b/internal/filesystem/file.go
@@ -53,6 +53,7 @@ func (f *file) Text() []byte {
 }
 
 func (f *file) applyChange(change FileChange) error {
+	// hcl pos column and line start from 1
 	// such case, we regard it as full content change
 	if change.Range().End.Column == 0 && change.Range().End.Line == 0 {
 		f.content = []byte(change.Text())

--- a/internal/filesystem/file.go
+++ b/internal/filesystem/file.go
@@ -18,8 +18,9 @@ type file struct {
 	content  []byte
 	open     bool
 
-	ls   source.Lines
-	errs bool
+	version int
+	ls      source.Lines
+	errs    bool
 }
 
 func NewFile(fullPath string, content []byte) *file {
@@ -40,6 +41,14 @@ func (f *file) Filename() string {
 
 func (f *file) URI() string {
 	return URIFromPath(f.fullPath)
+}
+
+func (f *file) Version() int {
+	return f.version
+}
+
+func (f *file) IncrementVersion() {
+	f.version += 1
 }
 
 func (f *file) Lines() source.Lines {

--- a/internal/filesystem/file.go
+++ b/internal/filesystem/file.go
@@ -83,8 +83,8 @@ func (f *file) change(s []byte) {
 	f.ls = nil
 }
 
-// hcl pos column and line start from 1
-// if the range end position column and line are 0, we regard it is a nil range
+// HCL column and line indexes start from 1, therefore if the any index
+// contains 0, we assume it is an undefined range
 func rangeIsNil(r hcl.Range) bool {
 	return r.End.Column == 0 && r.End.Line == 0
 }

--- a/internal/filesystem/file_test.go
+++ b/internal/filesystem/file_test.go
@@ -18,6 +18,18 @@ func TestFile_ApplyChange_fullUpdate(t *testing.T) {
 	}
 }
 
+func TestFile_ApplyChange_partialUpdate(t *testing.T) {
+	f := NewFile("file:///test.tf", []byte("hello world"))
+
+	fChange := &fileChange{
+		text: "something else",
+	}
+	err := f.applyChange(fChange)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 type fileChange struct {
 	text string
 }

--- a/internal/filesystem/file_test.go
+++ b/internal/filesystem/file_test.go
@@ -22,16 +22,34 @@ func TestFile_ApplyChange_partialUpdate(t *testing.T) {
 	f := NewFile("file:///test.tf", []byte("hello world"))
 
 	fChange := &fileChange{
-		text: "something else",
+		text: "terraform",
+		rng: hcl.Range{
+			Start: hcl.Pos{
+				Line:   1,
+				Column: 6,
+				Byte:   6,
+			},
+			End: hcl.Pos{
+				Line:   1,
+				Column: 11,
+				Byte:   11,
+			},
+		},
 	}
 	err := f.applyChange(fChange)
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	expected := "hello terraform"
+	if string(f.content) != expected {
+		t.Fatalf("expected: %q but actually: %q", expected, string(f.content))
+	}
 }
 
 type fileChange struct {
 	text string
+	rng  hcl.Range
 }
 
 func (fc *fileChange) Text() string {
@@ -39,7 +57,5 @@ func (fc *fileChange) Text() string {
 }
 
 func (fc *fileChange) Range() hcl.Range {
-	return hcl.Range{
-		// TODO: Implement partial updates
-	}
+	return fc.rng
 }

--- a/internal/filesystem/file_test.go
+++ b/internal/filesystem/file_test.go
@@ -19,31 +19,126 @@ func TestFile_ApplyChange_fullUpdate(t *testing.T) {
 }
 
 func TestFile_ApplyChange_partialUpdate(t *testing.T) {
-	f := NewFile("file:///test.tf", []byte("hello world"))
-
-	fChange := &fileChange{
-		text: "terraform",
-		rng: hcl.Range{
-			Start: hcl.Pos{
-				Line:   1,
-				Column: 6,
-				Byte:   6,
+	testData := []struct {
+		Name       string
+		Content    string
+		FileChange *fileChange
+		Expect     string
+	}{
+		{
+			Name:    "length grow: 4",
+			Content: "hello world",
+			FileChange: &fileChange{
+				text: "terraform",
+				rng: hcl.Range{
+					Start: hcl.Pos{
+						Line:   1,
+						Column: 7,
+						Byte:   6,
+					},
+					End: hcl.Pos{
+						Line:   1,
+						Column: 12,
+						Byte:   11,
+					},
+				},
 			},
-			End: hcl.Pos{
-				Line:   1,
-				Column: 11,
-				Byte:   11,
+			Expect: "hello terraform",
+		},
+		{
+			Name:    "length the same",
+			Content: "hello world",
+			FileChange: &fileChange{
+				text: "earth",
+				rng: hcl.Range{
+					Start: hcl.Pos{
+						Line:   1,
+						Column: 7,
+						Byte:   6,
+					},
+					End: hcl.Pos{
+						Line:   1,
+						Column: 12,
+						Byte:   11,
+					},
+				},
 			},
+			Expect: "hello earth",
+		},
+		{
+			Name:    "length grow: -2",
+			Content: "hello world",
+			FileChange: &fileChange{
+				text: "HCL",
+				rng: hcl.Range{
+					Start: hcl.Pos{
+						Line:   1,
+						Column: 7,
+						Byte:   6,
+					},
+					End: hcl.Pos{
+						Line:   1,
+						Column: 12,
+						Byte:   11,
+					},
+				},
+			},
+			Expect: "hello HCL",
+		},
+		{
+			Name:    "add utf-18 character",
+			Content: "hello world",
+			FileChange: &fileChange{
+				text: "𐐀𐐀 ",
+				rng: hcl.Range{
+					Start: hcl.Pos{
+						Line:   1,
+						Column: 7,
+						Byte:   6,
+					},
+					End: hcl.Pos{
+						Line:   1,
+						Column: 7,
+						Byte:   6,
+					},
+				},
+			},
+			Expect: "hello 𐐀𐐀 world",
+		},
+		{
+			Name:    "modify when containing utf-18 character",
+			Content: "hello 𐐀𐐀 world",
+			FileChange: &fileChange{
+				text: "aa𐐀",
+				rng: hcl.Range{
+					Start: hcl.Pos{
+						Line:   1,
+						Column: 9,
+						Byte:   10,
+					},
+					End: hcl.Pos{
+						Line:   1,
+						Column: 11,
+						Byte:   14,
+					},
+				},
+			},
+			Expect: "hello 𐐀aa𐐀 world",
 		},
 	}
-	err := f.applyChange(fChange)
-	if err != nil {
-		t.Fatal(err)
-	}
 
-	expected := "hello terraform"
-	if string(f.content) != expected {
-		t.Fatalf("expected: %q but actually: %q", expected, string(f.content))
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Name)
+
+		f := NewFile("file:///test.tf", []byte(v.Content))
+		err := f.applyChange(v.FileChange)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if string(f.content) != v.Expect {
+			t.Fatalf("expected: %q but actually: %q", v.Expect, string(f.content))
+		}
 	}
 }
 

--- a/internal/filesystem/filesystem.go
+++ b/internal/filesystem/filesystem.go
@@ -39,6 +39,7 @@ func (fs *fsystem) Open(file File) error {
 		f = NewFile(file.FullPath(), file.Text())
 	}
 	f.open = true
+	f.version = file.Version()
 	d.files[file.Filename()] = f
 	return nil
 }
@@ -54,6 +55,8 @@ func (fs *fsystem) Change(fh VersionedFileHandler, changes FileChanges) error {
 	for _, change := range changes {
 		f.applyChange(change)
 	}
+
+	f.IncrementVersion()
 	return nil
 }
 

--- a/internal/filesystem/filesystem.go
+++ b/internal/filesystem/filesystem.go
@@ -55,8 +55,7 @@ func (fs *fsystem) Change(fh VersionedFileHandler, changes FileChanges) error {
 	for _, change := range changes {
 		f.applyChange(change)
 	}
-
-	f.IncrementVersion()
+	f.SetVersion(fh.Version())
 	return nil
 }
 

--- a/internal/filesystem/filesystem_test.go
+++ b/internal/filesystem/filesystem_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/terraform-ls/internal/source"
 )
 
@@ -12,7 +11,7 @@ func TestFilesystem_Change_notOpen(t *testing.T) {
 	fs := NewFilesystem()
 
 	var changes FileChanges
-	changes = append(changes, &testChange{})
+	changes = append(changes, &fileChange{})
 	h := &testHandler{"file:///doesnotexist"}
 
 	err := fs.Change(h, changes)
@@ -41,7 +40,7 @@ func TestFilesystem_Change_closed(t *testing.T) {
 	}
 
 	var changes FileChanges
-	changes = append(changes, &testChange{})
+	changes = append(changes, &fileChange{})
 	err = fs.Change(fh, changes)
 
 	expectedErr := &FileNotOpenErr{fh}
@@ -105,10 +104,10 @@ func TestFilesystem_Change_multipleChanges(t *testing.T) {
 	})
 
 	var changes FileChanges
-	changes = append(changes, &testChange{text: "ahoy"})
-	changes = append(changes, &testChange{text: ""})
-	changes = append(changes, &testChange{text: "quick brown fox jumped over\nthe lazy dog"})
-	changes = append(changes, &testChange{text: "bye"})
+	changes = append(changes, &fileChange{text: "ahoy"})
+	changes = append(changes, &fileChange{text: ""})
+	changes = append(changes, &fileChange{text: "quick brown fox jumped over\nthe lazy dog"})
+	changes = append(changes, &fileChange{text: "bye"})
 
 	err := fs.Change(fh, changes)
 	if err != nil {
@@ -195,18 +194,4 @@ func (fh *testHandler) Filename() string {
 }
 func (fh *testHandler) Version() int {
 	return 0
-}
-
-type testChange struct {
-	text string
-}
-
-func (ch *testChange) Text() string {
-	return ch.text
-}
-
-func (ch *testChange) Range() hcl.Range {
-	return hcl.Range{
-		// TODO: Implement partial updates
-	}
 }

--- a/internal/filesystem/types.go
+++ b/internal/filesystem/types.go
@@ -9,6 +9,7 @@ type File interface {
 	FileHandler
 	Text() []byte
 	Lines() source.Lines
+	Version() int
 }
 
 type FilePosition interface {

--- a/internal/lsp/file.go
+++ b/internal/lsp/file.go
@@ -14,9 +14,10 @@ type File interface {
 }
 
 type file struct {
-	fh   FileHandler
-	ls   source.Lines
-	text []byte
+	fh      FileHandler
+	ls      source.Lines
+	text    []byte
+	version int
 }
 
 func (f *file) URI() string {
@@ -50,9 +51,14 @@ func (f *file) lines() source.Lines {
 	return f.ls
 }
 
+func (f *file) Version() int {
+	return f.version
+}
+
 func FileFromDocumentItem(doc lsp.TextDocumentItem) *file {
 	return &file{
-		fh:   FileHandler(doc.URI),
-		text: []byte(doc.Text),
+		fh:      FileHandler(doc.URI),
+		text:    []byte(doc.Text),
+		version: doc.Version,
 	}
 }

--- a/internal/lsp/file_change.go
+++ b/internal/lsp/file_change.go
@@ -67,13 +67,13 @@ func hclRangeToLSP(hclRng hcl.Range) lsp.Range {
 	}
 }
 
-func lspRangeToHCL(hclRng lsp.Range, f File) (*hcl.Range, error) {
-	startPos, err := lspPositionToHCL(f.Lines(), hclRng.Start)
+func lspRangeToHCL(lspRng lsp.Range, f File) (*hcl.Range, error) {
+	startPos, err := lspPositionToHCL(f.Lines(), lspRng.Start)
 	if err != nil {
 		return nil, err
 	}
 
-	endPos, err := lspPositionToHCL(f.Lines(), hclRng.End)
+	endPos, err := lspPositionToHCL(f.Lines(), lspRng.End)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/lsp/file_change_test.go
+++ b/internal/lsp/file_change_test.go
@@ -1,0 +1,94 @@
+package lsp
+
+import (
+	"github.com/hashicorp/hcl/v2"
+	"github.com/sourcegraph/go-lsp"
+	"reflect"
+	"testing"
+)
+
+func TestLspRangeToHCL(t *testing.T) {
+	testData := []struct {
+		Name    string
+		Content string
+		Range   lsp.Range
+		Expect  hcl.Range
+	}{
+		{
+			Name:    "normal case",
+			Content: "hello world",
+			// the range part of "world"
+			Range: lsp.Range{
+				Start: lsp.Position{
+					Line:      0,
+					Character: 6,
+				},
+				End: lsp.Position{
+					Line:      0,
+					Character: 11,
+				},
+			},
+			Expect: hcl.Range{
+				Start: hcl.Pos{
+					Line:   1,
+					Column: 7,
+					Byte:   6,
+				},
+				End: hcl.Pos{
+					Line:   1,
+					Column: 12,
+					Byte:   11,
+				},
+			},
+		},
+		{
+			Name: "contain 𐐀",
+			// 𐐀 in utf-16 has two character
+			// in utf-8 has four character
+			Content: "hello 𐐀a𐐀a world",
+			// the range part of "a𐐀a"
+			Range: lsp.Range{
+				Start: lsp.Position{
+					Line:      0,
+					Character: 8,
+				},
+				End: lsp.Position{
+					Line:      0,
+					Character: 12,
+				},
+			},
+			Expect: hcl.Range{
+				Start: hcl.Pos{
+					Line:   1,
+					Column: 9,
+					Byte:   10,
+				},
+				End: hcl.Pos{
+					Line:   1,
+					Column: 13,
+					Byte:   16,
+				},
+			},
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Name)
+
+		result, err := lspRangeToHCL(v.Range, &file{
+			fh:   "file:///test.tf",
+			text: []byte(v.Content),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !reflect.DeepEqual(v.Expect.Start, result.Start) {
+			t.Fatalf("Expected %+v but got %+v", v.Expect.Start, result.Start)
+		}
+
+		if !reflect.DeepEqual(v.Expect.End, result.End) {
+			t.Fatalf("Expected %+v but got %+v", v.Expect.End, result.End)
+		}
+	}
+}

--- a/internal/lsp/file_change_test.go
+++ b/internal/lsp/file_change_test.go
@@ -43,8 +43,8 @@ func TestLspRangeToHCL(t *testing.T) {
 		},
 		{
 			Name: "contain 𐐀",
-			// 𐐀 in utf-16 has two character
-			// in utf-8 has four character
+			// 𐐀 in utf-16 has two unit
+			// in utf-8 has four unit
 			Content: "hello 𐐀a𐐀a world",
 			// the range part of "a𐐀a"
 			Range: lsp.Range{

--- a/langserver/handlers/did_change.go
+++ b/langserver/handlers/did_change.go
@@ -49,6 +49,8 @@ func TextDocumentDidChange(ctx context.Context, params DidChangeTextDocumentPara
 	return fs.Change(fh, changes)
 }
 
+// TODO: Revisit after https://github.com/hashicorp/terraform-ls/issues/118 is addressed
+// Then we could switch back to upstream go-lsp
 type DidChangeTextDocumentParams struct {
 	TextDocument   VersionedTextDocumentIdentifier      `json:"textDocument"`
 	ContentChanges []lsp.TextDocumentContentChangeEvent `json:"contentChanges"`

--- a/langserver/handlers/did_change.go
+++ b/langserver/handlers/did_change.go
@@ -2,26 +2,74 @@ package handlers
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 
 	lsctx "github.com/hashicorp/terraform-ls/internal/context"
 	ilsp "github.com/hashicorp/terraform-ls/internal/lsp"
 	lsp "github.com/sourcegraph/go-lsp"
 )
 
-func TextDocumentDidChange(ctx context.Context, params lsp.DidChangeTextDocumentParams) error {
+func TextDocumentDidChange(ctx context.Context, params DidChangeTextDocumentParams) error {
+	p := lsp.DidChangeTextDocumentParams{
+		TextDocument: lsp.VersionedTextDocumentIdentifier{
+			TextDocumentIdentifier: lsp.TextDocumentIdentifier{
+				URI: params.TextDocument.URI,
+			},
+			Version: params.TextDocument.Version,
+		},
+		ContentChanges: params.ContentChanges,
+	}
+
 	fs, err := lsctx.Filesystem(ctx)
 	if err != nil {
 		return err
 	}
 
-	fh := ilsp.VersionedFileHandler(params.TextDocument)
+	fh := ilsp.VersionedFileHandler(p.TextDocument)
 	f, err := fs.GetFile(fh)
 	if err != nil {
 		return err
 	}
+
+	// old version change, just skip
+	if p.TextDocument.Version <= f.Version() {
+		return fmt.Errorf("skip old version %d change: %#v, current file version %d", p.TextDocument.Version, params, f.Version())
+	}
+
+	// missing version
+	if p.TextDocument.Version > f.Version()+1 {
+		return fmt.Errorf("missing version %d change: %#v, current file version %d", p.TextDocument.Version, params, f.Version())
+	}
+
 	changes, err := ilsp.FileChanges(params.ContentChanges, f)
 	if err != nil {
 		return err
 	}
 	return fs.Change(fh, changes)
+}
+
+type DidChangeTextDocumentParams struct {
+	TextDocument   VersionedTextDocumentIdentifier      `json:"textDocument"`
+	ContentChanges []lsp.TextDocumentContentChangeEvent `json:"contentChanges"`
+}
+
+type VersionedTextDocumentIdentifier struct {
+	URI lsp.DocumentURI `json:"uri"`
+	/**
+	 * The version number of this document.
+	 */
+	Version int `json:"version"`
+}
+
+// UnmarshalJSON implements non-strict json.Unmarshaler.
+func (v *DidChangeTextDocumentParams) UnmarshalJSON(b []byte) error {
+	type t DidChangeTextDocumentParams
+	return json.Unmarshal(b, (*t)(v))
+}
+
+// UnmarshalJSON implements non-strict json.Unmarshaler.
+func (v *VersionedTextDocumentIdentifier) UnmarshalJSON(b []byte) error {
+	type t VersionedTextDocumentIdentifier
+	return json.Unmarshal(b, (*t)(v))
 }

--- a/langserver/handlers/did_change.go
+++ b/langserver/handlers/did_change.go
@@ -32,14 +32,18 @@ func TextDocumentDidChange(ctx context.Context, params DidChangeTextDocumentPara
 		return err
 	}
 
-	// old version change, just skip
 	if p.TextDocument.Version <= f.Version() {
-		return fmt.Errorf("skip old version %d change: %#v, current file version %d", p.TextDocument.Version, params, f.Version())
+		fs.Close(fh)
+		return fmt.Errorf("Old version (%d) received, current version is %d. "+
+			"Unable to update %s. This is likely a bug, please report it.",
+			p.TextDocument.Version, f.Version(), p.TextDocument.URI)
 	}
 
-	// missing version
 	if p.TextDocument.Version > f.Version()+1 {
-		return fmt.Errorf("missing version %d change: %#v, current file version %d", p.TextDocument.Version, params, f.Version())
+		fs.Close(fh)
+		return fmt.Errorf("New version (%d) received, current version is %d. "+
+			"Unable to update %s. This is likely a bug, please report it.",
+			p.TextDocument.Version, f.Version(), p.TextDocument.URI)
 	}
 
 	changes, err := ilsp.FileChanges(params.ContentChanges, f)

--- a/langserver/handlers/handlers_test.go
+++ b/langserver/handlers/handlers_test.go
@@ -28,7 +28,7 @@ func TestInitalizeAndShutdown(t *testing.T) {
 			"capabilities": {
 				"textDocumentSync": {
 					"openClose": true,
-					"change": 1
+					"change": 2
 				},
 				"completionProvider": {},
 				"documentFormattingProvider":true
@@ -63,7 +63,7 @@ func TestEOF(t *testing.T) {
 			"capabilities": {
 				"textDocumentSync": {
 					"openClose": true,
-					"change": 1
+					"change": 2
 				},
 				"completionProvider": {},
 				"documentFormattingProvider":true

--- a/langserver/handlers/initialize.go
+++ b/langserver/handlers/initialize.go
@@ -18,7 +18,7 @@ func (lh *logHandler) Initialize(ctx context.Context, params lsp.InitializeParam
 			TextDocumentSync: &lsp.TextDocumentSyncOptionsOrKind{
 				Options: &lsp.TextDocumentSyncOptions{
 					OpenClose: true,
-					Change:    lsp.TDSKFull,
+					Change:    lsp.TDSKIncremental,
 				},
 			},
 			CompletionProvider: &lsp.CompletionOptions{


### PR DESCRIPTION
fix #34

add support for file partial update.

- personally I want to make `func (fc *fileChange) Range() hcl.Range` to return a pointer, which is convenient to check whether to apply full content replace or partial update, but it seems need to change the interface and other parts, please confirm whether I should do in this way.

