### PR TITLE
Display '.' in warning message for top directory

### DIFF
--- a/langserver/handlers/did_open.go
+++ b/langserver/handlers/did_open.go
@@ -64,6 +64,10 @@ func renderCandidates(rootDir string, candidatePaths []string) string {
 }
 
 func renderCandidate(rootDir, path string) string {
-	return strings.TrimPrefix(
+	trimmed := strings.TrimPrefix(
 		strings.TrimPrefix(path, rootDir), string(os.PathSeparator))
+	if trimmed == "" {
+		return "."
+	}
+	return trimmed
 }


### PR DESCRIPTION
Ideally I'd like to refactor the logic here to _not_ parse paths as string, but given that this is merely a rendering/UX detail, I think it can be done in a separate PR.

I assume there will be need for some more path-parsing logic in https://github.com/hashicorp/terraform-ls/issues/179 anyway, so it can be developed in that context.

### Before

![Screenshot 2020-06-24 at 15 07 28](https://user-images.githubusercontent.com/287584/85572028-91411800-b62c-11ea-979a-c894509bf416.png)

### After

![Screenshot 2020-06-24 at 15 06 46](https://user-images.githubusercontent.com/287584/85572093-9dc57080-b62c-11ea-97cf-850377ea8ca7.png)
