### PR TITLE
textDocument/complete: Complete first level keywords

### DIFF
--- a/internal/hcl/errors.go
+++ b/internal/hcl/errors.go
@@ -22,3 +22,8 @@ type NoBlockFoundErr struct {
 func (e *NoBlockFoundErr) Error() string {
 	return fmt.Sprintf("no block found at %#v", e.AtPos)
 }
+
+func IsNoBlockFoundErr(err error) bool {
+	_, ok := err.(*NoBlockFoundErr)
+	return ok
+}

--- a/internal/hcl/hcl.go
+++ b/internal/hcl/hcl.go
@@ -52,8 +52,13 @@ func (f *file) blockAtPosition(pos hcllib.Pos) (*hcllib.Block, error) {
 		if body.SrcRange.Empty() && pos != hcllib.InitialPos {
 			return nil, &InvalidHclPosErr{pos, body.SrcRange}
 		}
-		if !body.SrcRange.Empty() && !body.SrcRange.ContainsPos(pos) {
-			return nil, &InvalidHclPosErr{pos, body.SrcRange}
+		if !body.SrcRange.Empty() {
+			if posIsEqual(body.SrcRange.End, pos) {
+				return nil, &NoBlockFoundErr{pos}
+			}
+			if !body.SrcRange.ContainsPos(pos) {
+				return nil, &InvalidHclPosErr{pos, body.SrcRange}
+			}
 		}
 	}
 
@@ -63,4 +68,10 @@ func (f *file) blockAtPosition(pos hcllib.Pos) (*hcllib.Block, error) {
 	}
 
 	return block, nil
+}
+
+func posIsEqual(a, b hcllib.Pos) bool {
+	return a.Byte == b.Byte &&
+		a.Column == b.Column &&
+		a.Line == b.Line
 }

--- a/internal/hcl/hcl_test.go
+++ b/internal/hcl/hcl_test.go
@@ -111,6 +111,20 @@ func TestFile_BlockAtPosition(t *testing.T) {
 			},
 			nil,
 		},
+		{
+			"valid config and EOF position",
+			`provider "aws" {
+
+}
+`,
+			hcl.Pos{
+				Line:   4,
+				Column: 1,
+				Byte:   20,
+			},
+			&NoBlockFoundErr{AtPos: hcl.Pos{Line: 4, Column: 1, Byte: 20}},
+			nil,
+		},
 	}
 
 	opts := cmp.Options{

--- a/internal/source/source.go
+++ b/internal/source/source.go
@@ -25,17 +25,30 @@ func (l sourceLine) Bytes() []byte {
 
 func MakeSourceLines(filename string, s []byte) []Line {
 	var ret []Line
-	if len(s) == 0 {
-		return ret
-	}
 
+	lastRng := hcl.Range{
+		Filename: filename,
+		Start:    hcl.InitialPos,
+		End:      hcl.InitialPos,
+	}
 	sc := hcl.NewRangeScanner(s, filename, scanLines)
 	for sc.Scan() {
 		ret = append(ret, sourceLine{
 			content: sc.Bytes(),
 			rng:     sc.Range(),
 		})
+		lastRng = sc.Range()
 	}
+
+	// Account for the last (virtual) user-percieved line
+	ret = append(ret, sourceLine{
+		content: []byte{},
+		rng: hcl.Range{
+			Filename: lastRng.Filename,
+			Start:    lastRng.End,
+			End:      lastRng.End,
+		},
+	})
 
 	return ret
 }

--- a/internal/source/source_test.go
+++ b/internal/source/source_test.go
@@ -6,15 +6,15 @@ import (
 
 func TestMakeSourceLines_empty(t *testing.T) {
 	lines := MakeSourceLines("/test.tf", []byte{})
-	if len(lines) != 0 {
-		t.Fatalf("Expected no lines from empty file, %d parsed:\n%#v",
+	if len(lines) != 1 {
+		t.Fatalf("Expected 1 line from empty file, %d parsed:\n%#v",
 			len(lines), lines)
 	}
 }
 
 func TestMakeSourceLines_success(t *testing.T) {
 	lines := MakeSourceLines("/test.tf", []byte("\n\n\n\n"))
-	expectedLines := 4
+	expectedLines := 5
 	if len(lines) != expectedLines {
 		t.Fatalf("Expected exactly %d lines, %d parsed",
 			expectedLines, len(lines))

--- a/internal/terraform/lang/config_block.go
+++ b/internal/terraform/lang/config_block.go
@@ -11,8 +11,8 @@ import (
 
 type configBlockFactory interface {
 	New(*hclsyntax.Block) (ConfigBlock, error)
+	LabelSchema() LabelSchema
 }
-
 
 type labelCandidates map[string][]CompletionCandidate
 
@@ -118,6 +118,10 @@ func (l *completeList) Sort() {
 
 func (l *completeList) List() []CompletionCandidate {
 	return l.candidates
+}
+
+func (l *completeList) Len() int {
+	return len(l.candidates)
 }
 
 func (l *completeList) IsComplete() bool {

--- a/internal/terraform/lang/config_block_test.go
+++ b/internal/terraform/lang/config_block_test.go
@@ -250,7 +250,7 @@ func TestCompletableBlock_CompletionCandidatesAtPos(t *testing.T) {
 
 			cb := &completableBlock{
 				logger: testLogger(),
-				block:  ParseBlock(block, []*Label{}, tc.sb),
+				block:  ParseBlock(block, []*ParsedLabel{}, tc.sb),
 			}
 
 			list, err := cb.completionCandidatesAtPos(tc.pos)

--- a/internal/terraform/lang/config_block_test.go
+++ b/internal/terraform/lang/config_block_test.go
@@ -2,6 +2,7 @@ package lang
 
 import (
 	"fmt"
+	"sort"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -292,6 +293,12 @@ func renderCandidates(list CompletionCandidates, pos hcl.Pos) []renderedCandidat
 		}
 	}
 	return rendered
+}
+
+func sortRenderedCandidates(candidates []renderedCandidate) {
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].Label < candidates[j].Label
+	})
 }
 
 type renderedCandidate struct {

--- a/internal/terraform/lang/datasource_block.go
+++ b/internal/terraform/lang/datasource_block.go
@@ -38,7 +38,7 @@ type datasourceBlock struct {
 	logger *log.Logger
 
 	labelSchema LabelSchema
-	labels      []*Label
+	labels      []*ParsedLabel
 	hclBlock    *hclsyntax.Block
 	sr          schema.Reader
 }
@@ -64,7 +64,7 @@ func (r *datasourceBlock) Name() string {
 	return fmt.Sprintf("%s.%s", firstLabel, secondLabel)
 }
 
-func (r *datasourceBlock) Labels() []*Label {
+func (r *datasourceBlock) Labels() []*ParsedLabel {
 	if r.labels != nil {
 		return r.labels
 	}

--- a/internal/terraform/lang/datasource_block.go
+++ b/internal/terraform/lang/datasource_block.go
@@ -24,13 +24,20 @@ func (f *datasourceBlockFactory) New(block *hclsyntax.Block) (ConfigBlock, error
 	return &datasourceBlock{
 		logger: f.logger,
 
-		labelSchema: LabelSchema{"type", "name"},
+		labelSchema: f.LabelSchema(),
 		hclBlock:    block,
 		sr:          f.schemaReader,
 	}, nil
 }
 
-func (r *datasourceBlockFactory) BlockType() string {
+func (f *datasourceBlockFactory) LabelSchema() LabelSchema {
+	return LabelSchema{
+		Label{Name: "type", IsCompletable: true},
+		Label{Name: "name"},
+	}
+}
+
+func (f *datasourceBlockFactory) BlockType() string {
 	return "data"
 }
 

--- a/internal/terraform/lang/hcl_block.go
+++ b/internal/terraform/lang/hcl_block.go
@@ -7,7 +7,7 @@ import (
 
 type parsedBlock struct {
 	hclBlock      *hclsyntax.Block
-	labels        []*Label
+	labels        []*ParsedLabel
 	AttributesMap map[string]*Attribute
 	BlockTypesMap map[string]*BlockType
 
@@ -59,7 +59,7 @@ func (b *parsedBlock) PosInLabels(pos hcl.Pos) bool {
 	return false
 }
 
-func (b *parsedBlock) LabelAtPos(pos hcl.Pos) (*Label, bool) {
+func (b *parsedBlock) LabelAtPos(pos hcl.Pos) (*ParsedLabel, bool) {
 	for i, rng := range b.hclBlock.LabelRanges {
 		if rng.ContainsPos(pos) {
 			// TODO: Guard against crashes when user sets label where we don't expect it

--- a/internal/terraform/lang/hcl_block_type.go
+++ b/internal/terraform/lang/hcl_block_type.go
@@ -62,7 +62,7 @@ func (bt BlockTypes) AddBlock(name string, block *hclsyntax.Block, typeSchema *t
 
 	if block != nil {
 		// SDK doesn't support named blocks yet, so we expect no labels here for now
-		labels := make([]*Label, 0)
+		labels := make([]*ParsedLabel, 0)
 		bt[name].BlockList = append(bt[name].BlockList, ParseBlock(block, labels, typeSchema.Block))
 	}
 }

--- a/internal/terraform/lang/hcl_parser.go
+++ b/internal/terraform/lang/hcl_parser.go
@@ -10,7 +10,7 @@ import (
 
 // ParseBlock parses HCL configuration based on tfjson's SchemaBlock
 // and keeps hold of all tfjson schema details on block or attribute level
-func ParseBlock(block *hclsyntax.Block, labels []*Label, schema *tfjson.SchemaBlock) Block {
+func ParseBlock(block *hclsyntax.Block, labels []*ParsedLabel, schema *tfjson.SchemaBlock) Block {
 	b := &parsedBlock{
 		hclBlock: block,
 		labels:   labels,

--- a/internal/terraform/lang/hcl_parser_test.go
+++ b/internal/terraform/lang/hcl_parser_test.go
@@ -307,7 +307,7 @@ func TestParseBlock_attributesAndBlockTypes(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			b := ParseBlock(block, []*Label{}, tc.schema)
+			b := ParseBlock(block, []*ParsedLabel{}, tc.schema)
 
 			if diff := cmp.Diff(tc.expectedAttributes, b.Attributes(), opts...); diff != "" {
 				t.Fatalf("Attributes don't match.\n%s", diff)
@@ -471,7 +471,7 @@ func TestBlock_BlockAtPos(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			b := ParseBlock(block, []*Label{}, schema)
+			b := ParseBlock(block, []*ParsedLabel{}, schema)
 			fBlock, _ := b.BlockAtPos(tc.pos)
 			if diff := cmp.Diff(tc.expectedBlock, fBlock, opts...); diff != "" {
 				t.Fatalf("Block doesn't match.\n%s", diff)
@@ -631,7 +631,7 @@ func TestBlock_PosInBody(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			b := ParseBlock(block, []*Label{}, schema)
+			b := ParseBlock(block, []*ParsedLabel{}, schema)
 			isInBody := b.PosInBody(tc.pos)
 			if tc.expected != isInBody {
 				if tc.expected {
@@ -766,7 +766,7 @@ func TestBlock_PosInAttributes(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			b := ParseBlock(block, []*Label{}, schema)
+			b := ParseBlock(block, []*ParsedLabel{}, schema)
 			isInAttribute := b.PosInAttribute(tc.pos)
 			if tc.expected != isInAttribute {
 				if tc.expected {

--- a/internal/terraform/lang/labels.go
+++ b/internal/terraform/lang/labels.go
@@ -1,14 +1,14 @@
 package lang
 
-func parseLabels(blockType string, schema LabelSchema, parsed []string) []*Label {
-	labels := make([]*Label, len(schema))
+func parseLabels(blockType string, schema LabelSchema, parsed []string) []*ParsedLabel {
+	labels := make([]*ParsedLabel, len(schema))
 
 	for i, labelName := range schema {
 		var value string
 		if len(parsed)-1 >= i {
 			value = parsed[i]
 		}
-		labels[i] = &Label{
+		labels[i] = &ParsedLabel{
 			Name:  labelName,
 			Value: value,
 		}

--- a/internal/terraform/lang/labels.go
+++ b/internal/terraform/lang/labels.go
@@ -3,13 +3,13 @@ package lang
 func parseLabels(blockType string, schema LabelSchema, parsed []string) []*ParsedLabel {
 	labels := make([]*ParsedLabel, len(schema))
 
-	for i, labelName := range schema {
+	for i, l := range schema {
 		var value string
 		if len(parsed)-1 >= i {
 			value = parsed[i]
 		}
 		labels[i] = &ParsedLabel{
-			Name:  labelName,
+			Name:  l.Name,
 			Value: value,
 		}
 	}

--- a/internal/terraform/lang/parser.go
+++ b/internal/terraform/lang/parser.go
@@ -91,6 +91,40 @@ func (p *parser) blockTypes() map[string]configBlockFactory {
 	}
 }
 
+func (p *parser) BlockTypeCandidates() CompletionCandidates {
+	bTypes := p.blockTypes()
+
+	list := &completeList{
+		candidates: make([]CompletionCandidate, 0),
+	}
+
+	for name, t := range bTypes {
+		list.candidates = append(list.candidates, &completableBlockType{
+			TypeName:    name,
+			LabelSchema: t.LabelSchema(),
+		})
+	}
+
+	return list
+}
+
+type completableBlockType struct {
+	TypeName    string
+	LabelSchema LabelSchema
+}
+
+func (bt *completableBlockType) Label() string {
+	return bt.TypeName
+}
+
+func (bt *completableBlockType) Snippet(pos hcl.Pos) (hcl.Pos, string) {
+	return pos, snippetForBlock(bt.TypeName, bt.LabelSchema)
+}
+
+func (bt *completableBlockType) Detail() string {
+	return ""
+}
+
 func (p *parser) ParseBlockFromHCL(block *hcl.Block) (ConfigBlock, error) {
 	if block == nil {
 		return nil, EmptyConfigErr

--- a/internal/terraform/lang/parser_test.go
+++ b/internal/terraform/lang/parser_test.go
@@ -8,9 +8,41 @@ import (
 	"os"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 )
+
+func TestParser_BlockTypeCandidates_len(t *testing.T) {
+	p := newParser()
+
+	candidates := p.BlockTypeCandidates()
+	if candidates.Len() < 3 {
+		t.Fatalf("Expected >= 3 candidates, %d given", candidates.Len())
+	}
+}
+
+func TestParser_BlockTypeCandidates_snippet(t *testing.T) {
+	p := newParser()
+
+	list := p.BlockTypeCandidates()
+	rendered := renderCandidates(list, hcl.InitialPos)
+	sortRenderedCandidates(rendered)
+
+	expectedCandidate := renderedCandidate{
+		Label:  "data",
+		Detail: "",
+		Snippet: renderedSnippet{
+			Pos: hcl.InitialPos,
+			Text: `data "${1}" "${2:name}" {
+  ${3}
+}`,
+		},
+	}
+	if diff := cmp.Diff(expectedCandidate, rendered[0]); diff != "" {
+		t.Fatalf("Completion candidate does not match.\n%s", diff)
+	}
+}
 
 func TestParser_ParseBlockFromHCL(t *testing.T) {
 	testCases := []struct {

--- a/internal/terraform/lang/provider_block.go
+++ b/internal/terraform/lang/provider_block.go
@@ -23,10 +23,16 @@ func (f *providerBlockFactory) New(block *hclsyntax.Block) (ConfigBlock, error) 
 	return &providerBlock{
 		logger: f.logger,
 
-		labelSchema: LabelSchema{"name"},
+		labelSchema: f.LabelSchema(),
 		hclBlock:    block,
 		sr:          f.schemaReader,
 	}, nil
+}
+
+func (f *providerBlockFactory) LabelSchema() LabelSchema {
+	return LabelSchema{
+		Label{Name: "name", IsCompletable: true},
+	}
 }
 
 func (f *providerBlockFactory) BlockType() string {

--- a/internal/terraform/lang/provider_block.go
+++ b/internal/terraform/lang/provider_block.go
@@ -37,7 +37,7 @@ type providerBlock struct {
 	logger *log.Logger
 
 	labelSchema LabelSchema
-	labels      []*Label
+	labels      []*ParsedLabel
 	hclBlock    *hclsyntax.Block
 	sr          schema.Reader
 }
@@ -54,7 +54,7 @@ func (p *providerBlock) RawName() string {
 	return p.Labels()[0].Value
 }
 
-func (p *providerBlock) Labels() []*Label {
+func (p *providerBlock) Labels() []*ParsedLabel {
 	if p.labels != nil {
 		return p.labels
 	}

--- a/internal/terraform/lang/resource_block.go
+++ b/internal/terraform/lang/resource_block.go
@@ -38,7 +38,7 @@ type resourceBlock struct {
 	logger *log.Logger
 
 	labelSchema LabelSchema
-	labels      []*Label
+	labels      []*ParsedLabel
 	hclBlock    *hclsyntax.Block
 	sr          schema.Reader
 }
@@ -64,7 +64,7 @@ func (r *resourceBlock) Name() string {
 	return fmt.Sprintf("%s.%s", firstLabel, secondLabel)
 }
 
-func (r *resourceBlock) Labels() []*Label {
+func (r *resourceBlock) Labels() []*ParsedLabel {
 	if r.labels != nil {
 		return r.labels
 	}

--- a/internal/terraform/lang/resource_block.go
+++ b/internal/terraform/lang/resource_block.go
@@ -24,10 +24,17 @@ func (f *resourceBlockFactory) New(block *hclsyntax.Block) (ConfigBlock, error) 
 	return &resourceBlock{
 		logger: f.logger,
 
-		labelSchema: LabelSchema{"type", "name"},
+		labelSchema: f.LabelSchema(),
 		hclBlock:    block,
 		sr:          f.schemaReader,
 	}, nil
+}
+
+func (f *resourceBlockFactory) LabelSchema() LabelSchema {
+	return LabelSchema{
+		Label{Name: "type", IsCompletable: true},
+		Label{Name: "name", IsCompletable: false},
+	}
 }
 
 func (r *resourceBlockFactory) BlockType() string {

--- a/internal/terraform/lang/schema.go
+++ b/internal/terraform/lang/schema.go
@@ -44,6 +44,22 @@ func snippetForNestedBlock(name string) string {
 	return fmt.Sprintf("%s {\n  ${0}\n}", name)
 }
 
+func snippetForBlock(name string, labelSchema LabelSchema) string {
+	bodyPlaceholder := 0
+	labels := make([]string, len(labelSchema))
+	for i, l := range labelSchema {
+		if l.IsCompletable {
+			labels[i] = fmt.Sprintf(`"${%d}"`, i+1)
+		} else {
+			labels[i] = fmt.Sprintf(`"${%d:%s}"`, i+1, l.Name)
+		}
+		bodyPlaceholder = i + 2
+	}
+
+	return fmt.Sprintf("%s %s {\n  ${%d}\n}",
+		name, strings.Join(labels, " "), bodyPlaceholder)
+}
+
 func schemaAttributeDetail(attr *tfjson.SchemaAttribute) string {
 	var requiredText string
 	if attr.Optional {

--- a/internal/terraform/lang/types.go
+++ b/internal/terraform/lang/types.go
@@ -13,6 +13,7 @@ import (
 type Parser interface {
 	SetLogger(*log.Logger)
 	SetSchemaReader(schema.Reader)
+	BlockTypeCandidates() CompletionCandidates
 	ParseBlockFromHCL(*hcl.Block) (ConfigBlock, error)
 }
 
@@ -38,7 +39,12 @@ type Block interface {
 	BlockTypes() map[string]*BlockType
 }
 
-type LabelSchema []string
+type LabelSchema []Label
+
+type Label struct {
+	Name          string
+	IsCompletable bool
+}
 
 type ParsedLabel struct {
 	Name  string
@@ -59,6 +65,7 @@ type Attribute struct {
 // for completion loosely reflecting lsp.CompletionList
 type CompletionCandidates interface {
 	List() []CompletionCandidate
+	Len() int
 	IsComplete() bool
 }
 

--- a/internal/terraform/lang/types.go
+++ b/internal/terraform/lang/types.go
@@ -22,14 +22,14 @@ type ConfigBlock interface {
 	CompletionCandidatesAtPos(pos hcl.Pos) (CompletionCandidates, error)
 	Name() string
 	BlockType() string
-	Labels() []*Label
+	Labels() []*ParsedLabel
 }
 
 // Block represents a decoded HCL block (by a Parser)
 // which keeps track of the related schema
 type Block interface {
 	BlockAtPos(pos hcl.Pos) (Block, bool)
-	LabelAtPos(pos hcl.Pos) (*Label, bool)
+	LabelAtPos(pos hcl.Pos) (*ParsedLabel, bool)
 	Range() hcl.Range
 	PosInLabels(pos hcl.Pos) bool
 	PosInBody(pos hcl.Pos) bool
@@ -40,7 +40,7 @@ type Block interface {
 
 type LabelSchema []string
 
-type Label struct {
+type ParsedLabel struct {
 	Name  string
 	Value string
 }

--- a/langserver/handlers/complete.go
+++ b/langserver/handlers/complete.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"fmt"
 
+	hcl "github.com/hashicorp/hcl/v2"
 	lsctx "github.com/hashicorp/terraform-ls/internal/context"
-	"github.com/hashicorp/terraform-ls/internal/hcl"
+	ihcl "github.com/hashicorp/terraform-ls/internal/hcl"
 	ilsp "github.com/hashicorp/terraform-ls/internal/lsp"
 	"github.com/hashicorp/terraform-ls/internal/terraform/lang"
 	lsp "github.com/sourcegraph/go-lsp"
@@ -40,17 +41,11 @@ func (h *logHandler) TextDocumentComplete(ctx context.Context, params lsp.Comple
 	if err != nil {
 		return list, err
 	}
-	hclFile := hcl.NewFile(file)
+	hclFile := ihcl.NewFile(file)
 	fPos, err := ilsp.FilePositionFromDocumentPosition(params.TextDocumentPositionParams, file)
 	if err != nil {
 		return list, err
 	}
-
-	hclBlock, hclPos, err := hclFile.BlockAtPosition(fPos)
-	if err != nil {
-		return list, fmt.Errorf("finding HCL block failed: %s", err)
-	}
-	h.logger.Printf("HCL block found at HCL pos %#v", hclPos)
 
 	p, err := lang.FindCompatibleParser(tfVersion)
 	if err != nil {
@@ -59,16 +54,30 @@ func (h *logHandler) TextDocumentComplete(ctx context.Context, params lsp.Comple
 	p.SetLogger(h.logger)
 	p.SetSchemaReader(sr)
 
-	cfgBlock, err := p.ParseBlockFromHCL(hclBlock)
+	hclBlock, hclPos, err := hclFile.BlockAtPosition(fPos)
 	if err != nil {
-		return list, fmt.Errorf("finding config block failed: %w", err)
-	}
-	h.logger.Printf("Configuration block %q parsed", cfgBlock.BlockType())
+		if ihcl.IsNoBlockFoundErr(err) {
+			return ilsp.CompletionList(p.BlockTypeCandidates(), fPos.Position(), cc.TextDocument), nil
+		}
 
-	candidates, err := cfgBlock.CompletionCandidatesAtPos(hclPos)
+		return list, fmt.Errorf("finding HCL block failed: %#v", err)
+	}
+
+	h.logger.Printf("HCL block found at HCL pos %#v", hclPos)
+	candidates, err := h.completeBlock(p, hclBlock, hclPos)
 	if err != nil {
 		return list, fmt.Errorf("finding completion items failed: %w", err)
 	}
 
 	return ilsp.CompletionList(candidates, fPos.Position(), cc.TextDocument), nil
+}
+
+func (h *logHandler) completeBlock(p lang.Parser, block *hcl.Block, pos hcl.Pos) (lang.CompletionCandidates, error) {
+	cfgBlock, err := p.ParseBlockFromHCL(block)
+	if err != nil {
+		return nil, fmt.Errorf("finding config block failed: %w", err)
+	}
+	h.logger.Printf("Configuration block %q parsed", cfgBlock.BlockType())
+
+	return cfgBlock.CompletionCandidatesAtPos(pos)
 }


### PR DESCRIPTION
Closes #18

As described in that issue, this only adds support for the blocks which have schema provided by providers, supporting other blocks is generally tracked under #36

### UX

![Screenshot 2020-05-19 at 12 26 36](https://user-images.githubusercontent.com/287584/82321236-6ed43300-99cc-11ea-9c27-6508c7bc107e.png)
![Screenshot 2020-05-19 at 12 27 23](https://user-images.githubusercontent.com/287584/82321238-6f6cc980-99cc-11ea-98e8-143cf0f09d22.png)
