### PR TITLE
Treat schema availability as not essential

### DIFF
--- a/internal/terraform/errors/errors.go
+++ b/internal/terraform/errors/errors.go
@@ -37,24 +37,3 @@ func (utv *UnsupportedTerraformVersion) Is(err error) bool {
 
 	return te.Version == utv.Version
 }
-
-type NotInitializedErr struct {
-	Dir string
-}
-
-func (e *NotInitializedErr) Is(err error) bool {
-	_, ok := err.(*NotInitializedErr)
-	if !ok {
-		return false
-	}
-
-	return true
-}
-
-func (e *NotInitializedErr) Error() string {
-	if e.Dir != "" {
-		return fmt.Sprintf("directory %s not initialized", e.Dir)
-	}
-
-	return fmt.Sprintf("directory not initialized")
-}

--- a/internal/terraform/rootmodule/root_module.go
+++ b/internal/terraform/rootmodule/root_module.go
@@ -81,6 +81,8 @@ func (rm *rootModule) init(ctx context.Context, dir string) error {
 		return err
 	}
 
+	rm.logger.Printf("Terraform version %s found at %s", version, tf.GetExecPath())
+
 	err = schema.SchemaSupportsTerraform(version)
 	if err != nil {
 		return err

--- a/internal/terraform/rootmodule/root_module.go
+++ b/internal/terraform/rootmodule/root_module.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-ls/internal/terraform/discovery"
-	tferr "github.com/hashicorp/terraform-ls/internal/terraform/errors"
 	"github.com/hashicorp/terraform-ls/internal/terraform/exec"
 	"github.com/hashicorp/terraform-ls/internal/terraform/lang"
 	"github.com/hashicorp/terraform-ls/internal/terraform/schema"
@@ -153,7 +152,8 @@ func (rm *rootModule) initPluginCache(dir string) error {
 		lf, err = findFile(lockPaths)
 		if err != nil {
 			if os.IsNotExist(err) {
-				return &tferr.NotInitializedErr{Dir: dir}
+				rm.logger.Printf("no plugin cache found: %s", err.Error())
+				return nil
 			}
 
 			return fmt.Errorf("unable to calculate hash: %w", err)
@@ -204,7 +204,7 @@ func (rm *rootModule) initModuleCache(dir string) error {
 	lf, err := newFile(moduleManifestFilePath(dir))
 	if err != nil {
 		if os.IsNotExist(err) {
-			rm.logger.Printf("module lock file not found: %s", err.Error())
+			rm.logger.Printf("no module manifest file found: %s", err.Error())
 			return nil
 		}
 

--- a/internal/terraform/rootmodule/root_module_manager.go
+++ b/internal/terraform/rootmodule/root_module_manager.go
@@ -39,20 +39,20 @@ func newRootModuleManager(ctx context.Context) *rootModuleManager {
 }
 
 func (rmm *rootModuleManager) defaultRootModuleFactory(ctx context.Context, dir string) (*rootModule, error) {
-	w := newRootModule(ctx)
+	rm := newRootModule(ctx)
 
-	w.SetLogger(rmm.logger)
+	rm.SetLogger(rmm.logger)
 
 	d := &discovery.Discovery{}
-	w.tfDiscoFunc = d.LookPath
-	w.tfNewExecutor = exec.NewExecutor
-	w.newSchemaStorage = schema.NewStorage
+	rm.tfDiscoFunc = d.LookPath
+	rm.tfNewExecutor = exec.NewExecutor
+	rm.newSchemaStorage = schema.NewStorage
 
-	w.tfExecPath = rmm.tfExecPath
-	w.tfExecTimeout = rmm.tfExecTimeout
-	w.tfExecLogPath = rmm.tfExecLogPath
+	rm.tfExecPath = rmm.tfExecPath
+	rm.tfExecTimeout = rmm.tfExecTimeout
+	rm.tfExecLogPath = rmm.tfExecLogPath
 
-	return w, w.init(ctx, dir)
+	return rm, rm.init(ctx, dir)
 }
 
 func (rmm *rootModuleManager) SetTerraformExecPath(path string) {
@@ -78,15 +78,15 @@ func (rmm *rootModuleManager) AddRootModule(dir string) error {
 
 	_, exists := rmm.rms[dir]
 	if exists {
-		return fmt.Errorf("rootModule %s was already added", dir)
+		return fmt.Errorf("root module %s was already added", dir)
 	}
 
-	w, err := rmm.newRootModule(context.Background(), dir)
+	rm, err := rmm.newRootModule(context.Background(), dir)
 	if err != nil {
 		return err
 	}
 
-	rmm.rms[dir] = w
+	rmm.rms[dir] = rm
 
 	return nil
 }
@@ -119,21 +119,21 @@ func (rmm *rootModuleManager) RootModuleByPath(path string) (RootModule, error) 
 }
 
 func (rmm *rootModuleManager) ParserForDir(path string) (lang.Parser, error) {
-	w, err := rmm.RootModuleByPath(path)
+	rm, err := rmm.RootModuleByPath(path)
 	if err != nil {
 		return nil, err
 	}
 
-	return w.Parser(), nil
+	return rm.Parser(), nil
 }
 
 func (rmm *rootModuleManager) TerraformExecutorForDir(path string) (*exec.Executor, error) {
-	w, err := rmm.RootModuleByPath(path)
+	rm, err := rmm.RootModuleByPath(path)
 	if err != nil {
 		return nil, err
 	}
 
-	return w.TerraformExecutor(), nil
+	return rm.TerraformExecutor(), nil
 }
 
 // rootModuleDirFromPath strips known lock file paths and filenames

--- a/langserver/handlers/initialize.go
+++ b/langserver/handlers/initialize.go
@@ -42,17 +42,17 @@ func (lh *logHandler) Initialize(ctx context.Context, params lsp.InitializeParam
 		return serverCaps, err
 	}
 
-	wm, err := lsctx.RootModuleManager(ctx)
+	rmm, err := lsctx.RootModuleManager(ctx)
 	if err != nil {
 		return serverCaps, err
 	}
 
-	ww, err := lsctx.Watcher(ctx)
+	w, err := lsctx.Watcher(ctx)
 	if err != nil {
 		return serverCaps, err
 	}
 
-	err = wm.AddRootModule(fh.Dir())
+	err = rmm.AddRootModule(fh.Dir())
 	if err != nil {
 		if errors.Is(err, &tferr.NotInitializedErr{}) {
 			return serverCaps, fmt.Errorf("Directory not initialized. "+
@@ -61,12 +61,12 @@ func (lh *logHandler) Initialize(ctx context.Context, params lsp.InitializeParam
 		return serverCaps, err
 	}
 
-	err = ww.AddPaths(wm.PathsToWatch())
+	err = w.AddPaths(rmm.PathsToWatch())
 	if err != nil {
 		return serverCaps, err
 	}
 
-	err = ww.Start()
+	err = w.Start()
 	if err != nil {
 		return serverCaps, err
 	}

--- a/langserver/handlers/initialize.go
+++ b/langserver/handlers/initialize.go
@@ -2,12 +2,10 @@ package handlers
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	lsctx "github.com/hashicorp/terraform-ls/internal/context"
 	ilsp "github.com/hashicorp/terraform-ls/internal/lsp"
-	tferr "github.com/hashicorp/terraform-ls/internal/terraform/errors"
 	lsp "github.com/sourcegraph/go-lsp"
 )
 
@@ -54,10 +52,6 @@ func (lh *logHandler) Initialize(ctx context.Context, params lsp.InitializeParam
 
 	err = rmm.AddRootModule(fh.Dir())
 	if err != nil {
-		if errors.Is(err, &tferr.NotInitializedErr{}) {
-			return serverCaps, fmt.Errorf("Directory not initialized. "+
-				"Please run `terraform init` in %s", fh.Dir())
-		}
 		return serverCaps, err
 	}
 


### PR DESCRIPTION
Closes #83 

This does *not* yet introduce support for more complex hierarchies
but enables formatting even for files in directories
which do not have any plugin cache.

The lack of plugin cache is now emitted just as a log message.

Informing the user at this point wouldn't be very helpful
because we don't know where the module usually gets init'd from yet,
i.e. whether the plugin cache is even expected *there*.

Complex hierarchies will be addressed in other PRs in iterative steps as part of #32 