### PR TITLE
rootmodule: Fix schema/module update detection

### DIFF
--- a/internal/terraform/rootmodule/root_module.go
+++ b/internal/terraform/rootmodule/root_module.go
@@ -303,17 +303,6 @@ func (rm *rootModule) PathsToWatch() []string {
 }
 
 func (rm *rootModule) IsKnownModuleManifestFile(path string) bool {
-	rm.pluginMu.RLock()
-	defer rm.pluginMu.RUnlock()
-
-	if rm.pluginLockFile == nil {
-		return false
-	}
-
-	return rm.pluginLockFile.Path() == path
-}
-
-func (rm *rootModule) IsKnownPluginLockFile(path string) bool {
 	rm.moduleMu.RLock()
 	defer rm.moduleMu.RUnlock()
 
@@ -322,4 +311,15 @@ func (rm *rootModule) IsKnownPluginLockFile(path string) bool {
 	}
 
 	return rm.moduleManifestFile.Path() == path
+}
+
+func (rm *rootModule) IsKnownPluginLockFile(path string) bool {
+	rm.pluginMu.RLock()
+	defer rm.pluginMu.RUnlock()
+
+	if rm.pluginLockFile == nil {
+		return false
+	}
+
+	return rm.pluginLockFile.Path() == path
 }


### PR DESCRIPTION
This is fixing a bug where we would detect plugin lock file change as module change and vice versa. Therefore the server would attempt to update plugins when module change and update module cache when plugins change. This could lead to a situation where obtaining schema errors out because the plugin lock file wasn't written to the disk yet (modules are updated first during `init`).

This was introduced as part of #167 (so far unreleased 😅 )

The watcher logic is entirely untested at this point - something to address.

I'm just not sure what the best testing strategy there is yet. Should we entirely mock out the watcher, or genuinely update real files on the filesystem in TMPDIR? I feel like that question needs to be answered, but I'd like to answer it in a separate PR.