### PR TITLE
textDocument/didOpen: Enrich warning message

### DIFF
--- a/langserver/handlers/did_open.go
+++ b/langserver/handlers/did_open.go
@@ -33,8 +33,11 @@ func TextDocumentDidOpen(ctx context.Context, params lsp.DidOpenTextDocumentPara
 
 	candidates := cf.RootModuleCandidatesByPath(f.Dir())
 	if len(candidates) == 0 {
-		msg := fmt.Sprintf("No root module found for %s"+
-			" functionality may be limited", f.Filename())
+		msg := fmt.Sprintf("No root module found for %s."+
+			" Functionality may be limited."+
+			// Unfortunately we can't be any more specific wrt where
+			// because we don't gather "init-able folders" in any way
+			" You may need to run terraform init", f.Filename())
 		return jrpc2.ServerPush(ctx, "window/showMessage", lsp.ShowMessageParams{
 			Type:    lsp.MTWarning,
 			Message: msg,


### PR DESCRIPTION
This is in reaction to https://discuss.hashicorp.com/t/no-root-module-found/10944

It's likely this will generate more pressure to resolving https://github.com/hashicorp/terraform-ls/issues/128 but it would at least get people closer to the point where it works (assuming they setup auth wrapper or use local state) and make the message more actionable.
