### PR TITLE
fix: os.Environ() returns KEY=val, not just keys

### DIFF
--- a/internal/lsp/completion.go
+++ b/internal/lsp/completion.go
@@ -41,7 +41,7 @@ func CompletionItem(candidate lang.CompletionCandidate, pos hcl.Pos, snippetSupp
 			InsertTextFormat: lsp.ITFSnippet,
 			Detail:           candidate.Detail(),
 			Documentation:    doc,
-			TextEdit: textEdit(candidate.Snippet(), pos),
+			TextEdit:         textEdit(candidate.Snippet(), pos),
 		}
 	}
 
@@ -51,7 +51,7 @@ func CompletionItem(candidate lang.CompletionCandidate, pos hcl.Pos, snippetSupp
 		InsertTextFormat: lsp.ITFPlainText,
 		Detail:           candidate.Detail(),
 		Documentation:    doc,
-		TextEdit: textEdit(candidate.PlainText(), pos),
+		TextEdit:         textEdit(candidate.PlainText(), pos),
 	}
 }
 
@@ -60,12 +60,12 @@ func textEdit(te lang.TextEdit, pos hcl.Pos) *lsp.TextEdit {
 	if rng == nil {
 		rng = &hcl.Range{
 			Start: pos,
-			End: pos,
+			End:   pos,
 		}
 	}
 
 	return &lsp.TextEdit{
-			NewText: te.NewText(),
-			Range: hclRangeToLSP(*rng),
-		}
+		NewText: te.NewText(),
+		Range:   hclRangeToLSP(*rng),
+	}
 }

--- a/internal/terraform/exec/exec.go
+++ b/internal/terraform/exec/exec.go
@@ -108,10 +108,8 @@ func (e *Executor) cmd(args ...string) (*command, error) {
 	// so we don't need to ask checkpoint for upgrades.
 	cmd.Env = append(cmd.Env, "CHECKPOINT_DISABLE=1")
 
-	for _, key := range passthroughEnvVars {
-		if value := os.Getenv(key); value != "" {
-			cmd.Env = append(cmd.Env, key+"="+value)
-		}
+	for _, envVar := range passthroughEnvVars {
+		cmd.Env = append(cmd.Env, envVar)
 	}
 
 	if e.execLogPath != "" {


### PR DESCRIPTION
Fix #141 