### PR TITLE
add support for "prefill all required fields"

### DIFF
--- a/internal/lsp/completion.go
+++ b/internal/lsp/completion.go
@@ -37,21 +37,23 @@ func CompletionItem(candidate lang.CompletionCandidate, pos hcl.Pos, snippetSupp
 	if snippetSupport {
 		return lsp.CompletionItem{
 			Label:            candidate.Label(),
-			Kind:             lsp.CIKField,
+			Kind:             lsp.CompletionItemKind(candidate.CompletionItemKind()),
 			InsertTextFormat: lsp.ITFSnippet,
 			Detail:           candidate.Detail(),
 			Documentation:    doc,
 			TextEdit:         textEdit(candidate.Snippet(), pos),
+			SortText:         candidate.SortText(),
 		}
 	}
 
 	return lsp.CompletionItem{
 		Label:            candidate.Label(),
-		Kind:             lsp.CIKField,
+		Kind:             lsp.CompletionItemKind(candidate.CompletionItemKind()),
 		InsertTextFormat: lsp.ITFPlainText,
 		Detail:           candidate.Detail(),
 		Documentation:    doc,
 		TextEdit:         textEdit(candidate.PlainText(), pos),
+		SortText:         candidate.SortText(),
 	}
 }
 

--- a/internal/terraform/lang/config_block.go
+++ b/internal/terraform/lang/config_block.go
@@ -395,7 +395,7 @@ func (c *AllRequiredFieldCandidate) Snippet() TextEdit {
 		placeHolder = nextPlaceHolder
 	}
 	for _, nestedBlock := range c.NestedBlockCandidates {
-		content = append(content, "\n"+snippetForNestedBlockWithPlaceholder(placeHolder, nestedBlock.Name))
+		content = append(content, snippetForNestedBlockWithPlaceholder(placeHolder, nestedBlock.Name)+"\n")
 		placeHolder++
 	}
 	return &textEdit{

--- a/internal/terraform/lang/config_block_test.go
+++ b/internal/terraform/lang/config_block_test.go
@@ -98,12 +98,21 @@ func TestCompletableBlock_CompletionCandidatesAtPos(t *testing.T) {
 			attrOnlySchema,
 			[]renderedCandidate{
 				{
+					Label:         "Fill Required Fields...",
+					Detail:        "",
+					Documentation: "Auto-generated object literal (required fields)\n{\n\trequired_bool = false\n}",
+					Snippet: renderedSnippet{
+						Pos:  hcl.Pos{Line: 2, Column: 1, Byte: 14},
+						Text: `required_bool = ${1:false}`,
+					},
+				},
+				{
 					Label:         "first_str",
 					Detail:        "Optional, string",
 					Documentation: "",
 					Snippet: renderedSnippet{
 						Pos:  hcl.Pos{Line: 2, Column: 1, Byte: 14},
-						Text: `first_str = "${0:value}"`,
+						Text: `first_str = "${1:value}"`,
 					},
 				},
 				{
@@ -112,7 +121,7 @@ func TestCompletableBlock_CompletionCandidatesAtPos(t *testing.T) {
 					Documentation: "test boolean",
 					Snippet: renderedSnippet{
 						Pos:  hcl.Pos{Line: 2, Column: 1, Byte: 14},
-						Text: "required_bool = ${0:false}",
+						Text: "required_bool = ${1:false}",
 					},
 				},
 				{
@@ -121,7 +130,7 @@ func TestCompletableBlock_CompletionCandidatesAtPos(t *testing.T) {
 					Documentation: "random number",
 					Snippet: renderedSnippet{
 						Pos:  hcl.Pos{Line: 2, Column: 1, Byte: 14},
-						Text: "second_num = ${0:42}",
+						Text: "second_num = ${1:0}",
 					},
 				},
 			},
@@ -136,12 +145,21 @@ func TestCompletableBlock_CompletionCandidatesAtPos(t *testing.T) {
 			singleBlockOnlySchema,
 			[]renderedCandidate{
 				{
+					Label:         "Fill Required Fields...",
+					Detail:        "",
+					Documentation: "Auto-generated object literal (required fields)\n{\n\t\n\trequired_single {\n\t  \n\t}\n}",
+					Snippet: renderedSnippet{
+						Pos:  hcl.Pos{Line: 2, Column: 1, Byte: 14},
+						Text: "required_single {\n  ${1}\n}\n",
+					},
+				},
+				{
 					Label:         "optional_single",
 					Detail:        "Block, single",
 					Documentation: "",
 					Snippet: renderedSnippet{
 						Pos:  hcl.Pos{Line: 2, Column: 1, Byte: 14},
-						Text: "optional_single {\n  ${0}\n}",
+						Text: "optional_single {\n  ${1}\n}",
 					},
 				},
 				{
@@ -150,7 +168,7 @@ func TestCompletableBlock_CompletionCandidatesAtPos(t *testing.T) {
 					Documentation: "",
 					Snippet: renderedSnippet{
 						Pos:  hcl.Pos{Line: 2, Column: 1, Byte: 14},
-						Text: "required_single {\n  ${0}\n}",
+						Text: "required_single {\n  ${1}\n}",
 					},
 				},
 			},
@@ -165,12 +183,21 @@ func TestCompletableBlock_CompletionCandidatesAtPos(t *testing.T) {
 			listBlockOnlySchema,
 			[]renderedCandidate{
 				{
+					Label:         "Fill Required Fields...",
+					Detail:        "",
+					Documentation: "Auto-generated object literal (required fields)\n{\n\t\n\trequired_list {\n\t  \n\t}\n}",
+					Snippet: renderedSnippet{
+						Pos:  hcl.Pos{Line: 2, Column: 1, Byte: 14},
+						Text: "required_list {\n  ${1}\n}\n",
+					},
+				},
+				{
 					Label:         "optional_list",
 					Detail:        "Block, list",
 					Documentation: "",
 					Snippet: renderedSnippet{
 						Pos:  hcl.Pos{Line: 2, Column: 1, Byte: 14},
-						Text: "optional_list {\n  ${0}\n}",
+						Text: "optional_list {\n  ${1}\n}",
 					},
 				},
 				{
@@ -179,7 +206,7 @@ func TestCompletableBlock_CompletionCandidatesAtPos(t *testing.T) {
 					Documentation: "",
 					Snippet: renderedSnippet{
 						Pos:  hcl.Pos{Line: 2, Column: 1, Byte: 14},
-						Text: "required_list {\n  ${0}\n}",
+						Text: "required_list {\n  ${1}\n}",
 					},
 				},
 				{
@@ -188,7 +215,7 @@ func TestCompletableBlock_CompletionCandidatesAtPos(t *testing.T) {
 					Documentation: "",
 					Snippet: renderedSnippet{
 						Pos:  hcl.Pos{Line: 2, Column: 1, Byte: 14},
-						Text: "undeclared_max1_list {\n  ${0}\n}",
+						Text: "undeclared_max1_list {\n  ${1}\n}",
 					},
 				},
 			},
@@ -208,7 +235,7 @@ func TestCompletableBlock_CompletionCandidatesAtPos(t *testing.T) {
 					Documentation: "",
 					Snippet: renderedSnippet{
 						Pos:  hcl.Pos{Line: 2, Column: 20, Byte: 33},
-						Text: `one = "${0:value}"`,
+						Text: `one = "${1:value}"`,
 					},
 				},
 			},
@@ -223,12 +250,21 @@ func TestCompletableBlock_CompletionCandidatesAtPos(t *testing.T) {
 			attrOnlySchema,
 			[]renderedCandidate{
 				{
+					Label:         "Fill Required Fields...",
+					Detail:        "",
+					Documentation: "Auto-generated object literal (required fields)\n{\n\trequired_bool = false\n}",
+					Snippet: renderedSnippet{
+						Pos:  hcl.Pos{Line: 2, Column: 1, Byte: 14},
+						Text: "required_bool = ${1:false}",
+					},
+				},
+				{
 					Label:         "first_str",
 					Detail:        "Optional, string",
 					Documentation: "",
 					Snippet: renderedSnippet{
 						Pos:  hcl.Pos{Column: 1, Line: 2, Byte: 14},
-						Text: `first_str = "${0:value}"`,
+						Text: `first_str = "${1:value}"`,
 					},
 				},
 				{
@@ -237,7 +273,7 @@ func TestCompletableBlock_CompletionCandidatesAtPos(t *testing.T) {
 					Documentation: "test boolean",
 					Snippet: renderedSnippet{
 						Pos:  hcl.Pos{Column: 1, Line: 2, Byte: 14},
-						Text: `required_bool = ${0:false}`,
+						Text: `required_bool = ${1:false}`,
 					},
 				},
 				{
@@ -246,7 +282,7 @@ func TestCompletableBlock_CompletionCandidatesAtPos(t *testing.T) {
 					Documentation: "random number",
 					Snippet: renderedSnippet{
 						Pos:  hcl.Pos{Column: 1, Line: 2, Byte: 14},
-						Text: `second_num = ${0:42}`,
+						Text: `second_num = ${1:0}`,
 					},
 				},
 			},

--- a/internal/terraform/lang/datasource_block_test.go
+++ b/internal/terraform/lang/datasource_block_test.go
@@ -127,11 +127,20 @@ func TestDataSourceBlock_completionCandidatesAtPos(t *testing.T) {
 			hcl.Pos{Line: 2, Column: 1, Byte: 26},
 			[]renderedCandidate{
 				{
+					Label:         "Fill Required Fields...",
+					Detail:        "",
+					Documentation: "Auto-generated object literal (required fields)\n{\n\tattr_required = \"\"\n}",
+					Snippet: renderedSnippet{
+						Pos:  hcl.Pos{Line: 2, Column: 1, Byte: 26},
+						Text: `attr_required = "${1:value}"`,
+					},
+				},
+				{
 					Label:  "attr_optional",
 					Detail: "Optional, string",
 					Snippet: renderedSnippet{
 						Pos:  hcl.Pos{Line: 2, Column: 1, Byte: 26},
-						Text: `attr_optional = "${0:value}"`,
+						Text: `attr_optional = "${1:value}"`,
 					},
 				},
 				{
@@ -139,7 +148,7 @@ func TestDataSourceBlock_completionCandidatesAtPos(t *testing.T) {
 					Detail: "Required, string",
 					Snippet: renderedSnippet{
 						Pos:  hcl.Pos{Line: 2, Column: 1, Byte: 26},
-						Text: `attr_required = "${0:value}"`,
+						Text: `attr_required = "${1:value}"`,
 					},
 				},
 			},

--- a/internal/terraform/lang/hcl_block_type.go
+++ b/internal/terraform/lang/hcl_block_type.go
@@ -49,6 +49,13 @@ func (b *BlockType) ReachedMaxItems() bool {
 	return false
 }
 
+func (b *BlockType) MissedMinItems() int {
+	if b.schema.MinItems > 0 && len(b.BlockList) < int(b.schema.MinItems) {
+		return int(b.schema.MinItems) - len(b.BlockList)
+	}
+	return 0
+}
+
 type BlockTypes map[string]*BlockType
 
 func (bt BlockTypes) AddBlock(name string, block *hclsyntax.Block, typeSchema *tfjson.SchemaBlockType) {

--- a/internal/terraform/lang/parser.go
+++ b/internal/terraform/lang/parser.go
@@ -152,6 +152,15 @@ type completableBlockType struct {
 	documentation MarkupContent
 	prefix        string
 	prefixRng     *hcl.Range
+	sortText      string
+}
+
+func (bt *completableBlockType) SortText() string {
+	return bt.sortText
+}
+
+func (bt *completableBlockType) CompletionItemKind() int {
+	return 14 //lsp.CIKKeyword
 }
 
 func (bt *completableBlockType) Label() string {

--- a/internal/terraform/lang/provider_block_test.go
+++ b/internal/terraform/lang/provider_block_test.go
@@ -118,12 +118,21 @@ func TestProviderBlock_completionCandidatesAtPos(t *testing.T) {
 			hcl.Pos{Line: 2, Column: 1, Byte: 20},
 			[]renderedCandidate{
 				{
+					Label:         "Fill Required Fields...",
+					Detail:        "",
+					Documentation: "Auto-generated object literal (required fields)\n{\n\tattr_required = \"\"\n}",
+					Snippet: renderedSnippet{
+						Pos:  hcl.Pos{Line: 2, Column: 1, Byte: 20},
+						Text: `attr_required = "${1:value}"`,
+					},
+				},
+				{
 					Label:         "attr_optional",
 					Detail:        "Optional, string",
 					Documentation: "",
 					Snippet: renderedSnippet{
 						Pos:  hcl.Pos{Line: 2, Column: 1, Byte: 20},
-						Text: `attr_optional = "${0:value}"`,
+						Text: `attr_optional = "${1:value}"`,
 					},
 				},
 				{
@@ -132,7 +141,7 @@ func TestProviderBlock_completionCandidatesAtPos(t *testing.T) {
 					Documentation: "",
 					Snippet: renderedSnippet{
 						Pos:  hcl.Pos{Line: 2, Column: 1, Byte: 20},
-						Text: `attr_required = "${0:value}"`,
+						Text: `attr_required = "${1:value}"`,
 					},
 				},
 			},

--- a/internal/terraform/lang/resource_block_test.go
+++ b/internal/terraform/lang/resource_block_test.go
@@ -127,11 +127,20 @@ func TestResourceBlock_completionCandidatesAtPos(t *testing.T) {
 			hcl.Pos{Line: 2, Column: 1, Byte: 30},
 			[]renderedCandidate{
 				{
+					Label:         "Fill Required Fields...",
+					Detail:        "",
+					Documentation: "Auto-generated object literal (required fields)\n{\n\tattr_required = \"\"\n}",
+					Snippet: renderedSnippet{
+						Pos:  hcl.Pos{Line: 2, Column: 1, Byte: 30},
+						Text: `attr_required = "${1:value}"`,
+					},
+				},
+				{
 					Label:  "attr_optional",
 					Detail: "Optional, string",
 					Snippet: renderedSnippet{
 						Pos:  hcl.Pos{Line: 2, Column: 1, Byte: 30},
-						Text: `attr_optional = "${0:value}"`,
+						Text: `attr_optional = "${1:value}"`,
 					},
 				},
 				{
@@ -139,7 +148,7 @@ func TestResourceBlock_completionCandidatesAtPos(t *testing.T) {
 					Detail: "Required, string",
 					Snippet: renderedSnippet{
 						Pos:  hcl.Pos{Line: 2, Column: 1, Byte: 30},
-						Text: `attr_required = "${0:value}"`,
+						Text: `attr_required = "${1:value}"`,
 					},
 				},
 			},

--- a/internal/terraform/lang/sort.go
+++ b/internal/terraform/lang/sort.go
@@ -1,0 +1,35 @@
+package lang
+
+import "fmt"
+
+func candidateSortTextPolicy(candidate CompletionCandidate) string {
+	switch candidate.(type) {
+	case *AllRequiredFieldCandidate:
+		return "00001"
+	case *attributeCandidate:
+		return "20000"
+	case *nestedBlockCandidate:
+		return "40000"
+	case *labelCandidate:
+		return "60000"
+	case *completableBlockType:
+		return "80000"
+	default:
+		return "99999"
+	}
+}
+
+func setCandidateSortText(candidate CompletionCandidate, order int) {
+	switch v := candidate.(type) {
+	case *AllRequiredFieldCandidate:
+		v.sortText = fmt.Sprintf("%05d", order)
+	case *attributeCandidate:
+		v.sortText = fmt.Sprintf("%05d", order)
+	case *nestedBlockCandidate:
+		v.sortText = fmt.Sprintf("%05d", order)
+	case *labelCandidate:
+		v.sortText = fmt.Sprintf("%05d", order)
+	case *completableBlockType:
+		v.sortText = fmt.Sprintf("%05d", order)
+	}
+}

--- a/internal/terraform/lang/types.go
+++ b/internal/terraform/lang/types.go
@@ -78,6 +78,8 @@ type CompletionCandidate interface {
 	Documentation() MarkupContent
 	Snippet() TextEdit
 	PlainText() TextEdit
+	SortText() string
+	CompletionItemKind() int
 }
 
 type TextEdit interface {

--- a/langserver/handlers/complete_test.go
+++ b/langserver/handlers/complete_test.go
@@ -86,6 +86,7 @@ func TestCompletion_withValidData(t *testing.T) {
 						"kind":5,
 						"detail":"Optional, number",
 						"documentation":"Desc 1",
+						"sortText":"00001",
 						"insertTextFormat":1,
 						"textEdit": {
 							"range": {
@@ -106,6 +107,7 @@ func TestCompletion_withValidData(t *testing.T) {
 						"kind":5,
 						"detail":"Optional, string",
 						"documentation":"Desc 2",
+						"sortText":"00002",
 						"insertTextFormat":1,
 						"textEdit": {
 							"range": {
@@ -126,6 +128,7 @@ func TestCompletion_withValidData(t *testing.T) {
 						"kind":5,
 						"detail":"Optional, bool",
 						"documentation":"Desc 3",
+						"sortText":"00003",
 						"insertTextFormat":1,
 						"textEdit": {
 							"range": {


### PR DESCRIPTION
fix #96 

- add support for prefill all required fields. (only prefix is empty will trigger this)
- support for sortText and a little refactor of sort logic(to ensure the `prefill all fields` item could place first)

something maybe not good: 
- In original design, `CompletionCandidate` is immutable, to avoid adding a `setSortText` func, I add some functions in `sort.go`, but in such way, everytime we add a new candidate type, we should remember to add revelant code in this file.

![image](https://user-images.githubusercontent.com/2786738/84021664-9f99fd80-a9b7-11ea-9d61-762944197a91.png)
