### PR TITLE
Add support for autocomplete based on a prefix

### DIFF
--- a/internal/hcl/errors.go
+++ b/internal/hcl/errors.go
@@ -27,3 +27,11 @@ func IsNoBlockFoundErr(err error) bool {
 	_, ok := err.(*NoBlockFoundErr)
 	return ok
 }
+
+type NoTokenFoundErr struct {
+	AtPos hcllib.Pos
+}
+
+func (e *NoTokenFoundErr) Error() string {
+	return fmt.Sprintf("no token found at %#v", e.AtPos)
+}

--- a/internal/hcl/hcl.go
+++ b/internal/hcl/hcl.go
@@ -9,11 +9,6 @@ import (
 	"github.com/hashicorp/terraform-ls/internal/filesystem"
 )
 
-type File interface {
-	BlockTokensAtPosition(hcl.Pos) (hclsyntax.Tokens, error)
-	TokenAtPosition(hcl.Pos) (hclsyntax.Token, error)
-}
-
 type file struct {
 	filename string
 	content  []byte
@@ -25,11 +20,41 @@ type parsedFile struct {
 	Tokens hclsyntax.Tokens
 }
 
-func NewFile(f filesystem.File) File {
+type parsedBlock struct {
+	tokens hclsyntax.Tokens
+}
+
+func (pb *parsedBlock) Tokens() hclsyntax.Tokens {
+	return pb.tokens
+}
+
+func (pb *parsedBlock) TokenAtPosition(pos hcl.Pos) (hclsyntax.Token, error) {
+	for _, t := range pb.tokens {
+		if rangeContainsOffset(t.Range, pos.Byte) {
+			return t, nil
+		}
+	}
+
+	return hclsyntax.Token{}, &NoTokenFoundErr{pos}
+}
+
+func NewFile(f filesystem.File) TokenizedFile {
 	return &file{
 		filename: f.Filename(),
 		content:  []byte(f.Text()),
 	}
+}
+
+func NewTestFile(b []byte) TokenizedFile {
+	return &file{
+		filename: "/test.tf",
+		content:  b,
+	}
+}
+
+func NewTestBlock(b []byte) (TokenizedBlock, error) {
+	f := NewTestFile(b)
+	return f.BlockAtPosition(hcllib.InitialPos)
 }
 
 func (f *file) parse() (*parsedFile, error) {
@@ -60,32 +85,42 @@ func (f *file) parse() (*parsedFile, error) {
 	return f.pf, nil
 }
 
-func (f *file) BlockTokensAtPosition(pos hcllib.Pos) (hclsyntax.Tokens, error) {
+func (f *file) PosInBlock(pos hcl.Pos) bool {
+	_, err := f.BlockAtPosition(pos)
+	if IsNoBlockFoundErr(err) {
+		return false
+	}
+
+	return true
+}
+
+func (f *file) BlockAtPosition(pos hcllib.Pos) (TokenizedBlock, error) {
 	pf, _ := f.parse()
 
 	body, ok := pf.Body.(*hclsyntax.Body)
 	if !ok {
-		return hclsyntax.Tokens{}, fmt.Errorf("unexpected body type (%T)", body)
+		return nil, fmt.Errorf("unexpected body type (%T)", body)
 	}
 	if body.SrcRange.Empty() && pos != hcllib.InitialPos {
-		return hclsyntax.Tokens{}, &InvalidHclPosErr{pos, body.SrcRange}
+		return nil, &InvalidHclPosErr{pos, body.SrcRange}
 	}
 	if !body.SrcRange.Empty() {
 		if posIsEqual(body.SrcRange.End, pos) {
-			return pf.Tokens, &NoBlockFoundErr{pos}
+			return nil, &NoBlockFoundErr{pos}
 		}
 		if !body.SrcRange.ContainsPos(pos) {
-			return hclsyntax.Tokens{}, &InvalidHclPosErr{pos, body.SrcRange}
+			return nil, &InvalidHclPosErr{pos, body.SrcRange}
 		}
 	}
 
 	for _, block := range body.Blocks {
 		if block.Range().ContainsPos(pos) {
-			return definitionTokens(tokensInRange(pf.Tokens, block.Range())), nil
+			dt := definitionTokens(tokensInRange(pf.Tokens, block.Range()))
+			return &parsedBlock{dt}, nil
 		}
 	}
 
-	return pf.Tokens, &NoBlockFoundErr{pos}
+	return nil, &NoBlockFoundErr{pos}
 }
 
 func (f *file) TokenAtPosition(pos hcllib.Pos) (hclsyntax.Token, error) {

--- a/internal/hcl/hcl.go
+++ b/internal/hcl/hcl.go
@@ -10,7 +10,7 @@ import (
 )
 
 type File interface {
-	BlockTokensAtPosition(filesystem.FilePosition) (hclsyntax.Tokens, hcllib.Pos, error)
+	BlockTokensAtPosition(hcl.Pos) (hclsyntax.Tokens, error)
 }
 
 type file struct {
@@ -59,18 +59,7 @@ func (f *file) parse() (*parsedFile, error) {
 	return f.pf, nil
 }
 
-func (f *file) BlockTokensAtPosition(filePos filesystem.FilePosition) (hclsyntax.Tokens, hcllib.Pos, error) {
-	pos := filePos.Position()
-
-	b, err := f.blockAtPosition(pos)
-	if err != nil {
-		return hclsyntax.Tokens{}, pos, err
-	}
-
-	return b, pos, nil
-}
-
-func (f *file) blockAtPosition(pos hcllib.Pos) (hclsyntax.Tokens, error) {
+func (f *file) BlockTokensAtPosition(pos hcllib.Pos) (hclsyntax.Tokens, error) {
 	pf, _ := f.parse()
 
 	body, ok := pf.Body.(*hclsyntax.Body)

--- a/internal/hcl/hcl.go
+++ b/internal/hcl/hcl.go
@@ -71,7 +71,7 @@ func (f *file) BlockTokensAtPosition(pos hcllib.Pos) (hclsyntax.Tokens, error) {
 	}
 	if !body.SrcRange.Empty() {
 		if posIsEqual(body.SrcRange.End, pos) {
-			return hclsyntax.Tokens{}, &NoBlockFoundErr{pos}
+			return pf.Tokens, &NoBlockFoundErr{pos}
 		}
 		if !body.SrcRange.ContainsPos(pos) {
 			return hclsyntax.Tokens{}, &InvalidHclPosErr{pos, body.SrcRange}
@@ -79,13 +79,12 @@ func (f *file) BlockTokensAtPosition(pos hcllib.Pos) (hclsyntax.Tokens, error) {
 	}
 
 	for _, block := range body.Blocks {
-		wholeRange := hcllib.RangeBetween(block.TypeRange, block.CloseBraceRange)
-		if wholeRange.ContainsPos(pos) {
-			return definitionTokens(tokensInRange(f.pf.Tokens, block.Range())), nil
+		if block.Range().ContainsPos(pos) {
+			return definitionTokens(tokensInRange(pf.Tokens, block.Range())), nil
 		}
 	}
 
-	return nil, &NoBlockFoundErr{pos}
+	return pf.Tokens, &NoBlockFoundErr{pos}
 }
 
 func tokensInRange(tokens hclsyntax.Tokens, rng hcllib.Range) hclsyntax.Tokens {

--- a/internal/hcl/hcl.go
+++ b/internal/hcl/hcl.go
@@ -11,6 +11,7 @@ import (
 
 type File interface {
 	BlockTokensAtPosition(hcl.Pos) (hclsyntax.Tokens, error)
+	TokenAtPosition(hcl.Pos) (hclsyntax.Token, error)
 }
 
 type file struct {
@@ -85,6 +86,18 @@ func (f *file) BlockTokensAtPosition(pos hcllib.Pos) (hclsyntax.Tokens, error) {
 	}
 
 	return pf.Tokens, &NoBlockFoundErr{pos}
+}
+
+func (f *file) TokenAtPosition(pos hcllib.Pos) (hclsyntax.Token, error) {
+	pf, _ := f.parse()
+
+	for _, t := range pf.Tokens {
+		if rangeContainsOffset(t.Range, pos.Byte) {
+			return t, nil
+		}
+	}
+
+	return hclsyntax.Token{}, &NoTokenFoundErr{pos}
 }
 
 func tokensInRange(tokens hclsyntax.Tokens, rng hcllib.Range) hclsyntax.Tokens {

--- a/internal/hcl/hcl_test.go
+++ b/internal/hcl/hcl_test.go
@@ -129,7 +129,7 @@ func TestFile_BlockAtPosition(t *testing.T) {
 			},
 			&InvalidHclPosErr{
 				Pos:     hcl.Pos{Line: -42, Column: -3, Byte: -46},
-				InRange: hcl.Range{Filename: "test.tf", Start: hcl.InitialPos, End: hcl.InitialPos},
+				InRange: hcl.Range{Filename: "/test.tf", Start: hcl.InitialPos, End: hcl.InitialPos},
 			},
 			nil,
 		},
@@ -143,7 +143,7 @@ func TestFile_BlockAtPosition(t *testing.T) {
 			},
 			&InvalidHclPosErr{
 				Pos:     hcl.Pos{Line: 42, Column: 3, Byte: 46},
-				InRange: hcl.Range{Filename: "test.tf", Start: hcl.InitialPos, End: hcl.InitialPos},
+				InRange: hcl.Range{Filename: "/test.tf", Start: hcl.InitialPos, End: hcl.InitialPos},
 			},
 			nil,
 		},
@@ -161,7 +161,7 @@ func TestFile_BlockAtPosition(t *testing.T) {
 			&InvalidHclPosErr{
 				Pos: hcl.Pos{Line: 42, Column: 3, Byte: 46},
 				InRange: hcl.Range{
-					Filename: "test.tf",
+					Filename: "/test.tf",
 					Start:    hcl.InitialPos,
 					End:      hcl.Pos{Column: 1, Line: 4, Byte: 20},
 				},
@@ -237,10 +237,9 @@ provider "aws" {
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("%d-%s", i+1, tc.name), func(t *testing.T) {
-			fsFile := filesystem.NewFile("test.tf", []byte(tc.content))
-			f := NewFile(fsFile)
+			f := NewTestFile([]byte(tc.content))
 
-			tokens, err := f.BlockTokensAtPosition(tc.pos)
+			tBlock, err := f.BlockAtPosition(tc.pos)
 			if err != nil {
 				if tc.expectedErr == nil {
 					t.Fatal(err)
@@ -254,7 +253,7 @@ provider "aws" {
 				t.Fatalf("Expected error: %s", tc.expectedErr)
 			}
 
-			if diff := cmp.Diff(hclsyntax.Tokens(tc.expectedTokens), tokens, opts...); diff != "" {
+			if diff := cmp.Diff(hclsyntax.Tokens(tc.expectedTokens), tBlock.Tokens(), opts...); diff != "" {
 				t.Fatalf("Unexpected token difference: %s", diff)
 			}
 

--- a/internal/hcl/hcl_test.go
+++ b/internal/hcl/hcl_test.go
@@ -239,12 +239,8 @@ provider "aws" {
 		t.Run(fmt.Sprintf("%d-%s", i+1, tc.name), func(t *testing.T) {
 			fsFile := filesystem.NewFile("test.tf", []byte(tc.content))
 			f := NewFile(fsFile)
-			fp := &testPosition{
-				FileHandler: fsFile,
-				pos:         tc.pos,
-			}
 
-			tokens, _, err := f.BlockTokensAtPosition(fp)
+			tokens, err := f.BlockTokensAtPosition(tc.pos)
 			if err != nil {
 				if tc.expectedErr == nil {
 					t.Fatal(err)

--- a/internal/hcl/types.go
+++ b/internal/hcl/types.go
@@ -1,0 +1,17 @@
+package hcl
+
+import (
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+)
+
+type TokenizedFile interface {
+	BlockAtPosition(hcl.Pos) (TokenizedBlock, error)
+	TokenAtPosition(hcl.Pos) (hclsyntax.Token, error)
+	PosInBlock(hcl.Pos) bool
+}
+
+type TokenizedBlock interface {
+	TokenAtPosition(hcl.Pos) (hclsyntax.Token, error)
+	Tokens() hclsyntax.Tokens
+}

--- a/internal/terraform/lang/config_block_test.go
+++ b/internal/terraform/lang/config_block_test.go
@@ -256,16 +256,13 @@ func TestCompletableBlock_CompletionCandidatesAtPos(t *testing.T) {
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("%d-%s", i, tc.name), func(t *testing.T) {
-			tokens := lexConfig(t, tc.src)
-			block, err := AsHCLSyntaxBlock(parseHclBlock(t, tc.src))
-			if err != nil {
-				t.Fatal(err)
-			}
+			tBlock := newTestBlock(t, tc.src)
 
 			cb := &completableBlock{
-				logger: testLogger(),
-				block:  ParseBlock(block, []*ParsedLabel{}, tc.sb),
-				tokens: tokens,
+				logger:       testLogger(),
+				parsedLabels: []*ParsedLabel{},
+				schema:       tc.sb,
+				tBlock:       tBlock,
 			}
 
 			list, err := cb.completionCandidatesAtPos(tc.pos)

--- a/internal/terraform/lang/config_block_test.go
+++ b/internal/terraform/lang/config_block_test.go
@@ -257,11 +257,15 @@ func TestCompletableBlock_CompletionCandidatesAtPos(t *testing.T) {
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("%d-%s", i, tc.name), func(t *testing.T) {
 			tokens := lexConfig(t, tc.src)
-			block := ParseBlock(tokens, []*ParsedLabel{}, tc.sb)
+			block, err := AsHCLSyntaxBlock(parseHclBlock(t, tc.src))
+			if err != nil {
+				t.Fatal(err)
+			}
 
 			cb := &completableBlock{
 				logger: testLogger(),
-				block:  block,
+				block:  ParseBlock(block, []*ParsedLabel{}, tc.sb),
+				tokens: tokens,
 			}
 
 			list, err := cb.completionCandidatesAtPos(tc.pos)
@@ -291,7 +295,7 @@ func renderCandidates(list CompletionCandidates, pos hcl.Pos) []renderedCandidat
 	}
 	rendered := make([]renderedCandidate, len(list.List()))
 	for i, c := range list.List() {
-		pos, text := c.Snippet(pos)
+		text := c.Snippet()
 		doc := ""
 		if c.Documentation() != nil {
 			doc = c.Documentation().Value()

--- a/internal/terraform/lang/datasource_block_test.go
+++ b/internal/terraform/lang/datasource_block_test.go
@@ -58,10 +58,10 @@ func TestDatasourceBlock_Name(t *testing.T) {
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("%d-%s", i, tc.name), func(t *testing.T) {
-			tokens := lexConfig(t, tc.src)
+			tBlock := newTestBlock(t, tc.src)
 
 			pf := &datasourceBlockFactory{logger: log.New(os.Stdout, "", 0)}
-			p, err := pf.New(tokens)
+			p, err := pf.New(tBlock)
 
 			if err != nil {
 				if tc.expectedErr != nil && err.Error() == tc.expectedErr.Error() {
@@ -146,6 +146,16 @@ func TestDataSourceBlock_completionCandidatesAtPos(t *testing.T) {
 			nil,
 		},
 		{
+			"missing type",
+			`data "" "" {
+}`,
+			simpleSchema,
+			nil,
+			hcl.Pos{Line: 2, Column: 1, Byte: 13},
+			[]renderedCandidate{},
+			&schema.SchemaUnavailableErr{BlockType: "data", FullName: ""},
+		},
+		{
 			"schema reader error",
 			`data "custom_ds" "name" {
 
@@ -179,7 +189,7 @@ func TestDataSourceBlock_completionCandidatesAtPos(t *testing.T) {
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("%d-%s", i, tc.name), func(t *testing.T) {
-			tokens := lexConfig(t, tc.src)
+			tBlock := newTestBlock(t, tc.src)
 
 			pf := &datasourceBlockFactory{
 				logger: log.New(os.Stdout, "", 0),
@@ -188,7 +198,7 @@ func TestDataSourceBlock_completionCandidatesAtPos(t *testing.T) {
 					DataSourceSchemaErr: tc.readerErr,
 				},
 			}
-			p, err := pf.New(tokens)
+			p, err := pf.New(tBlock)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/terraform/lang/datasource_block_test.go
+++ b/internal/terraform/lang/datasource_block_test.go
@@ -146,17 +146,6 @@ func TestDataSourceBlock_completionCandidatesAtPos(t *testing.T) {
 			nil,
 		},
 		{
-			"missing type doesn't error",
-			`data "" "" {
-
-}`,
-			simpleSchema,
-			nil,
-			hcl.Pos{Line: 2, Column: 1, Byte: 13},
-			[]renderedCandidate{},
-			nil,
-		},
-		{
 			"schema reader error",
 			`data "custom_ds" "name" {
 

--- a/internal/terraform/lang/hcl_block.go
+++ b/internal/terraform/lang/hcl_block.go
@@ -50,18 +50,12 @@ func (b *parsedBlock) Range() hcl.Range {
 }
 
 func (b *parsedBlock) PosInLabels(pos hcl.Pos) bool {
-	for _, rng := range b.hclBlock.LabelRanges {
-		if rng.ContainsPos(pos) {
-			return true
-		}
-	}
-
-	return false
+	return PosInLabels(b.hclBlock, pos)
 }
 
 func (b *parsedBlock) LabelAtPos(pos hcl.Pos) (*ParsedLabel, bool) {
 	for i, rng := range b.hclBlock.LabelRanges {
-		if rng.ContainsPos(pos) {
+		if rangeContainsOffset(rng, pos.Byte) {
 			// TODO: Guard against crashes when user sets label where we don't expect it
 			return b.labels[i], true
 		}
@@ -104,11 +98,8 @@ func (b *parsedBlock) PosInAttribute(pos hcl.Pos) bool {
 			continue
 		}
 
-		attrRange := attr.Range()
 		// Account for the last character
-		attrRange.End.Byte += 1
-
-		if attrRange.ContainsPos(pos) {
+		if rangeContainsOffset(attr.Range(), pos.Byte) {
 			return true
 		}
 	}
@@ -124,12 +115,8 @@ func (b *parsedBlock) PosInAttribute(pos hcl.Pos) bool {
 	// but we do it anyway, for "correctness"
 
 	for _, attr := range b.unknownAttributes {
-		attrRange := attr.Range()
-
 		// Account for the last character
-		attrRange.End.Byte += 1
-
-		if attrRange.ContainsPos(pos) {
+		if rangeContainsOffset(attr.Range(), pos.Byte) {
 			return true
 		}
 	}

--- a/internal/terraform/lang/hcl_block.go
+++ b/internal/terraform/lang/hcl_block.go
@@ -7,7 +7,6 @@ import (
 
 type parsedBlock struct {
 	hclBlock      *hclsyntax.Block
-	labels        []*ParsedLabel
 	AttributesMap map[string]*Attribute
 	BlockTypesMap map[string]*BlockType
 
@@ -47,21 +46,6 @@ func (b *parsedBlock) BlockAtPos(pos hcl.Pos) (Block, bool) {
 
 func (b *parsedBlock) Range() hcl.Range {
 	return b.hclBlock.Range()
-}
-
-func (b *parsedBlock) PosInLabels(pos hcl.Pos) bool {
-	return PosInLabels(b.hclBlock, pos)
-}
-
-func (b *parsedBlock) LabelAtPos(pos hcl.Pos) (*ParsedLabel, bool) {
-	for i, rng := range b.hclBlock.LabelRanges {
-		if rangeContainsOffset(rng, pos.Byte) {
-			// TODO: Guard against crashes when user sets label where we don't expect it
-			return b.labels[i], true
-		}
-	}
-
-	return nil, false
 }
 
 func (b *parsedBlock) PosInBody(pos hcl.Pos) bool {

--- a/internal/terraform/lang/hcl_block_type.go
+++ b/internal/terraform/lang/hcl_block_type.go
@@ -62,8 +62,7 @@ func (bt BlockTypes) AddBlock(name string, block *hclsyntax.Block, typeSchema *t
 
 	if block != nil {
 		// SDK doesn't support named blocks yet, so we expect no labels here for now
-		labels := make([]*ParsedLabel, 0)
-		bt[name].BlockList = append(bt[name].BlockList, ParseBlock(block, labels, typeSchema.Block))
+		bt[name].BlockList = append(bt[name].BlockList, parseBlock(block, typeSchema.Block))
 	}
 }
 

--- a/internal/terraform/lang/hcl_block_type.go
+++ b/internal/terraform/lang/hcl_block_type.go
@@ -63,7 +63,7 @@ func (bt BlockTypes) AddBlock(name string, block *hclsyntax.Block, typeSchema *t
 	if block != nil {
 		// SDK doesn't support named blocks yet, so we expect no labels here for now
 		labels := make([]*ParsedLabel, 0)
-		bt[name].BlockList = append(bt[name].BlockList, parseBlock(block, labels, typeSchema.Block))
+		bt[name].BlockList = append(bt[name].BlockList, ParseBlock(block, labels, typeSchema.Block))
 	}
 }
 

--- a/internal/terraform/lang/hcl_parser.go
+++ b/internal/terraform/lang/hcl_parser.go
@@ -8,16 +8,7 @@ import (
 	tfjson "github.com/hashicorp/terraform-json"
 )
 
-// ParseBlock parses HCL block's tokens based on tfjson's SchemaBlock
-// and keeps hold of all tfjson schema details on block or attribute level
-func ParseBlock(tokens hclsyntax.Tokens, labels []*ParsedLabel, schema *tfjson.SchemaBlock) (Block) {
-	// We ignore diags as we assume incomplete (invalid) configuration
-	hclBlock, _ := hclsyntax.ParseBlockFromTokens(tokens)
-
-	return parseBlock(hclBlock, labels, schema)
-}
-
-func parseBlock(block *hclsyntax.Block, labels []*ParsedLabel, schema *tfjson.SchemaBlock) Block {
+func ParseBlock(block *hclsyntax.Block, labels []*ParsedLabel, schema *tfjson.SchemaBlock) Block {
 	b := &parsedBlock{
 		hclBlock: block,
 		labels:   labels,
@@ -42,7 +33,7 @@ func parseBlock(block *hclsyntax.Block, labels []*ParsedLabel, schema *tfjson.Sc
 
 // ParseLabels parses HCL block's tokens based on LabelSchema,
 // returning labels as a slice of *ParsedLabel
-func ParseLabels(tokens hclsyntax.Tokens, schema LabelSchema) ([]*ParsedLabel) {
+func ParseLabels(tokens hclsyntax.Tokens, schema LabelSchema) []*ParsedLabel {
 	// We ignore diags as we assume incomplete (invalid) configuration
 	hclBlock, _ := hclsyntax.ParseBlockFromTokens(tokens)
 

--- a/internal/terraform/lang/hcl_parser.go
+++ b/internal/terraform/lang/hcl_parser.go
@@ -6,12 +6,21 @@ import (
 	hcl "github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	tfjson "github.com/hashicorp/terraform-json"
+	ihcl "github.com/hashicorp/terraform-ls/internal/hcl"
 )
 
-func ParseBlock(block *hclsyntax.Block, labels []*ParsedLabel, schema *tfjson.SchemaBlock) Block {
+// ParseBlock parses HCL block's tokens based on tfjson's SchemaBlock
+// and keeps hold of all tfjson schema details on block or attribute level
+func ParseBlock(tBlock ihcl.TokenizedBlock, schema *tfjson.SchemaBlock) Block {
+	// We ignore diags as we assume incomplete (invalid) configuration
+	hclBlock, _ := hclsyntax.ParseBlockFromTokens(tBlock.Tokens())
+
+	return parseBlock(hclBlock, schema)
+}
+
+func parseBlock(block *hclsyntax.Block, schema *tfjson.SchemaBlock) Block {
 	b := &parsedBlock{
 		hclBlock: block,
-		labels:   labels,
 	}
 	if block == nil {
 		return b
@@ -33,28 +42,44 @@ func ParseBlock(block *hclsyntax.Block, labels []*ParsedLabel, schema *tfjson.Sc
 
 // ParseLabels parses HCL block's tokens based on LabelSchema,
 // returning labels as a slice of *ParsedLabel
-func ParseLabels(tokens hclsyntax.Tokens, schema LabelSchema) []*ParsedLabel {
+func ParseLabels(tBlock ihcl.TokenizedBlock, schema LabelSchema) []*ParsedLabel {
 	// We ignore diags as we assume incomplete (invalid) configuration
-	hclBlock, _ := hclsyntax.ParseBlockFromTokens(tokens)
+	hclBlock, _ := hclsyntax.ParseBlockFromTokens(tBlock.Tokens())
 
-	return parseLabels(hclBlock.Type, schema, hclBlock.Labels)
+	return parseLabels(hclBlock, schema)
 }
 
-func parseLabels(blockType string, schema LabelSchema, parsed []string) []*ParsedLabel {
+func parseLabels(block *hclsyntax.Block, schema LabelSchema) []*ParsedLabel {
+	parsed := block.Labels
+
 	labels := make([]*ParsedLabel, len(schema))
 
 	for i, l := range schema {
 		var value string
+		var rng hcl.Range
 		if len(parsed)-1 >= i {
 			value = parsed[i]
+			rng = block.LabelRanges[i]
 		}
 		labels[i] = &ParsedLabel{
 			Name:  l.Name,
 			Value: value,
+			Range: rng,
 		}
 	}
 
 	return labels
+}
+
+func LabelAtPos(labels []*ParsedLabel, pos hcl.Pos) (*ParsedLabel, bool) {
+	for _, l := range labels {
+		if rangeContainsOffset(l.Range, pos.Byte) {
+			// TODO: Guard against crashes when user sets label where we don't expect it
+			return l, true
+		}
+	}
+
+	return nil, false
 }
 
 func AsHCLSyntaxBlock(block *hcl.Block) (*hclsyntax.Block, error) {

--- a/internal/terraform/lang/hcl_parser_test.go
+++ b/internal/terraform/lang/hcl_parser_test.go
@@ -23,13 +23,6 @@ func TestParseBlock_attributesAndBlockTypes(t *testing.T) {
 		expectedBlockTypes map[string]*BlockType
 	}{
 		{
-			"empty cfg, nil schema",
-			"",
-			nil,
-			nil,
-			nil,
-		},
-		{
 			"empty block, nil schema",
 			`myblock {}`,
 			nil,
@@ -302,12 +295,9 @@ func TestParseBlock_attributesAndBlockTypes(t *testing.T) {
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("%d-%s", i, tc.name), func(t *testing.T) {
-			block, err := AsHCLSyntaxBlock(parseHclBlock(t, tc.cfg))
-			if err != nil {
-				t.Fatal(err)
-			}
+			tBlock := newTestBlock(t, tc.cfg)
 
-			b := ParseBlock(block, []*ParsedLabel{}, tc.schema)
+			b := ParseBlock(tBlock, tc.schema)
 
 			if diff := cmp.Diff(tc.expectedAttributes, b.Attributes(), opts...); diff != "" {
 				t.Fatalf("Attributes don't match.\n%s", diff)
@@ -466,11 +456,8 @@ func TestBlock_BlockAtPos(t *testing.T) {
 	}
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("%d-%s", i, tc.name), func(t *testing.T) {
-			block, err := AsHCLSyntaxBlock(parseHclBlock(t, tc.cfg))
-			if err != nil {
-				t.Fatal(err)
-			}
-			b := ParseBlock(block, []*ParsedLabel{}, schema)
+			tBlock := newTestBlock(t, tc.cfg)
+			b := ParseBlock(tBlock, schema)
 
 			fBlock, _ := b.BlockAtPos(tc.pos)
 			if diff := cmp.Diff(tc.expectedBlock, fBlock, opts...); diff != "" {
@@ -626,11 +613,8 @@ func TestBlock_PosInBody(t *testing.T) {
 	}
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("%d-%s", i, tc.name), func(t *testing.T) {
-			block, err := AsHCLSyntaxBlock(parseHclBlock(t, tc.cfg))
-			if err != nil {
-				t.Fatal(err)
-			}
-			b := ParseBlock(block, []*ParsedLabel{}, schema)
+			tBlock := newTestBlock(t, tc.cfg)
+			b := ParseBlock(tBlock, schema)
 
 			isInBody := b.PosInBody(tc.pos)
 			if tc.expected != isInBody {
@@ -761,11 +745,8 @@ func TestBlock_PosInAttributes(t *testing.T) {
 	}
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("%d-%s", i, tc.name), func(t *testing.T) {
-			block, err := AsHCLSyntaxBlock(parseHclBlock(t, tc.cfg))
-			if err != nil {
-				t.Fatal(err)
-			}
-			b := ParseBlock(block, []*ParsedLabel{}, schema)
+			tBlock := newTestBlock(t, tc.cfg)
+			b := ParseBlock(tBlock, schema)
 
 			isInAttribute := b.PosInAttribute(tc.pos)
 			if tc.expected != isInAttribute {

--- a/internal/terraform/lang/hcl_parser_test.go
+++ b/internal/terraform/lang/hcl_parser_test.go
@@ -302,9 +302,12 @@ func TestParseBlock_attributesAndBlockTypes(t *testing.T) {
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("%d-%s", i, tc.name), func(t *testing.T) {
-			tokens := lexConfig(t, tc.cfg)
+			block, err := AsHCLSyntaxBlock(parseHclBlock(t, tc.cfg))
+			if err != nil {
+				t.Fatal(err)
+			}
 
-			b := ParseBlock(tokens, []*ParsedLabel{}, tc.schema)
+			b := ParseBlock(block, []*ParsedLabel{}, tc.schema)
 
 			if diff := cmp.Diff(tc.expectedAttributes, b.Attributes(), opts...); diff != "" {
 				t.Fatalf("Attributes don't match.\n%s", diff)
@@ -463,8 +466,11 @@ func TestBlock_BlockAtPos(t *testing.T) {
 	}
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("%d-%s", i, tc.name), func(t *testing.T) {
-			tokens := lexConfig(t, tc.cfg)
-			b := ParseBlock(tokens, []*ParsedLabel{}, schema)
+			block, err := AsHCLSyntaxBlock(parseHclBlock(t, tc.cfg))
+			if err != nil {
+				t.Fatal(err)
+			}
+			b := ParseBlock(block, []*ParsedLabel{}, schema)
 
 			fBlock, _ := b.BlockAtPos(tc.pos)
 			if diff := cmp.Diff(tc.expectedBlock, fBlock, opts...); diff != "" {
@@ -620,8 +626,11 @@ func TestBlock_PosInBody(t *testing.T) {
 	}
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("%d-%s", i, tc.name), func(t *testing.T) {
-			tokens := lexConfig(t, tc.cfg)
-			b := ParseBlock(tokens, []*ParsedLabel{}, schema)
+			block, err := AsHCLSyntaxBlock(parseHclBlock(t, tc.cfg))
+			if err != nil {
+				t.Fatal(err)
+			}
+			b := ParseBlock(block, []*ParsedLabel{}, schema)
 
 			isInBody := b.PosInBody(tc.pos)
 			if tc.expected != isInBody {
@@ -752,8 +761,11 @@ func TestBlock_PosInAttributes(t *testing.T) {
 	}
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("%d-%s", i, tc.name), func(t *testing.T) {
-			tokens := lexConfig(t, tc.cfg)
-			b := ParseBlock(tokens, []*ParsedLabel{}, schema)
+			block, err := AsHCLSyntaxBlock(parseHclBlock(t, tc.cfg))
+			if err != nil {
+				t.Fatal(err)
+			}
+			b := ParseBlock(block, []*ParsedLabel{}, schema)
 
 			isInAttribute := b.PosInAttribute(tc.pos)
 			if tc.expected != isInAttribute {

--- a/internal/terraform/lang/parser_test.go
+++ b/internal/terraform/lang/parser_test.go
@@ -16,7 +16,16 @@ import (
 func TestParser_BlockTypeCandidates_len(t *testing.T) {
 	p := newParser()
 
-	candidates := p.BlockTypeCandidates()
+	content := `
+provider "aws" {
+}`
+	pos := hcl.Pos{
+		Line:   1,
+		Column: 1,
+		Byte:   0,
+	}
+	tokens := lexConfig(t, content)
+	candidates := p.BlockTypeCandidates(tokens, pos)
 	if candidates.Len() < 3 {
 		t.Fatalf("Expected >= 3 candidates, %d given", candidates.Len())
 	}
@@ -25,7 +34,16 @@ func TestParser_BlockTypeCandidates_len(t *testing.T) {
 func TestParser_BlockTypeCandidates_snippet(t *testing.T) {
 	p := newParser()
 
-	list := p.BlockTypeCandidates()
+	content := `
+provider "aws" {
+}`
+	pos := hcl.Pos{
+		Line:   1,
+		Column: 1,
+		Byte:   0,
+	}
+	tokens := lexConfig(t, content)
+	list := p.BlockTypeCandidates(tokens, pos)
 	rendered := renderCandidates(list, hcl.InitialPos)
 	sortRenderedCandidates(rendered)
 

--- a/internal/terraform/lang/provider_block_test.go
+++ b/internal/terraform/lang/provider_block_test.go
@@ -51,10 +51,10 @@ func TestProviderBlock_Name(t *testing.T) {
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("%d-%s", i, tc.name), func(t *testing.T) {
-			tokens := lexConfig(t, tc.src)
+			tBlock := newTestBlock(t, tc.src)
 
 			pf := &providerBlockFactory{logger: log.New(os.Stdout, "", 0)}
-			p, err := pf.New(tokens)
+			p, err := pf.New(tBlock)
 
 			if err != nil {
 				if tc.expectedErr != nil && err.Error() == tc.expectedErr.Error() {
@@ -139,6 +139,16 @@ func TestProviderBlock_completionCandidatesAtPos(t *testing.T) {
 			nil,
 		},
 		{
+			"missing type",
+			`provider "" {
+}`,
+			simpleSchema,
+			nil,
+			hcl.Pos{Line: 2, Column: 1, Byte: 14},
+			[]renderedCandidate{},
+			&schema.SchemaUnavailableErr{BlockType: "provider", FullName: ""},
+		},
+		{
 			"schema reader error",
 			`provider "custom" {
 
@@ -174,7 +184,7 @@ func TestProviderBlock_completionCandidatesAtPos(t *testing.T) {
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("%d-%s", i, tc.name), func(t *testing.T) {
-			tokens := lexConfig(t, tc.src)
+			tBlock := newTestBlock(t, tc.src)
 
 			pf := &providerBlockFactory{
 				logger: log.New(os.Stdout, "", 0),
@@ -183,7 +193,7 @@ func TestProviderBlock_completionCandidatesAtPos(t *testing.T) {
 					ProviderSchemaErr: tc.readerErr,
 				},
 			}
-			p, err := pf.New(tokens)
+			p, err := pf.New(tBlock)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/terraform/lang/provider_block_test.go
+++ b/internal/terraform/lang/provider_block_test.go
@@ -139,17 +139,6 @@ func TestProviderBlock_completionCandidatesAtPos(t *testing.T) {
 			nil,
 		},
 		{
-			"missing type doesn't error",
-			`provider "" {
-
-}`,
-			simpleSchema,
-			nil,
-			hcl.Pos{Line: 2, Column: 1, Byte: 14},
-			[]renderedCandidate{},
-			nil,
-		},
-		{
 			"schema reader error",
 			`provider "custom" {
 

--- a/internal/terraform/lang/resource_block_test.go
+++ b/internal/terraform/lang/resource_block_test.go
@@ -146,17 +146,6 @@ func TestResourceBlock_completionCandidatesAtPos(t *testing.T) {
 			nil,
 		},
 		{
-			"missing type doesn't error",
-			`resource "" "" {
-
-}`,
-			simpleSchema,
-			nil,
-			hcl.Pos{Line: 2, Column: 1, Byte: 17},
-			[]renderedCandidate{},
-			nil,
-		},
-		{
 			"schema reader error",
 			`resource "custom_rs" "name" {
 

--- a/internal/terraform/lang/resource_block_test.go
+++ b/internal/terraform/lang/resource_block_test.go
@@ -58,10 +58,10 @@ func TestResourceBlock_Name(t *testing.T) {
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("%d-%s", i, tc.name), func(t *testing.T) {
-			tokens := lexConfig(t, tc.src)
+			tBlock := newTestBlock(t, tc.src)
 
 			pf := &resourceBlockFactory{logger: log.New(os.Stdout, "", 0)}
-			p, err := pf.New(tokens)
+			p, err := pf.New(tBlock)
 
 			if err != nil {
 				if tc.expectedErr != nil && err.Error() == tc.expectedErr.Error() {
@@ -146,6 +146,16 @@ func TestResourceBlock_completionCandidatesAtPos(t *testing.T) {
 			nil,
 		},
 		{
+			"missing type",
+			`resource "" "" {
+}`,
+			simpleSchema,
+			nil,
+			hcl.Pos{Line: 2, Column: 1, Byte: 17},
+			[]renderedCandidate{},
+			&schema.SchemaUnavailableErr{BlockType: "resource", FullName: ""},
+		},
+		{
 			"schema reader error",
 			`resource "custom_rs" "name" {
 
@@ -181,7 +191,7 @@ func TestResourceBlock_completionCandidatesAtPos(t *testing.T) {
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("%d-%s", i, tc.name), func(t *testing.T) {
-			tokens := lexConfig(t, tc.src)
+			tBlock := newTestBlock(t, tc.src)
 
 			pf := &resourceBlockFactory{
 				logger: log.New(os.Stdout, "", 0),
@@ -190,7 +200,7 @@ func TestResourceBlock_completionCandidatesAtPos(t *testing.T) {
 					ResourceSchemaErr: tc.readerErr,
 				},
 			}
-			p, err := pf.New(tokens)
+			p, err := pf.New(tBlock)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/terraform/lang/types.go
+++ b/internal/terraform/lang/types.go
@@ -15,7 +15,7 @@ import (
 type Parser interface {
 	SetLogger(*log.Logger)
 	SetSchemaReader(schema.Reader)
-	BlockTypeCandidates() CompletionCandidates
+	BlockTypeCandidates(hclsyntax.Tokens, hcl.Pos) CompletionCandidates
 	ParseBlockFromTokens(hclsyntax.Tokens) (ConfigBlock, error)
 }
 
@@ -77,7 +77,9 @@ type CompletionCandidate interface {
 	Label() string
 	Detail() string
 	Documentation() MarkupContent
-	Snippet(pos hcl.Pos) (hcl.Pos, string)
+	Snippet() string
+	SetPrefix(string)
+	PrefixRange() hcl.Range
 }
 
 // MarkupContent reflects lsp.MarkupContent

--- a/internal/terraform/lang/utils.go
+++ b/internal/terraform/lang/utils.go
@@ -1,0 +1,45 @@
+package lang
+
+import (
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+)
+
+func PosInLabels(b *hclsyntax.Block, pos hcl.Pos) bool {
+	if b == nil {
+		return false
+	}
+
+	for _, rng := range b.LabelRanges {
+		if rangeContainsOffset(rng, pos.Byte) {
+			return true
+		}
+	}
+	return false
+}
+
+func wordBeforePos(tokens hclsyntax.Tokens, pos hcl.Pos) string {
+	switch token := tokenAtPos(tokens, pos); token.Type {
+	case hclsyntax.TokenIdent, hclsyntax.TokenQuotedLit, hclsyntax.TokenStringLit:
+		return string(token.Bytes[:pos.Byte-token.Range.Start.Byte])
+	default:
+		return ""
+	}
+}
+
+func tokenAtPos(tokens hclsyntax.Tokens, pos hcl.Pos) hclsyntax.Token {
+	for _, t := range tokens {
+		if rangeContainsOffset(t.Range, pos.Byte) {
+			return t
+		}
+	}
+	return hclsyntax.Token{
+		Type: hclsyntax.TokenNil,
+	}
+}
+
+// rangeContainsOffset is a reimplementation of hcl.Range.ContainsOffset
+// which treats offset matching the end of a range as contained
+func rangeContainsOffset(rng hcl.Range, offset int) bool {
+	return offset >= rng.Start.Byte && offset <= rng.End.Byte
+}

--- a/internal/terraform/lang/utils.go
+++ b/internal/terraform/lang/utils.go
@@ -18,24 +18,22 @@ func PosInLabels(b *hclsyntax.Block, pos hcl.Pos) bool {
 	return false
 }
 
-func wordBeforePos(tokens hclsyntax.Tokens, pos hcl.Pos) string {
-	switch token := tokenAtPos(tokens, pos); token.Type {
-	case hclsyntax.TokenIdent, hclsyntax.TokenQuotedLit, hclsyntax.TokenStringLit:
-		return string(token.Bytes[:pos.Byte-token.Range.Start.Byte])
-	default:
+func prefixAtPos(looker TokenAtPosLooker, pos hcl.Pos) string {
+	token, err := looker.TokenAtPosition(pos)
+	if err != nil {
 		return ""
 	}
+
+	switch token.Type {
+	case hclsyntax.TokenIdent, hclsyntax.TokenQuotedLit, hclsyntax.TokenStringLit:
+		return string(token.Bytes[:pos.Byte-token.Range.Start.Byte])
+	}
+
+	return ""
 }
 
-func tokenAtPos(tokens hclsyntax.Tokens, pos hcl.Pos) hclsyntax.Token {
-	for _, t := range tokens {
-		if rangeContainsOffset(t.Range, pos.Byte) {
-			return t
-		}
-	}
-	return hclsyntax.Token{
-		Type: hclsyntax.TokenNil,
-	}
+type TokenAtPosLooker interface {
+	TokenAtPosition(hcl.Pos) (hclsyntax.Token, error)
 }
 
 // rangeContainsOffset is a reimplementation of hcl.Range.ContainsOffset

--- a/langserver/handlers/complete.go
+++ b/langserver/handlers/complete.go
@@ -72,7 +72,7 @@ func (h *logHandler) TextDocumentComplete(ctx context.Context, params lsp.Comple
 		return list, fmt.Errorf("finding completion items failed: %w", err)
 	}
 
-	return ilsp.CompletionList(candidates, fPos.Position(), cc.TextDocument), nil
+	return ilsp.CompletionList(candidates, cc.TextDocument), nil
 }
 
 func (h *logHandler) completeBlock(p lang.Parser, tokens hclsyntax.Tokens, pos hcl.Pos) (lang.CompletionCandidates, error) {

--- a/langserver/handlers/complete_test.go
+++ b/langserver/handlers/complete_test.go
@@ -86,21 +86,60 @@ func TestCompletion_withValidData(t *testing.T) {
 						"kind":5,
 						"detail":"Optional, number",
 						"documentation":"Desc 1",
-						"insertTextFormat":1
+						"insertTextFormat":1,
+						"textEdit": {
+							"range": {
+								"start": {
+									"line": 1, 
+									"character": 0
+								},
+								"end": {
+									"line": 1, 
+									"character": 0
+								}
+							},
+							"newText": "anonymous"
+						}
 					},
 					{
 						"label":"base_url",
 						"kind":5,
 						"detail":"Optional, string",
 						"documentation":"Desc 2",
-						"insertTextFormat":1
+						"insertTextFormat":1,
+						"textEdit": {
+							"range": {
+								"start": {
+									"line": 1, 
+									"character": 0
+								},
+								"end": {
+									"line": 1, 
+									"character": 0
+								}
+							},
+							"newText": "base_url"
+						}
 					},
 					{
 						"label":"individual",
 						"kind":5,
 						"detail":"Optional, bool",
 						"documentation":"Desc 3",
-						"insertTextFormat":1
+						"insertTextFormat":1,
+						"textEdit": {
+							"range": {
+								"start": {
+									"line": 1, 
+									"character": 0
+								},
+								"end": {
+									"line": 1, 
+									"character": 0
+								}
+							},
+							"newText": "individual"
+						}
 					}
 				]
 			}


### PR DESCRIPTION
Related: #12 
- in your test case, when `Line:   2, Column: 5`, the Byte should be `21` but not `20`
- add some corner case for func `TokenAtPosition`
- I just filter the results in the last step, please confirm whether we should filter the candidates before putting them into the candidate list
- tested in vscode, it's ok for this feature