### PR TITLE
rootmodule: log errors after loading is finished

### DIFF
--- a/internal/terraform/rootmodule/root_module.go
+++ b/internal/terraform/rootmodule/root_module.go
@@ -196,6 +196,8 @@ func (rm *rootModule) load(ctx context.Context) error {
 	err = rm.UpdateSchemaCache(ctx, rm.pluginLockFile)
 	errs = multierror.Append(errs, err)
 
+	rm.logger.Printf("loading of root module %s finished: %s",
+		rm.Path(), errs)
 	return errs.ErrorOrNil()
 }
 


### PR DESCRIPTION
Closes #218 

There are still some edge cases where blocking would be better solution than just logging or surfacing of these errors, but that can be covered as part of #8 
