### PR TITLE
build: Scope hc-release publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
           CIRCLE_TOKEN: ${{ secrets.CIRCLE_TOKEN }}
       -
         name: Publish released artifacts
-        run: hc-releases publish
+        run: hc-releases publish -product=terraform-ls
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.RELEASE_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.RELEASE_AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
Takes advantage of recent improvements in hc-releases.

This should finally allow us to run the whole release pipeline in the GitHub Action end-to-end with scoped keys.
