### PR TITLE
fix: Prevent parsing invalid tokens

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,6 @@ require (
 	github.com/zclconf/go-cty v1.2.1
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 	golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527 // indirect
-	golang.org/x/text v0.3.2
 )
 
 replace github.com/sourcegraph/go-lsp => github.com/radeksimko/go-lsp v0.1.0

--- a/internal/hcl/hcl_test.go
+++ b/internal/hcl/hcl_test.go
@@ -57,6 +57,28 @@ func TestFile_BlockAtPosition(t *testing.T) {
 			},
 		},
 		{
+			"invalid tokens",
+			`provider "aws" {
+  arg = "
+}`,
+			hcl.Pos{
+				Line:   2,
+				Column: 10,
+				Byte:   26,
+			},
+			hcl.Diagnostics{
+				&hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Invalid multi-line string",
+					Detail: `Quoted strings may not be split over multiple lines. ` +
+						`To produce a multi-line string, either use the \n escape to ` +
+						`represent a newline character or use the "heredoc" ` +
+						`multi-line template syntax.`,
+				},
+			},
+			[]hclsyntax.Token{},
+		},
+		{
 			"valid config and position",
 			`provider "aws" {
 

--- a/internal/terraform/lang/parser_test.go
+++ b/internal/terraform/lang/parser_test.go
@@ -124,6 +124,7 @@ func TestParser_ParseBlockFromTokens(t *testing.T) {
 }
 
 func newTestBlock(t *testing.T, src string) ihcl.TokenizedBlock {
+	t.Helper()
 	b, err := ihcl.NewTestBlock([]byte(src))
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Fixes #217 

The user will often produce invalid/incomplete config as they type, so diagnostics are ignored - which is by design in case of the parser. However the parser also assumes that the sequence of tokens it receives from the lexer is valid, i.e. that the [important check for invalid tokens](https://github.com/hashicorp/hcl/blob/ea60f7f2a65052437fb8373fb6434597a4a9e079/hclsyntax/token.go#L174-L193) is **not** ignored.

There are some configs which one might expect to be "parseable", e.g.

```hcl
provider "null" {
}

variable "name" {
  default = "
}
```
but the parser isn't ready to deal with such config yet and the lexer returns the trailing `}` as string literal.

If we wanted to perform completion near the opening quote we would be completing in the context of a string literal. We don't do RHS completion yet anyway, so it is not a big deal to just error out now, but I reckon we will need to revisit this to e.g. support the following

```hcl
provider "null" {
}

variable "name" {
  default = "${var.
}
```
We could virtually append closing quote there, to make it a valid sequence, but the question is when (in terms of codepath). If that has to be done before we send bytes to the lexer, then we are practically reimplementing the lexer. We could also just check for particular diagnostics and rerun the lexer - which might be fragile, but it could be guarded by tests, so probably fine.