### PR TITLE
Gate formatting capability on v0.7.7+

### DIFF
--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -19,19 +19,19 @@ func (k *contextKey) String() string {
 }
 
 var (
-	ctxFs               = &contextKey{"filesystem"}
-	ctxClientCapsSetter = &contextKey{"client capabilities setter"}
-	ctxClientCaps       = &contextKey{"client capabilities"}
-	ctxTfExecPath       = &contextKey{"terraform executable path"}
-	ctxTfExecLogPath    = &contextKey{"terraform executor log path"}
-	ctxTfExecTimeout    = &contextKey{"terraform execution timeout"}
-	ctxWatcher          = &contextKey{"watcher"}
-	ctxRootModuleMngr   = &contextKey{"root module manager"}
-	ctxParserFinder     = &contextKey{"parser finder"}
-	ctxTfExecFinder     = &contextKey{"terraform exec finder"}
-	ctxRootModuleCaFi   = &contextKey{"root module candidate finder"}
-	ctxRootModuleWalker = &contextKey{"root module walker"}
-	ctxRootDir          = &contextKey{"root directory"}
+	ctxFs                = &contextKey{"filesystem"}
+	ctxClientCapsSetter  = &contextKey{"client capabilities setter"}
+	ctxClientCaps        = &contextKey{"client capabilities"}
+	ctxTfExecPath        = &contextKey{"terraform executable path"}
+	ctxTfExecLogPath     = &contextKey{"terraform executor log path"}
+	ctxTfExecTimeout     = &contextKey{"terraform execution timeout"}
+	ctxWatcher           = &contextKey{"watcher"}
+	ctxRootModuleMngr    = &contextKey{"root module manager"}
+	ctxParserFinder      = &contextKey{"parser finder"}
+	ctxTfFormatterFinder = &contextKey{"terraform formatter finder"}
+	ctxRootModuleCaFi    = &contextKey{"root module candidate finder"}
+	ctxRootModuleWalker  = &contextKey{"root module walker"}
+	ctxRootDir           = &contextKey{"root directory"}
 )
 
 func missingContextErr(ctxKey *contextKey) *MissingContextErr {
@@ -132,14 +132,14 @@ func ParserFinder(ctx context.Context) (rootmodule.ParserFinder, error) {
 	return pf, nil
 }
 
-func WithTerraformExecFinder(tef rootmodule.TerraformExecFinder, ctx context.Context) context.Context {
-	return context.WithValue(ctx, ctxTfExecFinder, tef)
+func WithTerraformFormatterFinder(tef rootmodule.TerraformFormatterFinder, ctx context.Context) context.Context {
+	return context.WithValue(ctx, ctxTfFormatterFinder, tef)
 }
 
-func TerraformExecutorFinder(ctx context.Context) (rootmodule.TerraformExecFinder, error) {
-	pf, ok := ctx.Value(ctxTfExecFinder).(rootmodule.TerraformExecFinder)
+func TerraformFormatterFinder(ctx context.Context) (rootmodule.TerraformFormatterFinder, error) {
+	pf, ok := ctx.Value(ctxTfFormatterFinder).(rootmodule.TerraformFormatterFinder)
 	if !ok {
-		return nil, missingContextErr(ctxTfExecFinder)
+		return nil, missingContextErr(ctxTfFormatterFinder)
 	}
 	return pf, nil
 }

--- a/internal/terraform/rootmodule/root_module.go
+++ b/internal/terraform/rootmodule/root_module.go
@@ -397,7 +397,7 @@ func (rm *rootModule) ReferencesModulePath(path string) bool {
 	return false
 }
 
-func (rm *rootModule) TerraformExecutor() (*exec.Executor, error) {
+func (rm *rootModule) TerraformFormatter() (exec.Formatter, error) {
 	if !rm.IsTerraformLoaded() {
 		return nil, fmt.Errorf("terraform executor is not loaded yet")
 	}
@@ -406,7 +406,7 @@ func (rm *rootModule) TerraformExecutor() (*exec.Executor, error) {
 		return nil, fmt.Errorf("no terraform executor available")
 	}
 
-	return rm.tfExec, nil
+	return rm.tfExec.FormatterForVersion(rm.tfVersion)
 }
 
 func (rm *rootModule) IsTerraformLoaded() bool {

--- a/internal/terraform/rootmodule/types.go
+++ b/internal/terraform/rootmodule/types.go
@@ -19,8 +19,8 @@ type ParserFinder interface {
 	IsSchemaLoaded(path string) (bool, error)
 }
 
-type TerraformExecFinder interface {
-	TerraformExecutorForDir(ctx context.Context, path string) (*exec.Executor, error)
+type TerraformFormatterFinder interface {
+	TerraformFormatterForDir(ctx context.Context, path string) (exec.Formatter, error)
 	IsTerraformLoaded(path string) (bool, error)
 }
 
@@ -30,7 +30,7 @@ type RootModuleCandidateFinder interface {
 
 type RootModuleManager interface {
 	ParserFinder
-	TerraformExecFinder
+	TerraformFormatterFinder
 	RootModuleCandidateFinder
 
 	SetLogger(logger *log.Logger)
@@ -68,7 +68,7 @@ type RootModule interface {
 	UpdateModuleManifest(manifestFile File) error
 	Parser() (lang.Parser, error)
 	IsParserLoaded() bool
-	TerraformExecutor() (*exec.Executor, error)
+	TerraformFormatter() (exec.Formatter, error)
 	IsTerraformLoaded() bool
 }
 

--- a/langserver/handlers/formatting.go
+++ b/langserver/handlers/formatting.go
@@ -20,7 +20,7 @@ func (h *logHandler) TextDocumentFormatting(ctx context.Context, params lsp.Docu
 		return edits, err
 	}
 
-	tff, err := lsctx.TerraformExecutorFinder(ctx)
+	tff, err := lsctx.TerraformFormatterFinder(ctx)
 	if err != nil {
 		return edits, err
 	}
@@ -31,12 +31,12 @@ func (h *logHandler) TextDocumentFormatting(ctx context.Context, params lsp.Docu
 		return edits, err
 	}
 
-	tf, err := findTerraformExecutor(ctx, tff, file.Dir())
+	format, err := findTerraformFormatter(ctx, tff, file.Dir())
 	if err != nil {
 		return edits, err
 	}
 
-	formatted, err := tf.Format(ctx, file.Text())
+	formatted, err := format(ctx, file.Text())
 	if err != nil {
 		return edits, err
 	}
@@ -46,11 +46,11 @@ func (h *logHandler) TextDocumentFormatting(ctx context.Context, params lsp.Docu
 	return ilsp.TextEdits(changes), nil
 }
 
-func findTerraformExecutor(ctx context.Context, tff rootmodule.TerraformExecFinder, dir string) (*exec.Executor, error) {
+func findTerraformFormatter(ctx context.Context, tff rootmodule.TerraformFormatterFinder, dir string) (exec.Formatter, error) {
 	isLoaded, err := tff.IsTerraformLoaded(dir)
 	if err != nil {
 		if rootmodule.IsRootModuleNotFound(err) {
-			return tff.TerraformExecutorForDir(ctx, dir)
+			return tff.TerraformFormatterForDir(ctx, dir)
 		}
 		return nil, err
 	} else {
@@ -60,5 +60,5 @@ func findTerraformExecutor(ctx context.Context, tff rootmodule.TerraformExecFind
 		}
 	}
 
-	return tff.TerraformExecutorForDir(ctx, dir)
+	return tff.TerraformFormatterForDir(ctx, dir)
 }

--- a/langserver/handlers/service.go
+++ b/langserver/handlers/service.go
@@ -193,7 +193,7 @@ func (svc *service) Assigner() (jrpc2.Assigner, error) {
 			}
 
 			ctx = lsctx.WithFilesystem(fs, ctx)
-			ctx = lsctx.WithTerraformExecFinder(svc.modMgr, ctx)
+			ctx = lsctx.WithTerraformFormatterFinder(svc.modMgr, ctx)
 
 			return handle(ctx, req, lh.TextDocumentFormatting)
 		},


### PR DESCRIPTION
Depends on #219

Closes #211

Technically #219 allows use of any Terraform version (hence fixes the bug). This patch just provides better UX for the incompatible versions.