### PR TITLE
terraform/exec: Pass through all environment variables

### DIFF
--- a/internal/terraform/exec/exec.go
+++ b/internal/terraform/exec/exec.go
@@ -21,15 +21,11 @@ import (
 
 var defaultExecTimeout = 30 * time.Second
 
-// Environment variables to pass through to Terraform
-var passthroughEnvVars = []string{
-	// This allows Terraform to find custom-built providers
-	"HOME", "USER", "USERPROFILE",
-	// This allows Terraform to create crash log in the desired temp directory
-	// os.TempDir would otherwise fall back to C:\Windows on Windows
-	// which has no write permissions for non-admins
-	"TMPDIR", "TMP", "TEMP",
-}
+// We pass through all variables, but longer term we'll need to reflect
+// that some variables might be workspace/directory specific
+// and passing through these may be dangerous once the LS
+// starts to execute commands which can mutate the state
+var passthroughEnvVars = os.Environ()
 
 // cmdCtxFunc allows mocking of Terraform in tests while retaining
 // ability to pass context for timeout/cancellation


### PR DESCRIPTION
Closes #138 

This should address many use cases where some form of external auth provider is being looked up by the provider or state backend.
e.g. https://docs.aws.amazon.com/eks/latest/userguide/install-aws-iam-authenticator.html in case of Kubernetes or `az` (Azure CLI) in case of AzureRM.

and also allow authentication from behind a corporate proxy, which can be configured on the workstation in such a way that the address of the proxy server is in standard environment variables.

We pass through all variables that are given to the server, which means that these could be reused between different workspaces, but this should be fairly safe for now, because

a) the language server doesn't execute `terraform` command that could do damage when provided wrong variables. We are working with the assumption that `terraform providers schema -json` does not push state.
b) we only allow one workspace at a time to be initialized anyway
