### PR TITLE
Remove third party GH action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,9 @@ jobs:
       -
         name: Read go version
         id: go-version
-        uses: juliangruber/read-file-action@v1
-        with:
-          path: ./.go-version
+        run: |
+          content=`cat ./.go-version`
+          echo "::set-output name=content::$content"
       -
         name: Set up Go
         uses: actions/setup-go@v1
@@ -54,18 +54,26 @@ jobs:
         name: Unshallow
         run: git fetch --prune --unshallow
       -
-        name: Read go version
-        id: go-version
-        uses: juliangruber/read-file-action@v1
-        with:
-          path: ./.go-version
+        name: Read go version (Unix)
+        if: ${{ runner.os != 'Windows' }}
+        id: go-version-unix
+        run: |
+          content=`cat ./.go-version`
+          echo "::set-output name=content::$content"
+      -
+        name: Read go version (Windows)
+        if: ${{ runner.os == 'Windows' }}
+        id: go-version-win
+        run: |
+          $content = Get-Content .\.go-version -Raw
+          echo "::set-output name=content::$content"
       -
         name: Set up Go
         uses: actions/setup-go@v1
         with:
           # TODO: Replace with go-version-from-file when it is supported
           # https://github.com/actions/setup-go/pull/62
-          go-version: ${{ steps.go-version.outputs.content }}
+          go-version: ${{ steps.go-version-unix.outputs.content || steps.go-version-win.outputs.content }}
       -
         name: Go mod verify
         run: go mod verify

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,9 +18,9 @@ jobs:
       -
         name: Read go version
         id: go-version
-        uses: juliangruber/read-file-action@v1
-        with:
-          path: ./.go-version
+        run: |
+          content=`cat ./.go-version`
+          echo "::set-output name=content::$content"
       -
         name: Set up Go
         uses: actions/setup-go@v1


### PR DESCRIPTION
Simplifies reading the file by just using a `cat` and the built-in functions for `::set-output`: https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#using-workflow-commands-to-access-toolkit-functions