### PR TITLE
build: print out hc-releases version after installation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,7 @@ jobs:
             -H "Accept: application/octet-stream" ${DOWNLOAD_URL}
           tar xzf /tmp/hc-releases.tgz
           sudo mv hc-releases /usr/bin/hc-releases
+          hc-releases version
       -
         name: Import PGP key for archive signing
         run: echo -e "${{ secrets.PGP_SIGNING_KEY }}" | gpg --import


### PR DESCRIPTION
This would aid potential debugging of failed releases.