### PR TITLE
settings: Support relative paths to root modules

### DIFF
--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -7,8 +7,14 @@ The language server supports the following configuration options:
 ## `rootModulePaths` (`[]string`)
 
 This allows overriding automatic root module discovery by passing a static list
-of absolute paths to root modules (i.e. folders with `*.tf` files
+of absolute or relative paths to root modules (i.e. folders with `*.tf` files
 which have been `terraform init`-ed).
+
+Relative paths are resolved relative to the directory opened in the editor.
+
+Path separators are converted automatically to the match separators
+of the target platform (e.g. `\` on Windows, or `/` on Unix),
+symlinks are followed and trailing slashes automatically removed.
 
 ## How to pass settings
 

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -1,10 +1,6 @@
 package settings
 
 import (
-	"fmt"
-	"path/filepath"
-
-	"github.com/hashicorp/go-multierror"
 	"github.com/mitchellh/mapstructure"
 )
 
@@ -19,15 +15,7 @@ type Options struct {
 }
 
 func (o *Options) Validate() error {
-	var result *multierror.Error
-
-	for _, p := range o.RootModulePaths {
-		if !filepath.IsAbs(p) {
-			result = multierror.Append(result, fmt.Errorf("%q is not an absolute path", p))
-		}
-	}
-
-	return result.ErrorOrNil()
+	return nil
 }
 
 type DecodedOptions struct {

--- a/internal/settings/settings_test.go
+++ b/internal/settings/settings_test.go
@@ -40,15 +40,3 @@ func TestDecodeOptions_success(t *testing.T) {
 		t.Fatalf("options mismatch: %s", diff)
 	}
 }
-
-func TestDecodedOptions_Validate(t *testing.T) {
-	opts := &Options{
-		RootModulePaths: []string{
-			"./relative/path",
-		},
-	}
-	err := opts.Validate()
-	if err == nil {
-		t.Fatal("expected relative path to fail validation")
-	}
-}

--- a/langserver/handlers/did_open_test.go
+++ b/langserver/handlers/did_open_test.go
@@ -2,6 +2,8 @@ package handlers
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/hashicorp/terraform-ls/langserver"
@@ -23,4 +25,19 @@ func TestLangServer_didOpenWithoutInitialization(t *testing.T) {
 			"uri": "%s/main.tf"
 		}
 	}`, TempDir(t).URI())}, session.SessionNotInitialized.Err())
+}
+
+func TestHumanReadablePath(t *testing.T) {
+	fh := TempDir(t)
+
+	err := os.Mkdir(filepath.Join(fh.Dir(), "testDir"), os.ModeDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedPath := "testDir"
+	path := humanReadablePath(fh.Dir(), "testDir")
+	if path != expectedPath {
+		t.Fatalf("expected %q, given: %q", expectedPath, path)
+	}
 }


### PR DESCRIPTION
Fixes #235 

It's worth noting that this does _not_ allow the user to just "force-pair" the root module. Any referenced root module still has to reference the folder being opened in the editor as a module, otherwise it will not be matched.

Force-pairing is something we could consider but that would likely require some UI changes, maybe even an entirely separate config option as we wouldn't be able to pick the right path from a list. Also I would like to first understand the use cases for such feature before implementing it.