### PR TITLE
langserver: Make requests sequential

### DIFF
--- a/langserver/langserver.go
+++ b/langserver/langserver.go
@@ -28,6 +28,10 @@ type langServer struct {
 func NewLangServer(srvCtx context.Context, sf session.SessionFactory) *langServer {
 	opts := &jrpc2.ServerOptions{
 		AllowPush: true,
+
+		// Disable concurrency to avoid race conditions
+		// between requests concerning the same document
+		Concurrency: 1,
 	}
 
 	return &langServer{


### PR DESCRIPTION
This presents a solution to problems that were discovered as part of #103 and #119
It follows gopls' implementation which doesn't have any concurrency either.

It does *not* address #8 but it significantly decreases the likelihood of in-flight conflicts. The only conflicts that may still occur is when provider schema is reloaded and any request leveraging the schema is in-flight at that time.

Longer-term we could look into parallelising unrelated requests which involve different files, but the real performance gain may be negligible, because it's unlikely that a single user would be working on more than 1 file at any given time.
