### PR TITLE
Symbols Support

### DIFF
--- a/internal/hcl/hcl.go
+++ b/internal/hcl/hcl.go
@@ -120,6 +120,27 @@ func (f *file) BlockAtPosition(pos hcl.Pos) (TokenizedBlock, error) {
 	return nil, &NoBlockFoundErr{pos}
 }
 
+func (f *file) Blocks() ([]TokenizedBlock, error) {
+	var blocks []TokenizedBlock
+
+	pf, err := f.parse()
+	if err != nil {
+		return blocks, err
+	}
+
+	body, ok := pf.Body.(*hclsyntax.Body)
+	if !ok {
+		return blocks, fmt.Errorf("unexpected body type (%T)", body)
+	}
+
+	for _, block := range body.Blocks {
+		dt := definitionTokens(tokensInRange(pf.Tokens, block.Range()))
+		blocks = append(blocks, &parsedBlock{dt})
+	}
+
+	return blocks, nil
+}
+
 func (f *file) TokenAtPosition(pos hcl.Pos) (hclsyntax.Token, error) {
 	pf, _ := f.parse()
 

--- a/internal/hcl/hcl.go
+++ b/internal/hcl/hcl.go
@@ -27,6 +27,14 @@ func (pb *parsedBlock) Tokens() hclsyntax.Tokens {
 	return pb.tokens
 }
 
+func (pb *parsedBlock) Range() hcl.Range {
+	return hcl.Range{
+		Filename: pb.tokens[0].Range.Filename,
+		Start:    pb.tokens[0].Range.Start,
+		End:      pb.tokens[len(pb.tokens)-1].Range.End,
+	}
+}
+
 func (pb *parsedBlock) TokenAtPosition(pos hcl.Pos) (hclsyntax.Token, error) {
 	for _, t := range pb.tokens {
 		if rangeContainsOffset(t.Range, pos.Byte) {

--- a/internal/hcl/types.go
+++ b/internal/hcl/types.go
@@ -15,4 +15,5 @@ type TokenizedFile interface {
 type TokenizedBlock interface {
 	TokenAtPosition(hcl.Pos) (hclsyntax.Token, error)
 	Tokens() hclsyntax.Tokens
+	Range() hcl.Range
 }

--- a/internal/hcl/types.go
+++ b/internal/hcl/types.go
@@ -9,6 +9,7 @@ type TokenizedFile interface {
 	BlockAtPosition(hcl.Pos) (TokenizedBlock, error)
 	TokenAtPosition(hcl.Pos) (hclsyntax.Token, error)
 	PosInBlock(hcl.Pos) bool
+	Blocks() ([]TokenizedBlock, error)
 }
 
 type TokenizedBlock interface {

--- a/internal/lsp/completion.go
+++ b/internal/lsp/completion.go
@@ -66,6 +66,6 @@ func textEdit(te lang.TextEdit, pos hcl.Pos) *lsp.TextEdit {
 
 	return &lsp.TextEdit{
 		NewText: te.NewText(),
-		Range:   hclRangeToLSP(*rng),
+		Range:   HCLRangeToLSP(*rng),
 	}
 }

--- a/internal/lsp/file_change.go
+++ b/internal/lsp/file_change.go
@@ -46,7 +46,7 @@ func TextEdits(changes filesystem.DocumentChanges) []lsp.TextEdit {
 
 	for i, change := range changes {
 		edits[i] = lsp.TextEdit{
-			Range:   hclRangeToLSP(change.Range()),
+			Range:   HCLRangeToLSP(change.Range()),
 			NewText: change.Text(),
 		}
 	}
@@ -54,7 +54,7 @@ func TextEdits(changes filesystem.DocumentChanges) []lsp.TextEdit {
 	return edits
 }
 
-func hclRangeToLSP(hclRng hcl.Range) lsp.Range {
+func HCLRangeToLSP(hclRng hcl.Range) lsp.Range {
 	return lsp.Range{
 		Start: lsp.Position{
 			Character: hclRng.Start.Column - 1,

--- a/internal/terraform/lang/parser.go
+++ b/internal/terraform/lang/parser.go
@@ -167,6 +167,26 @@ func (p *parser) BlockTypeCandidates(file ihcl.TokenizedFile, pos hcl.Pos) Compl
 	return list
 }
 
+func (p *parser) Blocks(file ihcl.TokenizedFile) ([]ConfigBlock, error) {
+	blocks, err := file.Blocks()
+	if err != nil {
+		return nil, err
+	}
+
+	var cfgBlocks []ConfigBlock
+
+	for _, block := range blocks {
+		cfgBlock, err := p.ParseBlockFromTokens(block)
+		if err != nil {
+			p.logger.Printf("parsing config block failed: %s", err)
+			continue
+		}
+		cfgBlocks = append(cfgBlocks, cfgBlock)
+	}
+
+	return cfgBlocks, nil
+}
+
 type completableBlockType struct {
 	TypeName      string
 	LabelSchema   LabelSchema

--- a/internal/terraform/lang/parser.go
+++ b/internal/terraform/lang/parser.go
@@ -178,6 +178,8 @@ func (p *parser) Blocks(file ihcl.TokenizedFile) ([]ConfigBlock, error) {
 	for _, block := range blocks {
 		cfgBlock, err := p.ParseBlockFromTokens(block)
 		if err != nil {
+			// do not error out if parsing failed, continue to parse
+			// blocks that are supported
 			p.logger.Printf("parsing config block failed: %s", err)
 			continue
 		}

--- a/internal/terraform/lang/provider_block.go
+++ b/internal/terraform/lang/provider_block.go
@@ -85,6 +85,10 @@ func (p *providerBlock) BlockType() string {
 	return "provider"
 }
 
+func (p *providerBlock) Range() hcl.Range {
+	return p.tBlock.Range()
+}
+
 func (p *providerBlock) CompletionCandidatesAtPos(pos hcl.Pos) (CompletionCandidates, error) {
 	if p.sr == nil {
 		return nil, &noSchemaReaderErr{p.BlockType()}

--- a/internal/terraform/lang/resource_block.go
+++ b/internal/terraform/lang/resource_block.go
@@ -96,6 +96,10 @@ func (r *resourceBlock) BlockType() string {
 	return "resource"
 }
 
+func (r *resourceBlock) Range() hcl.Range {
+	return r.tBlock.Range()
+}
+
 func (r *resourceBlock) CompletionCandidatesAtPos(pos hcl.Pos) (CompletionCandidates, error) {
 	if r.sr == nil {
 		return nil, &noSchemaReaderErr{r.BlockType()}

--- a/internal/terraform/lang/types.go
+++ b/internal/terraform/lang/types.go
@@ -19,6 +19,7 @@ type Parser interface {
 	SetProviderReferences(addrs.ProviderReferences)
 	BlockTypeCandidates(ihcl.TokenizedFile, hcl.Pos) CompletionCandidates
 	CompletionCandidatesAtPos(ihcl.TokenizedFile, hcl.Pos) (CompletionCandidates, error)
+	Blocks(ihcl.TokenizedFile) ([]ConfigBlock, error)
 }
 
 // ConfigBlock implements an abstraction above HCL block
@@ -28,6 +29,7 @@ type ConfigBlock interface {
 	Name() string
 	BlockType() string
 	Labels() []*ParsedLabel
+	Range() hcl.Range
 }
 
 // Block represents a decoded HCL block (by a Parser)

--- a/langserver/handlers/handlers_test.go
+++ b/langserver/handlers/handlers_test.go
@@ -37,6 +37,7 @@ func TestInitalizeAndShutdown(t *testing.T) {
 					"change": 2
 				},
 				"completionProvider": {},
+				"documentSymbolProvider":true,
 				"documentFormattingProvider":true
 			}
 		}
@@ -75,6 +76,7 @@ func TestEOF(t *testing.T) {
 					"change": 2
 				},
 				"completionProvider": {},
+				"documentSymbolProvider":true,
 				"documentFormattingProvider":true
 			}
 		}

--- a/langserver/handlers/initialize.go
+++ b/langserver/handlers/initialize.go
@@ -27,6 +27,7 @@ func (lh *logHandler) Initialize(ctx context.Context, params lsp.InitializeParam
 				ResolveProvider: false,
 			},
 			DocumentFormattingProvider: true,
+			DocumentSymbolProvider:     true,
 		},
 	}
 

--- a/langserver/handlers/service.go
+++ b/langserver/handlers/service.go
@@ -196,6 +196,17 @@ func (svc *service) Assigner() (jrpc2.Assigner, error) {
 			ctx = lsctx.WithDocumentStorage(ctx, fs)
 			return handle(ctx, req, TextDocumentDidClose)
 		},
+		"textDocument/documentSymbol": func(ctx context.Context, req *jrpc2.Request) (interface{}, error) {
+			err := session.CheckInitializationIsConfirmed()
+			if err != nil {
+				return nil, err
+			}
+
+			ctx = lsctx.WithDocumentStorage(ctx, fs)
+			ctx = lsctx.WithParserFinder(ctx, svc.modMgr)
+
+			return handle(ctx, req, lh.TextDocumentSymbol)
+		},
 		"textDocument/completion": func(ctx context.Context, req *jrpc2.Request) (interface{}, error) {
 			err := session.CheckInitializationIsConfirmed()
 			if err != nil {

--- a/langserver/handlers/symbol.go
+++ b/langserver/handlers/symbol.go
@@ -1,0 +1,70 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	lsctx "github.com/hashicorp/terraform-ls/internal/context"
+	ihcl "github.com/hashicorp/terraform-ls/internal/hcl"
+	ilsp "github.com/hashicorp/terraform-ls/internal/lsp"
+	"github.com/sourcegraph/go-lsp"
+)
+
+func (h *logHandler) TextDocumentSymbol(ctx context.Context, params lsp.DocumentSymbolParams) ([]lsp.SymbolInformation, error) {
+
+	h.logger.Printf("SymbolsTest")
+
+	var symbols []lsp.SymbolInformation
+
+	fs, err := lsctx.DocumentStorage(ctx)
+	if err != nil {
+		return symbols, err
+	}
+
+	file, err := fs.GetDocument(ilsp.FileHandlerFromDocumentURI(params.TextDocument.URI))
+	if err != nil {
+		return symbols, err
+	}
+
+	text, err := file.Text()
+	if err != nil {
+		return symbols, err
+	}
+
+	hclFile := ihcl.NewFile(file, text)
+
+	blocks, err := hclFile.Blocks()
+	if err != nil {
+		return symbols, err
+	}
+
+	for _, block := range blocks {
+		hclBlock, _ := hclsyntax.ParseBlockFromTokens(block.Tokens())
+		labels := hclBlock.Labels
+		if len(labels) == 0 || len(labels) > 2 {
+			h.logger.Printf("Block with no or more than 2 labels...skipping")
+			continue
+		}
+		var name string
+		// this is cheating, did not want to deal with LabelSchema
+		if len(labels) == 1 {
+			name = fmt.Sprintf("provider.%s", labels[0])
+		} else if len(labels) == 2 {
+			name = fmt.Sprintf("resourceordatasource.%s.%s", labels[0], labels[1])
+		}
+		symbols = append(symbols, lsp.SymbolInformation{
+			Name: name,
+			Kind: lsp.SKStruct,
+			Location: lsp.Location{
+				URI:   params.TextDocument.URI,
+				Range: ilsp.HCLRangeToLSP(hclBlock.LabelRanges[0]),
+			},
+		})
+	}
+
+	h.logger.Printf("SymbolsTest %+v", symbols)
+
+	return symbols, nil
+
+}

--- a/langserver/handlers/symbol.go
+++ b/langserver/handlers/symbol.go
@@ -3,21 +3,24 @@ package handlers
 import (
 	"context"
 	"fmt"
+	"time"
 
-	"github.com/hashicorp/hcl/v2/hclsyntax"
 	lsctx "github.com/hashicorp/terraform-ls/internal/context"
 	ihcl "github.com/hashicorp/terraform-ls/internal/hcl"
 	ilsp "github.com/hashicorp/terraform-ls/internal/lsp"
+	"github.com/hashicorp/terraform-ls/internal/terraform/lang"
 	"github.com/sourcegraph/go-lsp"
 )
 
 func (h *logHandler) TextDocumentSymbol(ctx context.Context, params lsp.DocumentSymbolParams) ([]lsp.SymbolInformation, error) {
-
-	h.logger.Printf("SymbolsTest")
-
 	var symbols []lsp.SymbolInformation
 
 	fs, err := lsctx.DocumentStorage(ctx)
+	if err != nil {
+		return symbols, err
+	}
+
+	pf, err := lsctx.ParserFinder(ctx)
 	if err != nil {
 		return symbols, err
 	}
@@ -34,37 +37,56 @@ func (h *logHandler) TextDocumentSymbol(ctx context.Context, params lsp.Document
 
 	hclFile := ihcl.NewFile(file, text)
 
-	blocks, err := hclFile.Blocks()
+	// TODO: block until it's available <-pf.ParserLoadingDone()
+	// requires https://github.com/hashicorp/terraform-ls/issues/8
+	// TODO: replace crude wait/timeout loop
+	var isParserLoaded bool
+	var elapsed time.Duration
+	sleepFor := 10 * time.Millisecond
+	maxWait := 3 * time.Second
+	for !isParserLoaded {
+		time.Sleep(sleepFor)
+		elapsed += sleepFor
+		if elapsed >= maxWait {
+			return symbols, fmt.Errorf("parser is not available yet for %s", file.Dir())
+		}
+		var err error
+		isParserLoaded, err = pf.IsParserLoaded(file.Dir())
+		if err != nil {
+			return symbols, err
+		}
+	}
+
+	p, err := pf.ParserForDir(file.Dir())
+	if err != nil {
+		return symbols, fmt.Errorf("finding compatible parser failed: %w", err)
+	}
+
+	blocks, err := p.Blocks(hclFile)
 	if err != nil {
 		return symbols, err
 	}
 
 	for _, block := range blocks {
-		hclBlock, _ := hclsyntax.ParseBlockFromTokens(block.Tokens())
-		labels := hclBlock.Labels
-		if len(labels) == 0 || len(labels) > 2 {
-			h.logger.Printf("Block with no or more than 2 labels...skipping")
-			continue
-		}
-		var name string
-		// this is cheating, did not want to deal with LabelSchema
-		if len(labels) == 1 {
-			name = fmt.Sprintf("provider.%s", labels[0])
-		} else if len(labels) == 2 {
-			name = fmt.Sprintf("resourceordatasource.%s.%s", labels[0], labels[1])
-		}
+		block.Labels()
 		symbols = append(symbols, lsp.SymbolInformation{
-			Name: name,
-			Kind: lsp.SKStruct,
+			Name: symbolName(block),
+			Kind: lsp.SKStruct, // We don't have a great SymbolKind match for blocks
 			Location: lsp.Location{
+				Range: ilsp.HCLRangeToLSP(block.Range()),
 				URI:   params.TextDocument.URI,
-				Range: ilsp.HCLRangeToLSP(hclBlock.LabelRanges[0]),
 			},
 		})
 	}
 
-	h.logger.Printf("SymbolsTest %+v", symbols)
-
 	return symbols, nil
 
+}
+
+func symbolName(b lang.ConfigBlock) string {
+	name := b.BlockType()
+	for _, l := range b.Labels() {
+		name += "." + l.Value
+	}
+	return name
 }

--- a/langserver/handlers/symbol.go
+++ b/langserver/handlers/symbol.go
@@ -68,7 +68,6 @@ func (h *logHandler) TextDocumentSymbol(ctx context.Context, params lsp.Document
 	}
 
 	for _, block := range blocks {
-		block.Labels()
 		symbols = append(symbols, lsp.SymbolInformation{
 			Name: symbolName(block),
 			Kind: lsp.SKStruct, // We don't have a great SymbolKind match for blocks


### PR DESCRIPTION
This provides initial support for symbols navigation. Only supports symbols within the active file, and only jumps to provider, resource, and datasource blocks.

Closes #263 
