### PR TITLE
terraform: Support 0.13 version

### DIFF
--- a/internal/terraform/errors/errors.go
+++ b/internal/terraform/errors/errors.go
@@ -29,6 +29,15 @@ func (utv *UnsupportedTerraformVersion) Error() string {
 	return msg
 }
 
+func (utv *UnsupportedTerraformVersion) Is(err error) bool {
+	te, ok := err.(*UnsupportedTerraformVersion)
+	if !ok {
+		return false
+	}
+
+	return te.Version == utv.Version
+}
+
 type NotInitializedErr struct {
 	Dir string
 }

--- a/internal/terraform/lang/parser.go
+++ b/internal/terraform/lang/parser.go
@@ -37,10 +37,19 @@ type parser struct {
 }
 
 func ParserSupportsTerraform(v string) error {
-	tfVersion, err := version.NewVersion(v)
+	rawVer, err := version.NewVersion(v)
 	if err != nil {
 		return err
 	}
+
+	// Assume that alpha/beta/rc prereleases have the same compatibility
+	segments := rawVer.Segments64()
+	segmentsOnly := fmt.Sprintf("%d.%d.%d", segments[0], segments[1], segments[2])
+	tfVersion, err := version.NewVersion(segmentsOnly)
+	if err != nil {
+		return fmt.Errorf("failed to parse stripped version: %w", err)
+	}
+
 	c, err := version.NewConstraint(parserVersionConstraint)
 	if err != nil {
 		return err

--- a/internal/terraform/schema/schema_storage.go
+++ b/internal/terraform/schema/schema_storage.go
@@ -75,9 +75,17 @@ func SchemaSupportsTerraform(v string) error {
 		return fmt.Errorf("failed to parse constraint: %w", err)
 	}
 
-	ver, err := version.NewVersion(v)
+	rawVer, err := version.NewVersion(v)
 	if err != nil {
-		return fmt.Errorf("failed to parse verison: %w", err)
+		return fmt.Errorf("failed to parse version: %w", err)
+	}
+
+	// Assume that alpha/beta/rc prereleases have the same compatibility
+	segments := rawVer.Segments64()
+	segmentsOnly := fmt.Sprintf("%d.%d.%d", segments[0], segments[1], segments[2])
+	ver, err := version.NewVersion(segmentsOnly)
+	if err != nil {
+		return fmt.Errorf("failed to parse stripped version: %w", err)
 	}
 
 	supported := c.Check(ver)
@@ -89,7 +97,7 @@ func SchemaSupportsTerraform(v string) error {
 		}
 	}
 
-	return watcherSupportsTerraform(ver)
+	return nil
 }
 
 func (s *Storage) SetLogger(logger *log.Logger) {

--- a/internal/terraform/schema/schema_storage_test.go
+++ b/internal/terraform/schema/schema_storage_test.go
@@ -2,10 +2,67 @@ package schema
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	tferr "github.com/hashicorp/terraform-ls/internal/terraform/errors"
 )
+
+func TestSchemaSupportsTerraform(t *testing.T) {
+	testCases := []struct {
+		version     string
+		expectedErr error
+	}{
+		{
+			"0.11.0",
+			&tferr.UnsupportedTerraformVersion{Version: "0.11.0"},
+		},
+		{
+			"0.12.0-rc1",
+			nil,
+		},
+		{
+			"0.12.0",
+			nil,
+		},
+		{
+			"0.13.0-beta1",
+			nil,
+		},
+		{
+			"0.14.0-beta1",
+			nil,
+		},
+		{
+			"0.14.0",
+			nil,
+		},
+		{
+			"1.0.0",
+			nil,
+		},
+	}
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			err := SchemaSupportsTerraform(tc.version)
+			if err != nil {
+				if tc.expectedErr == nil {
+					t.Fatalf("Expected no error for %q: %#v",
+						tc.version, err)
+				}
+				if !errors.Is(err, tc.expectedErr) {
+					diff := cmp.Diff(tc.expectedErr, err)
+					t.Fatalf("%q: error doesn't match: %s",
+						tc.version, diff)
+				}
+			} else if tc.expectedErr != nil {
+				t.Fatalf("Expected error for %q: %#v",
+					tc.version, tc.expectedErr)
+			}
+		})
+	}
+}
 
 func TestProviderConfigSchema_noSchema(t *testing.T) {
 	s := NewStorage()


### PR DESCRIPTION
This relaxes the version constraints as we now know where to find the lock file in 0.13+.

This also enables support for any 0.12 prereleases.

Closes #111 

I removed the upper bound constraint from the watcher as I reckon/hope that the lock file location won't change - and if it does, then the worst case scenario is that we will report the workspace as uninitialised.

I assume we may start constraining the parser at some point, but that's a problem for another day.