### PR TITLE
fix: Append EOF instead of newline

### DIFF
--- a/internal/hcl/hcl.go
+++ b/internal/hcl/hcl.go
@@ -174,26 +174,21 @@ func definitionTokens(tokens hclsyntax.Tokens) hclsyntax.Tokens {
 	if len(tokens) > 0 {
 		// Check if seqence has a terminating token
 		lastToken := tokens[len(tokens)-1]
-		if lastToken.Type != hclsyntax.TokenEOF &&
-			lastToken.Type != hclsyntax.TokenNewline {
+		if lastToken.Type != hclsyntax.TokenEOF {
 			tRng := lastToken.Range
 
-			// if not we attach a newline
-			trailingNewLine := hclsyntax.Token{
-				Type:  hclsyntax.TokenNewline,
-				Bytes: []byte("\n"),
+			// if not we attach EOF
+			eofToken := hclsyntax.Token{
+				Type:  hclsyntax.TokenEOF,
+				Bytes: []byte{},
 				Range: hcl.Range{
 					Filename: tRng.Filename,
 					Start:    tRng.End,
-					End: hcl.Pos{
-						Byte:   tRng.End.Byte + 1,
-						Column: 1,
-						Line:   tRng.End.Line + 1,
-					},
+					End:      tRng.End,
 				},
 			}
 
-			tokens = append(tokens, trailingNewLine)
+			tokens = append(tokens, eofToken)
 		}
 	}
 	return tokens

--- a/internal/hcl/hcl_test.go
+++ b/internal/hcl/hcl_test.go
@@ -51,8 +51,8 @@ func TestFile_BlockAtPosition(t *testing.T) {
 					Bytes: []byte("{"),
 				},
 				{
-					Type:  hclsyntax.TokenNewline,
-					Bytes: []byte("\n"),
+					Type:  hclsyntax.TokenEOF,
+					Bytes: []byte{},
 				},
 			},
 		},
@@ -163,8 +163,8 @@ func TestFile_BlockAtPosition(t *testing.T) {
 					Bytes: []byte{'}'},
 				},
 				{
-					Type:  hclsyntax.TokenNewline,
-					Bytes: []byte("\n"),
+					Type:  hclsyntax.TokenEOF,
+					Bytes: []byte{},
 				},
 			},
 		},
@@ -214,8 +214,8 @@ func TestFile_BlockAtPosition(t *testing.T) {
 					Bytes: []byte("}"),
 				},
 				{
-					Type:  hclsyntax.TokenNewline,
-					Bytes: []byte("\n"),
+					Type:  hclsyntax.TokenEOF,
+					Bytes: []byte{},
 				},
 			},
 		},
@@ -334,8 +334,8 @@ provider "aws" {
 					Bytes: []byte("}"),
 				},
 				{
-					Type:  hclsyntax.TokenNewline,
-					Bytes: []byte("\n"),
+					Type:  hclsyntax.TokenEOF,
+					Bytes: []byte{},
 				},
 			},
 		},

--- a/internal/hcl/hcl_test.go
+++ b/internal/hcl/hcl_test.go
@@ -79,6 +79,96 @@ func TestFile_BlockAtPosition(t *testing.T) {
 			[]hclsyntax.Token{},
 		},
 		{
+			"repro case",
+			`resource "aws_ecr_lifecycle_policy" "policy" {
+  for_each = toset(var.repo_name
+}`,
+			hcl.Pos{
+				Line:   2,
+				Column: 33,
+				Byte:   79,
+			},
+			nil,
+			[]hclsyntax.Token{
+				{
+					Type:  hclsyntax.TokenIdent,
+					Bytes: []byte("resource"),
+				},
+				{
+					Type:  hclsyntax.TokenOQuote,
+					Bytes: []byte(`"`),
+				},
+				{
+					Type:  hclsyntax.TokenQuotedLit,
+					Bytes: []byte("aws_ecr_lifecycle_policy"),
+				},
+				{
+					Type:  hclsyntax.TokenCQuote,
+					Bytes: []byte(`"`),
+				},
+				{
+					Type:  hclsyntax.TokenOQuote,
+					Bytes: []byte(`"`),
+				},
+				{
+					Type:  hclsyntax.TokenQuotedLit,
+					Bytes: []byte("policy"),
+				},
+				{
+					Type:  hclsyntax.TokenCQuote,
+					Bytes: []byte(`"`),
+				},
+				{
+					Type:  hclsyntax.TokenOBrace,
+					Bytes: []byte{'{'},
+				},
+				{
+					Type:  hclsyntax.TokenNewline,
+					Bytes: []byte("\n"),
+				},
+				{
+					Type:  hclsyntax.TokenIdent,
+					Bytes: []byte("for_each"),
+				},
+				{
+					Type:  hclsyntax.TokenEqual,
+					Bytes: []byte{'='},
+				},
+				{
+					Type:  hclsyntax.TokenIdent,
+					Bytes: []byte("toset"),
+				},
+				{
+					Type:  hclsyntax.TokenOParen,
+					Bytes: []byte{'('},
+				},
+				{
+					Type:  hclsyntax.TokenIdent,
+					Bytes: []byte("var"),
+				},
+				{
+					Type:  hclsyntax.TokenDot,
+					Bytes: []byte{'.'},
+				},
+				{
+					Type:  hclsyntax.TokenIdent,
+					Bytes: []byte("repo_name"),
+				},
+				{
+					Type:  hclsyntax.TokenNewline,
+					Bytes: []byte("\n"),
+				},
+				{
+					Type:  hclsyntax.TokenCBrace,
+					Bytes: []byte{'}'},
+				},
+				{
+					Type:  hclsyntax.TokenNewline,
+					Bytes: []byte("\n"),
+				},
+			},
+		},
+		{
 			"valid config and position",
 			`provider "aws" {
 

--- a/internal/terraform/lang/config_block.go
+++ b/internal/terraform/lang/config_block.go
@@ -99,6 +99,11 @@ func (cb *completableBlock) completionCandidatesAtPos(pos hcl.Pos) (CompletionCa
 		return nil, nil
 	}
 
+	if block.PosInAttributeValue(pos) {
+		cb.logger.Println("avoiding RHS completion as it's not yet implemented")
+		return nil, nil
+	}
+
 	// Completing the body (attributes and nested blocks)
 	b, ok := block.BlockAtPos(pos)
 	if !ok {

--- a/internal/terraform/lang/hcl_block_type.go
+++ b/internal/terraform/lang/hcl_block_type.go
@@ -30,6 +30,16 @@ func (b *BlockType) PosInAttribute(pos hcl.Pos) bool {
 	return false
 }
 
+func (b *BlockType) PosInAttributeValue(pos hcl.Pos) bool {
+	for _, block := range b.BlockList {
+		if block.PosInAttributeValue(pos) {
+			return true
+		}
+	}
+
+	return false
+}
+
 func (b *BlockType) ReachedMaxItems() bool {
 	blockS := b.schema
 

--- a/internal/terraform/lang/parser_test.go
+++ b/internal/terraform/lang/parser_test.go
@@ -95,6 +95,14 @@ func TestParser_ParseBlockFromTokens(t *testing.T) {
 			"provider",
 			nil,
 		},
+		{
+			"incomplete function call in block",
+			`resource "aws_ecr_lifecycle_policy" "policy" {
+  for_each = toset(var.repo_name
+}`,
+			"resource",
+			nil,
+		},
 	}
 
 	for i, tc := range testCases {

--- a/internal/terraform/lang/types.go
+++ b/internal/terraform/lang/types.go
@@ -35,6 +35,7 @@ type Block interface {
 	Range() hcl.Range
 	PosInBody(pos hcl.Pos) bool
 	PosInAttribute(pos hcl.Pos) bool
+	PosInAttributeValue(pos hcl.Pos) bool
 	Attributes() map[string]*Attribute
 	BlockTypes() map[string]*BlockType
 }


### PR DESCRIPTION
Fixes #238 

The HCL parser apparently isn't fully ready to parse isolated blocks terminated by newline and so we just append EOF instead of newline, which the parser can safely deal with.

This technically fixes the bug in the sense that CPU no longer spikes, but the completion context is a bit off, so that still needs fixing:

```hcl
resource "aws_ecr_lifecycle_policy" "policy" {
  for_each = toset(var.repo_name
# here -------------------------^
}
```

> config_block.go:112: completing block: **"repo_name"**, &hcl.Range{Filename:"main.tf", Start:hcl.Pos{Line:2, Column:24, Byte:70}, End:hcl.Pos{Line:2, Column:33, Byte:79}}

Technically we don't support RHS completion yet anyway, so there should be no context being matched, or something, but certainly not variable name being treated as block name/type.