### PR TITLE
Make Terraform exec timeout configurable

### DIFF
--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -2,6 +2,7 @@ package context
 
 import (
 	"context"
+	"time"
 
 	"github.com/hashicorp/terraform-ls/internal/filesystem"
 	"github.com/hashicorp/terraform-ls/internal/terraform/exec"
@@ -27,6 +28,7 @@ var (
 	ctxTfVersion        = &contextKey{"terraform version"}
 	ctxTfVersionSetter  = &contextKey{"terraform version setter"}
 	ctxTfExecLogPath    = &contextKey{"terraform executor log path"}
+	ctxTfExecTimeout    = &contextKey{"terraform execution timeout"}
 )
 
 func missingContextErr(ctxKey *contextKey) *MissingContextErr {
@@ -145,5 +147,14 @@ func WithTerraformExecLogPath(path string, ctx context.Context) context.Context 
 
 func TerraformExecLogPath(ctx context.Context) (string, bool) {
 	path, ok := ctx.Value(ctxTfExecLogPath).(string)
+	return path, ok
+}
+
+func WithTerraformExecTimeout(timeout time.Duration, ctx context.Context) context.Context {
+	return context.WithValue(ctx, ctxTfExecTimeout, timeout)
+}
+
+func TerraformExecTimeout(ctx context.Context) (time.Duration, bool) {
+	path, ok := ctx.Value(ctxTfExecTimeout).(time.Duration)
 	return path, ok
 }

--- a/internal/terraform/exec/exec.go
+++ b/internal/terraform/exec/exec.go
@@ -19,6 +19,8 @@ import (
 	"github.com/hashicorp/terraform-ls/logging"
 )
 
+var defaultExecTimeout = 30 * time.Second
+
 // Environment variables to pass through to Terraform
 var passthroughEnvVars = []string{
 	// This allows Terraform to find custom-built providers
@@ -56,7 +58,7 @@ type command struct {
 func NewExecutor(ctx context.Context, path string) *Executor {
 	return &Executor{
 		ctx:      ctx,
-		timeout:  10 * time.Second,
+		timeout:  defaultExecTimeout,
 		execPath: path,
 		logger:   log.New(ioutil.Discard, "", 0),
 		cmdCtxFunc: func(ctx context.Context, path string, arg ...string) *exec.Cmd {

--- a/langserver/handlers/service.go
+++ b/langserver/handlers/service.go
@@ -99,6 +99,12 @@ func (svc *service) Assigner() (jrpc2.Assigner, error) {
 			if path, ok := lsctx.TerraformExecLogPath(svc.srvCtx); ok {
 				tf.SetExecLogPath(path)
 			}
+
+			// Timeout is set via CLI flag, hence in the server context
+			if timeout, ok := lsctx.TerraformExecTimeout(svc.srvCtx); ok {
+				tf.SetTimeout(timeout)
+			}
+
 			tf.SetLogger(svc.logger)
 
 			ctx = lsctx.WithTerraformExecutor(tf, ctx)


### PR DESCRIPTION
This PR raises the default timeout from `10s` to `30s` to reflect the original timeout may not be sufficient for a combination of a few providers with large schemas used in the same config and slower disk I/O.

It seems pragmatic to accommodate such cases, but slow I/O is painful in general and configuration gets more fragile with more providers you add (e.g. because one API may be down, which makes applies stop half-way through etc.), so these users will suffer either way and this patch is not meant to solve all their problems, just to help them suffer _less_.