### PR TITLE
textDocument/didChange: Avoid flagging non-consecutive versions

### DIFF
--- a/langserver/handlers/did_change.go
+++ b/langserver/handlers/did_change.go
@@ -32,16 +32,10 @@ func TextDocumentDidChange(ctx context.Context, params DidChangeTextDocumentPara
 		return err
 	}
 
+	// Versions don't have to be consecutive, but they must be increasing
 	if p.TextDocument.Version <= f.Version() {
 		fs.Close(fh)
 		return fmt.Errorf("Old version (%d) received, current version is %d. "+
-			"Unable to update %s. This is likely a bug, please report it.",
-			p.TextDocument.Version, f.Version(), p.TextDocument.URI)
-	}
-
-	if p.TextDocument.Version > f.Version()+1 {
-		fs.Close(fh)
-		return fmt.Errorf("New version (%d) received, current version is %d. "+
 			"Unable to update %s. This is likely a bug, please report it.",
 			p.TextDocument.Version, f.Version(), p.TextDocument.URI)
 	}


### PR DESCRIPTION
I was under the impression that sequence of version numbers must be consecutive. According to the spec this is a wrong assumption:

https://microsoft.github.io/language-server-protocol/specifications/specification-current/#versionedTextDocumentIdentifier

```ts
interface VersionedTextDocumentIdentifier extends TextDocumentIdentifier {
	/**
	 * The version number of this document. If a versioned text document identifier
	 * is sent from the server to the client and the file is not open in the editor
	 * (the server has not received an open notification before) the server can send
	 * `null` to indicate that the version is known and the content on disk is the
	 * master (as speced with document content ownership).
	 *
	 * The version number of a document will increase after each change, including
	 * undo/redo. The number doesn't need to be consecutive.
	 */
	version: number | null;
}
```

> The version number of a document will increase after each change, including undo/redo. **The number doesn't need to be consecutive.**

[`coc.vim` specifically omits version numbers](https://gist.github.com/radeksimko/23e670c058af78fcb7fb5bd3535fcc51) after completion of labels, so this patch also reflects that.