### PR TITLE
Read go version from .go-version on GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v1
         with:
+          # TODO: Replace with go-version-from-file when it is supported
+          # https://github.com/actions/setup-go/pull/62
           go-version: ${{ steps.go-version.outputs.content }}
       -
         name: Snapshot build (cross-platform)
@@ -61,6 +63,8 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v1
         with:
+          # TODO: Replace with go-version-from-file when it is supported
+          # https://github.com/actions/setup-go/pull/62
           go-version: ${{ steps.go-version.outputs.content }}
       -
         name: Go mod verify

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,16 @@ jobs:
         name: Unshallow
         run: git fetch --prune --unshallow
       -
+        name: Read go version
+        id: go-version
+        uses: juliangruber/read-file-action@v1
+        with:
+          path: ./.go-version
+      -
         name: Set up Go
         uses: actions/setup-go@v1
-        with: # Ideally this should be picked up from .go-version rather than hard-coded
-          go-version: 1.14.1
+        with:
+          go-version: ${{ steps.go-version.outputs.content }}
       -
         name: Snapshot build (cross-platform)
         uses: goreleaser/goreleaser-action@v1
@@ -46,10 +52,16 @@ jobs:
         name: Unshallow
         run: git fetch --prune --unshallow
       -
+        name: Read go version
+        id: go-version
+        uses: juliangruber/read-file-action@v1
+        with:
+          path: ./.go-version
+      -
         name: Set up Go
         uses: actions/setup-go@v1
-        with: # Ideally this should be picked up from .go-version rather than hard-coded
-          go-version: 1.14.1
+        with:
+          go-version: ${{ steps.go-version.outputs.content }}
       -
         name: Go mod verify
         run: go mod verify

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,8 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v1
         with:
+          # TODO: Replace with go-version-from-file when it is supported
+          # https://github.com/actions/setup-go/pull/62
           go-version: ${{ steps.go-version.outputs.content }}
       -
         name: Install hc-codesign

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,10 +16,16 @@ jobs:
         name: Unshallow
         run: git fetch --prune --unshallow
       -
+        name: Read go version
+        id: go-version
+        uses: juliangruber/read-file-action@v1
+        with:
+          path: ./.go-version
+      -
         name: Set up Go
         uses: actions/setup-go@v1
-        with: # Ideally this should be picked up from .go-version rather than hard-coded
-          go-version: 1.14.1
+        with:
+          go-version: ${{ steps.go-version.outputs.content }}
       -
         name: Install hc-codesign
         run: |


### PR DESCRIPTION
As written in the comment, I fixed it to read version from `.go-version` instead of hard-coding.