### PR TITLE
textDocument/complete: Pass TextEdit instead of static text

### DIFF
--- a/internal/lsp/completion.go
+++ b/internal/lsp/completion.go
@@ -41,13 +41,7 @@ func CompletionItem(candidate lang.CompletionCandidate, pos hcl.Pos, snippetSupp
 			InsertTextFormat: lsp.ITFSnippet,
 			Detail:           candidate.Detail(),
 			Documentation:    doc,
-			TextEdit: &lsp.TextEdit{
-				Range: lsp.Range{
-					Start: lsp.Position{Line: pos.Line - 1, Character: pos.Column - 1},
-					End:   lsp.Position{Line: pos.Line - 1, Character: pos.Column - 1},
-				},
-				NewText: candidate.Snippet(),
-			},
+			TextEdit: textEdit(candidate.Snippet(), pos),
 		}
 	}
 
@@ -57,12 +51,21 @@ func CompletionItem(candidate lang.CompletionCandidate, pos hcl.Pos, snippetSupp
 		InsertTextFormat: lsp.ITFPlainText,
 		Detail:           candidate.Detail(),
 		Documentation:    doc,
-		TextEdit: &lsp.TextEdit{
-			Range: lsp.Range{
-				Start: lsp.Position{Line: pos.Line - 1, Character: pos.Column - 1},
-				End:   lsp.Position{Line: pos.Line - 1, Character: pos.Column - 1},
-			},
-			NewText: candidate.PlainText(),
-		},
+		TextEdit: textEdit(candidate.PlainText(), pos),
 	}
+}
+
+func textEdit(te lang.TextEdit, pos hcl.Pos) *lsp.TextEdit {
+	rng := te.Range()
+	if rng == nil {
+		rng = &hcl.Range{
+			Start: pos,
+			End: pos,
+		}
+	}
+
+	return &lsp.TextEdit{
+			NewText: te.NewText(),
+			Range: hclRangeToLSP(*rng),
+		}
 }

--- a/internal/terraform/lang/types.go
+++ b/internal/terraform/lang/types.go
@@ -76,8 +76,26 @@ type CompletionCandidate interface {
 	Label() string
 	Detail() string
 	Documentation() MarkupContent
-	Snippet() string
-	PlainText() string
+	Snippet() TextEdit
+	PlainText() TextEdit
+}
+
+type TextEdit interface {
+	Range() *hcl.Range
+	NewText() string
+}
+
+type textEdit struct {
+	newText string
+	rng     *hcl.Range
+}
+
+func (te *textEdit) Range() *hcl.Range {
+	return te.rng
+}
+
+func (te *textEdit) NewText() string {
+	return te.newText
 }
 
 // MarkupContent reflects lsp.MarkupContent

--- a/internal/terraform/lang/utils.go
+++ b/internal/terraform/lang/utils.go
@@ -18,18 +18,18 @@ func PosInLabels(b *hclsyntax.Block, pos hcl.Pos) bool {
 	return false
 }
 
-func prefixAtPos(looker TokenAtPosLooker, pos hcl.Pos) string {
+func prefixAtPos(looker TokenAtPosLooker, pos hcl.Pos) (string, *hcl.Range) {
 	token, err := looker.TokenAtPosition(pos)
 	if err != nil {
-		return ""
+		return "", nil
 	}
 
 	switch token.Type {
 	case hclsyntax.TokenIdent, hclsyntax.TokenQuotedLit, hclsyntax.TokenStringLit:
-		return string(token.Bytes[:pos.Byte-token.Range.Start.Byte])
+		return string(token.Bytes[:pos.Byte-token.Range.Start.Byte]), token.Range.Ptr()
 	}
 
-	return ""
+	return "", nil
 }
 
 type TokenAtPosLooker interface {


### PR DESCRIPTION
Depends on #132 

--- 

This seemingly small change has a positive effect on the UX while completing in the middle of an existing token, where clients can correctly highlight parts of completion candidates.

### Before

![Screenshot 2020-06-03 at 09 08 42](https://user-images.githubusercontent.com/287584/83612096-d74d1380-a579-11ea-8ceb-e2710c5aabe9.png)

![Screenshot 2020-06-03 at 09 14 06](https://user-images.githubusercontent.com/287584/83612654-999cba80-a57a-11ea-9be7-7fd88f29c656.png)


### After

![Screenshot 2020-06-03 at 09 08 06](https://user-images.githubusercontent.com/287584/83612112-dc11c780-a579-11ea-9482-7d9a4d315838.png)

![Screenshot 2020-06-03 at 09 13 34](https://user-images.githubusercontent.com/287584/83612663-9bff1480-a57a-11ea-9d11-a61323839c17.png)

--- 

As mentioned in the comment in code, this doesn't work (yet) for block types (e.g. `resource`, `data`, `provider`). It probably should, but some refactoring is necessary to make that work and realistically changing of block type is far less likely to occur in real scenarios, so it's ok to take on that tech debt.
