### PR TITLE
Improve root module discovery error handling

### DIFF
--- a/internal/terraform/rootmodule/root_module.go
+++ b/internal/terraform/rootmodule/root_module.go
@@ -447,15 +447,8 @@ func (rm *rootModule) UpdateSchemaCache(ctx context.Context, lockFile File) erro
 
 	rm.pluginLockFile = lockFile
 
-	err := rm.schemaStorage.ObtainSchemasForModule(ctx,
+	return rm.schemaStorage.ObtainSchemasForModule(ctx,
 		rm.tfExec, rootModuleDirFromFilePath(lockFile.Path()))
-	if err != nil {
-		// We fail silently here to still allow tracking the module
-		// The schema can be loaded later via watcher
-		rm.logger.Printf("failed to update plugin cache for %s: %s", rm.Path(), err.Error())
-	}
-
-	return nil
 }
 
 func (rm *rootModule) PathsToWatch() []string {

--- a/langserver/handlers/did_open.go
+++ b/langserver/handlers/did_open.go
@@ -36,6 +36,7 @@ func (lh *logHandler) TextDocumentDidOpen(ctx context.Context, params lsp.DidOpe
 	}
 
 	rootDir, _ := lsctx.RootDirectory(ctx)
+	dir := relativePath(rootDir, f.Dir())
 
 	candidates := cf.RootModuleCandidatesByPath(f.Dir())
 
@@ -43,22 +44,23 @@ func (lh *logHandler) TextDocumentDidOpen(ctx context.Context, params lsp.DidOpe
 		// avoid raising false warnings if walker hasn't finished yet
 		lh.logger.Printf("walker has not finished walking yet, data may be inaccurate for %s", f.FullPath())
 	} else if len(candidates) == 0 {
+		// TODO: Only notify once per f.Dir() per session
 		msg := fmt.Sprintf("No root module found for %s."+
 			" Functionality may be limited."+
 			// Unfortunately we can't be any more specific wrt where
 			// because we don't gather "init-able folders" in any way
-			" You may need to run terraform init", f.Filename())
+			" You may need to run terraform init"+
+			" and reload your editor.", dir)
 		return jrpc2.ServerPush(ctx, "window/showMessage", lsp.ShowMessageParams{
 			Type:    lsp.MTWarning,
 			Message: msg,
 		})
 	}
 	if len(candidates) > 1 {
-		// TODO: Suggest specifying explicit root modules?
-
-		msg := fmt.Sprintf("Alternative root modules found for %s (%s), picked: %s",
-			f.Filename(), candidatePaths(rootDir, candidates[1:]),
-			renderCandidatePath(rootDir, candidates[0]))
+		msg := fmt.Sprintf("Alternative root modules found for %s (%s), picked: %s."+
+			" You can try setting paths to root modules explicitly in settings.",
+			dir, candidatePaths(rootDir, candidates[1:]),
+			relativePath(rootDir, candidates[0].Path()))
 		return jrpc2.ServerPush(ctx, "window/showMessage", lsp.ShowMessageParams{
 			Type:    lsp.MTWarning,
 			Message: msg,
@@ -72,14 +74,14 @@ func candidatePaths(rootDir string, candidates []rootmodule.RootModule) string {
 	paths := make([]string, len(candidates))
 	for i, rm := range candidates {
 		// This helps displaying shorter, but still relevant paths
-		paths[i] = renderCandidatePath(rootDir, rm)
+		paths[i] = relativePath(rootDir, rm.Path())
 	}
 	return strings.Join(paths, ", ")
 }
 
-func renderCandidatePath(rootDir string, candidate rootmodule.RootModule) string {
+func relativePath(rootDir string, path string) string {
 	trimmed := strings.TrimPrefix(
-		strings.TrimPrefix(candidate.Path(), rootDir), string(os.PathSeparator))
+		strings.TrimPrefix(path, rootDir), string(os.PathSeparator))
 	if trimmed == "" {
 		return "."
 	}


### PR DESCRIPTION
This slightly improves logging, where previously we'd log error from plugin cache updating separately and then report 0 errors from loading a module, now all the loading stages are treated the same in terms of error reporting.
The relevant error is however still (intentionally) ignored as watcher invokes these methods:

https://github.com/hashicorp/terraform-ls/blob/2347f8dcc34685b179b6bd054f9774ec68b80345/internal/watcher/watcher.go#L89-L94

Secondly this also improves the message we show when there is no root module found, to be more helpful until https://github.com/hashicorp/terraform-ls/issues/222 is implemented and reflect that the message is related to the directory, rather than file.