### PR TITLE
Warn and skip invalid root module paths

### DIFF
--- a/langserver/handlers/initialize.go
+++ b/langserver/handlers/initialize.go
@@ -85,7 +85,11 @@ func (lh *logHandler) Initialize(ctx context.Context, params lsp.InitializeParam
 		for _, rawPath := range cfgOpts.RootModulePaths {
 			rmPath, err := resolvePath(rootDir, rawPath)
 			if err != nil {
-				return serverCaps, err
+				jrpc2.ServerPush(ctx, "window/showMessage", &lsp.ShowMessageParams{
+					Type:    lsp.MTWarning,
+					Message: fmt.Sprintf("Ignoring root module path %s: %s", rawPath, err),
+				})
+				continue
 			}
 			rm, err := addAndLoadRootModule(rmPath)
 			if err != nil {


### PR DESCRIPTION
We evaluate symlinks for explicit paths and the side effect of doing that is also checking if the target directory actually exists.
This would previously fail the initialization and cause the LS to be effectively shut down.

It seems more logical to just raise a warning and let the user carry on as they may have some other valid paths and the server may still be useful for auto-formatting which doesn't require a root module.
