### PR TITLE
auto-completion providers from registry

### DIFF
--- a/internal/terraform/addrs/provider.go
+++ b/internal/terraform/addrs/provider.go
@@ -12,9 +12,11 @@ import (
 // Provider encapsulates a single provider type. In the future this will be
 // extended to include additional fields including Namespace and SourceHost
 type Provider struct {
-	Type      string
-	Namespace string
-	Hostname  svchost.Hostname
+	Type        string
+	Namespace   string
+	Hostname    svchost.Hostname
+	Tier        string
+	Description string
 }
 
 // DefaultRegistryHost is the hostname used for provider addresses that do

--- a/internal/terraform/lang/provider_block.go
+++ b/internal/terraform/lang/provider_block.go
@@ -129,8 +129,9 @@ func providerCandidates(providers []addrs.Provider) []*labelCandidate {
 	candidates := []*labelCandidate{}
 	for _, pAddr := range providers {
 		candidates = append(candidates, &labelCandidate{
-			label:  pAddr.Type,
-			detail: pAddr.ForDisplay(),
+			label:         pAddr.Type,
+			detail:        pAddr.ForDisplay(),
+			documentation: PlainText(pAddr.Description),
 		})
 	}
 	return candidates

--- a/internal/terraform/registry/model.go
+++ b/internal/terraform/registry/model.go
@@ -1,0 +1,25 @@
+package registry
+
+type Provider struct {
+	Attributes ProviderAttr `json:"attributes"`
+}
+
+type ProviderAttr struct {
+	Name        string `json:"name"`
+	Namespace   string `json:"namespace"`
+	Tier        string `json:"tier"`
+	Source      string `json:"source"`
+	Description string `json:"description"`
+}
+
+type PageLink struct {
+	First string `json:"first"`
+	Last  string `json:"last"`
+	Next  string `json:"next"`
+	Prev  string `json:"prev"`
+}
+
+type ProviderPage struct {
+	Data  []Provider `json:"data"`
+	Links PageLink   `json:"links"`
+}

--- a/internal/terraform/registry/registry.go
+++ b/internal/terraform/registry/registry.go
@@ -1,0 +1,70 @@
+package registry
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"sync"
+
+	"github.com/hashicorp/terraform-ls/internal/terraform/addrs"
+)
+
+var registryProviders = make([]addrs.Provider, 0)
+var err error
+var o = &sync.Once{}
+
+func GetProviders() (*[]addrs.Provider, error) {
+	o.Do(func() {
+		var result *[]ProviderAttr
+		result, err := listAvailableProviders()
+		if err != nil {
+			return
+		}
+		for _, v := range *result {
+			registryProviders = append(registryProviders, addrs.Provider{
+				Type:        v.Name,
+				Namespace:   v.Namespace,
+				Hostname:    addrs.DefaultRegistryHost,
+				Tier:        v.Tier,
+				Description: v.Description,
+			})
+		}
+	})
+
+	return &registryProviders, err
+}
+
+func listAvailableProviders() (*[]ProviderAttr, error) {
+	var result []ProviderAttr
+	url := "/v2/providers?filter[tier]=official,partner,community&page[number]=1&page[size]=100"
+	for url != "" {
+		page, err := listProviders(url)
+		if err != nil {
+			return nil, err
+		}
+		for _, p := range page.Data {
+			result = append(result, p.Attributes)
+		}
+
+		url = page.Links.Next
+	}
+	return &result, nil
+}
+
+func listProviders(uri string) (*ProviderPage, error) {
+	if !strings.HasPrefix(uri, "https://") {
+		uri = "https://registry.terraform.io" + uri
+	}
+	resp, err := http.Get(uri)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var page ProviderPage
+	// UnknownFields are ignored
+	if err := json.NewDecoder(resp.Body).Decode(&page); err != nil {
+		return nil, err
+	}
+	return &page, nil
+}

--- a/internal/terraform/rootmodule/root_module.go
+++ b/internal/terraform/rootmodule/root_module.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-ls/internal/terraform/discovery"
 	"github.com/hashicorp/terraform-ls/internal/terraform/exec"
 	"github.com/hashicorp/terraform-ls/internal/terraform/lang"
+	"github.com/hashicorp/terraform-ls/internal/terraform/registry"
 	"github.com/hashicorp/terraform-ls/internal/terraform/schema"
 )
 
@@ -215,6 +216,12 @@ func (rm *rootModule) load(ctx context.Context) error {
 
 	err = rm.UpdateSchemaCache(ctx, rm.pluginLockFile)
 	errs = multierror.Append(errs, err)
+
+	if providers, err := registry.GetProviders(); err != nil {
+		rm.logger.Printf("loading providers from registry failed: %+v", err)
+	} else if len(*providers) != 0 {
+		rm.schemaStorage.SetRegistryProviders(providers)
+	}
 
 	rm.logger.Printf("loading of root module %s finished: %s",
 		rm.Path(), errs)

--- a/internal/terraform/schema/schema_storage.go
+++ b/internal/terraform/schema/schema_storage.go
@@ -179,7 +179,7 @@ func (s *Storage) providerIdentity(addr addrs.Provider) string {
 
 // get from registry first. If not exist get from schema
 func (s *Storage) Providers() ([]addrs.Provider, error) {
-	if s.registryProviders != nil || len(*s.registryProviders) != 0 {
+	if s.registryProviders != nil && len(*s.registryProviders) != 0 {
 		return *s.registryProviders, nil
 	}
 


### PR DESCRIPTION
fix #194 

based on current logic, there seems no need to use algolia search.
we could just get all providers from registry and reuse existing logic