### PR TITLE
Surface root module init errors on didOpen

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/hashicorp/terraform-ls
 go 1.13
 
 require (
+	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d
 	github.com/apparentlymart/go-textseg v1.0.0
 	github.com/creachadair/jrpc2 v0.8.1
 	github.com/fsnotify/fsnotify v1.4.9

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ bitbucket.org/creachadair/shell v0.0.6/go.mod h1:8Qqi/cYk7vPnsOePHroKXDJYmb5x7EN
 bitbucket.org/creachadair/stringset v0.0.8 h1:gQqe4vs8XWgMyijfyKE6K8o4TcyGGrRXe0JvHgx5H+M=
 bitbucket.org/creachadair/stringset v0.0.8/go.mod h1:AgthVMyMxC/6FK1KBJ2ALdqkZObGN8hOetgpwXyMn34=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpHMqeKTCYkitsPqHNxTmd4SNR5r94FGM8=
+github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
 github.com/agext/levenshtein v1.2.1 h1:QmvMAjj2aEICytGiWzmxoE0x2KZvE0fvmqMOfy2tjT8=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/apparentlymart/go-dump v0.0.0-20180507223929-23540a00eaa3/go.mod h1:oL81AME2rN47vu18xqj1S1jPIPuN7afo62yKTNn3XMM=

--- a/internal/terraform/exec/errors.go
+++ b/internal/terraform/exec/errors.go
@@ -5,6 +5,8 @@ import (
 	"os/exec"
 	"reflect"
 	"time"
+
+	"github.com/acarl005/stripansi"
 )
 
 type ExitError struct {
@@ -25,8 +27,8 @@ func (e *ExitError) Error() string {
 		e.Err.Pid(),
 		e.Err.ExitCode(),
 		e.Err.ProcessState.String(),
-		e.Stdout,
-		e.Stderr)
+		stripansi.Strip(e.Stdout),
+		stripansi.Strip(e.Stderr))
 
 	if e.CtxErr != nil {
 		return fmt.Sprintf("%s.\n%s", e.CtxErr, e.Err)

--- a/internal/terraform/rootmodule/root_module.go
+++ b/internal/terraform/rootmodule/root_module.go
@@ -24,6 +24,7 @@ type rootModule struct {
 	moduleManifestFile File
 	moduleManifest     *moduleManifest
 	tfVersion          string
+	lastErr            error
 
 	tfDiscoFunc       discovery.DiscoveryFunc
 	tfNewExecutor     exec.ExecutorFactory
@@ -59,13 +60,10 @@ func NewRootModule(ctx context.Context, dir string) (RootModule, error) {
 	rm.tfDiscoFunc = d.LookPath
 
 	rm.tfNewExecutor = exec.NewExecutor
-	rm.newSchemaStorage = func() *schema.Storage {
-		ss := schema.NewStorage()
-		ss.SetSynchronous()
-		return ss
-	}
+	rm.newSchemaStorage = schema.NewStorage
 
-	return rm, rm.init(ctx)
+	rm.lastErr = rm.init(ctx)
+	return rm, rm.lastErr
 }
 
 func (rm *rootModule) SetLogger(logger *log.Logger) {
@@ -217,6 +215,10 @@ func (rm *rootModule) initModuleCache(dir string) error {
 	}
 
 	return rm.UpdateModuleManifest(lf)
+}
+
+func (rm *rootModule) LastError() error {
+	return rm.lastErr
 }
 
 func (rm *rootModule) Path() string {

--- a/internal/terraform/rootmodule/root_module_manager.go
+++ b/internal/terraform/rootmodule/root_module_manager.go
@@ -76,7 +76,7 @@ func (rmm *rootModuleManager) AddRootModule(dir string) error {
 
 	// TODO: Follow symlinks (requires proper test data)
 
-	if rmm.exists(dir) {
+	if _, ok := rmm.rootModuleByPath(dir); ok {
 		return fmt.Errorf("root module %s was already added", dir)
 	}
 
@@ -90,46 +90,37 @@ func (rmm *rootModuleManager) AddRootModule(dir string) error {
 	return nil
 }
 
-func (rmm *rootModuleManager) exists(dir string) bool {
+func (rmm *rootModuleManager) rootModuleByPath(dir string) (*rootModule, bool) {
 	for _, rm := range rmm.rms {
 		if rm.Path() == dir {
-			return true
+			return rm, true
 		}
 	}
-	return false
+	return nil, false
 }
 
-func (rmm *rootModuleManager) rootModuleByPath(dir string) *rootModule {
-	for _, rm := range rmm.rms {
-		if rm.Path() == dir {
-			return rm
-		}
-	}
-	return nil
-}
-
-func (rmm *rootModuleManager) RootModuleCandidatesByPath(path string) []string {
+func (rmm *rootModuleManager) RootModuleCandidatesByPath(path string) RootModules {
 	path = filepath.Clean(path)
 
 	// TODO: Follow symlinks (requires proper test data)
 
-	if rmm.exists(path) {
+	if rm, ok := rmm.rootModuleByPath(path); ok {
 		rmm.logger.Printf("direct root module lookup succeeded: %s", path)
-		return []string{path}
+		return []RootModule{rm}
 	}
 
 	dir := rootModuleDirFromFilePath(path)
-	if rmm.exists(dir) {
+	if rm, ok := rmm.rootModuleByPath(dir); ok {
 		rmm.logger.Printf("dir-based root module lookup succeeded: %s", dir)
-		return []string{dir}
+		return []RootModule{rm}
 	}
 
-	candidates := make([]string, 0)
+	candidates := make([]RootModule, 0)
 	for _, rm := range rmm.rms {
 		rmm.logger.Printf("looking up %s in module references of %s", dir, rm.Path())
 		if rm.ReferencesModulePath(dir) {
 			rmm.logger.Printf("module-ref-based root module lookup succeeded: %s", dir)
-			candidates = append(candidates, rm.Path())
+			candidates = append(candidates, rm)
 		}
 	}
 
@@ -139,12 +130,7 @@ func (rmm *rootModuleManager) RootModuleCandidatesByPath(path string) []string {
 func (rmm *rootModuleManager) RootModuleByPath(path string) (RootModule, error) {
 	candidates := rmm.RootModuleCandidatesByPath(path)
 	if len(candidates) > 0 {
-		firstMatch := candidates[0]
-		if !rmm.exists(firstMatch) {
-			return nil, fmt.Errorf("Discovered root module %s not available,"+
-				" this is most likely a bug, please report it", firstMatch)
-		}
-		return rmm.rootModuleByPath(firstMatch), nil
+		return candidates[0], nil
 	}
 
 	return nil, &RootModuleNotFoundErr{path}

--- a/internal/terraform/rootmodule/root_module_manager_mock.go
+++ b/internal/terraform/rootmodule/root_module_manager_mock.go
@@ -29,7 +29,8 @@ func (rmf *RootModuleMockFactory) New(ctx context.Context, dir string) (*rootMod
 
 	mock := NewRootModuleMock(ctx, rmm, dir)
 	mock.SetLogger(rmf.logger)
-	return mock, mock.init(ctx)
+	mock.lastErr = mock.init(ctx)
+	return mock, mock.lastErr
 }
 
 func NewRootModuleMock(ctx context.Context, rmm *RootModuleMock, dir string) *rootModule {
@@ -44,11 +45,7 @@ func NewRootModuleMock(ctx context.Context, rmm *RootModuleMock, dir string) *ro
 	rm.tfNewExecutor = exec.MockExecutor(rmm.TerraformExecQueue)
 
 	if rmm.ProviderSchemas == nil {
-		rm.newSchemaStorage = func() *schema.Storage {
-			ss := schema.NewStorage()
-			ss.SetSynchronous()
-			return ss
-		}
+		rm.newSchemaStorage = schema.NewStorage
 	} else {
 		rm.newSchemaStorage = schema.MockStorage(rmm.ProviderSchemas)
 	}

--- a/internal/terraform/rootmodule/root_module_manager_test.go
+++ b/internal/terraform/rootmodule/root_module_manager_test.go
@@ -14,46 +14,6 @@ import (
 	"github.com/hashicorp/terraform-ls/internal/terraform/exec"
 )
 
-// func TestRootModuleManager_RootModuleByPath_basic(t *testing.T) {
-// 	rmm := testRootModuleManager(t)
-
-// 	tmpDir := tempDir(t)
-// 	direct, unrelated, dirbased := newTestRootModule(t, "direct"), newTestRootModule(t, "unrelated"), newTestRootModule(t, "dirbased")
-// 	rmm.rms = map[string]*rootModule{
-// 		direct.Dir:    direct.RootModule,
-// 		unrelated.Dir: unrelated.RootModule,
-// 		dirbased.Dir:  dirbased.RootModule,
-// 	}
-
-// 	w1, err := rmm.RootModuleByPath(direct.Dir)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	if direct.RootModule != w1 {
-// 		t.Fatalf("unexpected root module found: %p, expected: %p", w1, direct)
-// 	}
-
-// 	lockDirPath := filepath.Join(tmpDir, "dirbased", ".terraform", "plugins")
-// 	lockFilePath := filepath.Join(lockDirPath, "selections.json")
-// 	err = os.MkdirAll(lockDirPath, 0775)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	f, err := os.Create(lockFilePath)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	f.Close()
-
-// 	w2, err := rmm.RootModuleByPath(lockFilePath)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	if dirbased.RootModule != w2 {
-// 		t.Fatalf("unexpected root module found: %p, expected: %p", w2, dirbased)
-// 	}
-// }
-
 func TestRootModuleManager_RootModuleCandidatesByPath(t *testing.T) {
 	testData, err := filepath.Abs("testdata")
 	if err != nil {
@@ -483,7 +443,7 @@ func TestRootModuleManager_RootModuleCandidatesByPath(t *testing.T) {
 			}
 
 			candidates := rmm.RootModuleCandidatesByPath(tc.lookupPath)
-			if diff := cmp.Diff(tc.expectedCandidates, candidates); diff != "" {
+			if diff := cmp.Diff(tc.expectedCandidates, candidates.Paths()); diff != "" {
 				t.Fatalf("candidates don't match: %s", diff)
 			}
 		})

--- a/internal/terraform/rootmodule/types.go
+++ b/internal/terraform/rootmodule/types.go
@@ -22,7 +22,7 @@ type TerraformExecFinder interface {
 }
 
 type RootModuleCandidateFinder interface {
-	RootModuleCandidatesByPath(path string) []string
+	RootModuleCandidatesByPath(path string) RootModules
 }
 
 type RootModuleManager interface {
@@ -39,7 +39,18 @@ type RootModuleManager interface {
 	RootModuleByPath(path string) (RootModule, error)
 }
 
+type RootModules []RootModule
+
+func (rms RootModules) Paths() []string {
+	paths := make([]string, len(rms))
+	for i, rm := range rms {
+		paths[i] = rm.Path()
+	}
+	return paths
+}
+
 type RootModule interface {
+	Path() string
 	IsKnownPluginLockFile(path string) bool
 	IsKnownModuleManifestFile(path string) bool
 	PathsToWatch() []string

--- a/internal/terraform/rootmodule/types.go
+++ b/internal/terraform/rootmodule/types.go
@@ -51,6 +51,7 @@ func (rms RootModules) Paths() []string {
 
 type RootModule interface {
 	Path() string
+	LastError() error
 	IsKnownPluginLockFile(path string) bool
 	IsKnownModuleManifestFile(path string) bool
 	PathsToWatch() []string

--- a/internal/terraform/schema/schema_storage.go
+++ b/internal/terraform/schema/schema_storage.go
@@ -51,9 +51,6 @@ type Storage struct {
 	// sem ensures atomic reading and obtaining of schemas
 	// as the process of obtaining it may not be thread-safe
 	sem *semaphore.Weighted
-
-	// sync makes operations synchronous which makes testing easier
-	sync bool
 }
 
 var defaultLogger = log.New(ioutil.Discard, "", 0)
@@ -102,28 +99,10 @@ func (s *Storage) SetLogger(logger *log.Logger) {
 	s.logger = logger
 }
 
-func (s *Storage) SetSynchronous() {
-	s.sync = true
-}
-
-// ObtainSchemasForModule will (by default) asynchronously obtain schema via tf
+// ObtainSchemasForModule will obtain schema via tf
 // and store it for later consumption via Reader methods
 func (s *Storage) ObtainSchemasForModule(tf *exec.Executor, dir string) error {
-	if s.sync {
-		return s.obtainSchemasForModule(tf, dir)
-	}
-
-	// This routine is not cancellable in itself
-	// but the time-consuming part is done by exec.Executor
-	// which is cancellable via its own context
-	go func() {
-		err := s.obtainSchemasForModule(tf, dir)
-		if err != nil {
-			s.logger.Printf("error obtaining schemas for %s: %s", dir, err)
-		}
-	}()
-
-	return nil
+	return s.obtainSchemasForModule(tf, dir)
 }
 
 func (s *Storage) obtainSchemasForModule(tf *exec.Executor, dir string) error {

--- a/internal/terraform/schema/schema_storage_mock.go
+++ b/internal/terraform/schema/schema_storage_mock.go
@@ -11,7 +11,6 @@ func MockStorage(ps *tfjson.ProviderSchemas) StorageFactory {
 			ps = &tfjson.ProviderSchemas{}
 		}
 		s.ps = ps
-		s.sync = true
 		return s
 	}
 }

--- a/langserver/handlers/did_open.go
+++ b/langserver/handlers/did_open.go
@@ -52,6 +52,13 @@ func TextDocumentDidOpen(ctx context.Context, params lsp.DidOpenTextDocumentPara
 			Message: msg,
 		})
 	}
+	err = candidates[0].LastError()
+	if err != nil {
+		return jrpc2.ServerPush(ctx, "window/showMessage", lsp.ShowMessageParams{
+			Type:    lsp.MTError,
+			Message: fmt.Sprintf("%s: %s", renderCandidatePath(rootDir, candidates[0]), err.Error()),
+		})
+	}
 
 	return nil
 }

--- a/langserver/handlers/did_open.go
+++ b/langserver/handlers/did_open.go
@@ -9,6 +9,7 @@ import (
 	"github.com/creachadair/jrpc2"
 	lsctx "github.com/hashicorp/terraform-ls/internal/context"
 	ilsp "github.com/hashicorp/terraform-ls/internal/lsp"
+	"github.com/hashicorp/terraform-ls/internal/terraform/rootmodule"
 	lsp "github.com/sourcegraph/go-lsp"
 )
 
@@ -44,8 +45,8 @@ func TextDocumentDidOpen(ctx context.Context, params lsp.DidOpenTextDocumentPara
 		// TODO: Suggest specifying explicit root modules?
 
 		msg := fmt.Sprintf("Alternative root modules found for %s (%s), picked: %s",
-			f.Filename(), renderCandidates(rootDir, candidates[1:]),
-			renderCandidate(rootDir, candidates[0]))
+			f.Filename(), candidatePaths(rootDir, candidates[1:]),
+			renderCandidatePath(rootDir, candidates[0]))
 		return jrpc2.ServerPush(ctx, "window/showMessage", lsp.ShowMessageParams{
 			Type:    lsp.MTWarning,
 			Message: msg,
@@ -55,17 +56,18 @@ func TextDocumentDidOpen(ctx context.Context, params lsp.DidOpenTextDocumentPara
 	return nil
 }
 
-func renderCandidates(rootDir string, candidatePaths []string) string {
-	for i, p := range candidatePaths {
+func candidatePaths(rootDir string, candidates []rootmodule.RootModule) string {
+	paths := make([]string, len(candidates))
+	for i, rm := range candidates {
 		// This helps displaying shorter, but still relevant paths
-		candidatePaths[i] = renderCandidate(rootDir, p)
+		paths[i] = renderCandidatePath(rootDir, rm)
 	}
-	return strings.Join(candidatePaths, ", ")
+	return strings.Join(paths, ", ")
 }
 
-func renderCandidate(rootDir, path string) string {
+func renderCandidatePath(rootDir string, candidate rootmodule.RootModule) string {
 	trimmed := strings.TrimPrefix(
-		strings.TrimPrefix(path, rootDir), string(os.PathSeparator))
+		strings.TrimPrefix(candidate.Path(), rootDir), string(os.PathSeparator))
 	if trimmed == "" {
 		return "."
 	}

--- a/vendor/github.com/acarl005/stripansi/LICENSE
+++ b/vendor/github.com/acarl005/stripansi/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Andrew Carlson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/acarl005/stripansi/README.md
+++ b/vendor/github.com/acarl005/stripansi/README.md
@@ -1,0 +1,30 @@
+Strip ANSI
+==========
+
+This Go package removes ANSI escape codes from strings.
+
+Ideally, we would prevent these from appearing in any text we want to process.
+However, sometimes this can't be helped, and we need to be able to deal with that noise.
+This will use a regexp to remove those unwanted escape codes.
+
+
+## Install
+
+```sh
+$ go get -u github.com/acarl005/stripansi
+```
+
+## Usage
+
+```go
+import (
+	"fmt"
+	"github.com/acarl005/stripansi"
+)
+
+func main() {
+	msg := "\x1b[38;5;140m foo\x1b[0m bar"
+	cleanMsg := stripansi.Strip(msg)
+	fmt.Println(cleanMsg) // " foo bar"
+}
+```

--- a/vendor/github.com/acarl005/stripansi/stripansi.go
+++ b/vendor/github.com/acarl005/stripansi/stripansi.go
@@ -1,0 +1,13 @@
+package stripansi
+
+import (
+	"regexp"
+)
+
+const ansi = "[\u001B\u009B][[\\]()#;?]*(?:(?:(?:[a-zA-Z\\d]*(?:;[a-zA-Z\\d]*)*)?\u0007)|(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PRZcf-ntqry=><~]))"
+
+var re = regexp.MustCompile(ansi)
+
+func Strip(str string) string {
+	return re.ReplaceAllString(str, "")
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,5 +1,7 @@
 # bitbucket.org/creachadair/stringset v0.0.8
 bitbucket.org/creachadair/stringset
+# github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d
+github.com/acarl005/stripansi
 # github.com/agext/levenshtein v1.2.1
 github.com/agext/levenshtein
 # github.com/apparentlymart/go-textseg v1.0.0


### PR DESCRIPTION
I am marking this as draft for now, because I the format of errors it would produce is ... _suboptimal_ due to the fact that error output from `terraform providers schema -json` is just not designed to be displayed anywhere else outside of the terminal (even after stripping ANSI colour codes).

![Screenshot 2020-06-25 at 10 11 08](https://user-images.githubusercontent.com/287584/85696659-06febf80-b6d1-11ea-9eca-0e51149c9cdf.png)
