### PR TITLE
fix: prevent crash when listing symbols

### DIFF
--- a/internal/terraform/lang/parser.go
+++ b/internal/terraform/lang/parser.go
@@ -222,9 +222,10 @@ func (p *parser) ParseBlockFromTokens(tBlock ihcl.TokenizedBlock) (ConfigBlock, 
 	// It is probably excessive to be parsing the whole block just for type
 	// but there is no avoiding it without refactoring the upstream HCL parser
 	// and it should not hurt the performance too much
-	//
-	// We ignore diags as we assume incomplete (invalid) configuration
-	block, _ := hclsyntax.ParseBlockFromTokens(tBlock.Tokens())
+	block, diags := hclsyntax.ParseBlockFromTokens(tBlock.Tokens())
+	if block == nil {
+		return nil, diags
+	}
 
 	p.logger.Printf("Parsed block type: %q", block.Type)
 

--- a/langserver/handlers/handlers_test.go
+++ b/langserver/handlers/handlers_test.go
@@ -109,12 +109,18 @@ func validTfMockCalls() exec.ExecutorFactory {
 			},
 			ReturnArguments: []interface{}{
 				version.Must(version.NewVersion("0.12.0")),
-				map[string]*version.Version{},
 				nil,
 			},
 		},
 		{
-			Method:        "ProvidersSchema",
+			Method:        "GetExecPath",
+			Repeatability: 1,
+			ReturnArguments: []interface{}{
+				"",
+			},
+		},
+		{
+			Method:        "ProviderSchemas",
 			Repeatability: 1,
 			Arguments: []interface{}{
 				mock.AnythingOfType(""),

--- a/langserver/handlers/symbols_test.go
+++ b/langserver/handlers/symbols_test.go
@@ -1,0 +1,54 @@
+package handlers
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-ls/internal/terraform/rootmodule"
+	"github.com/hashicorp/terraform-ls/langserver"
+)
+
+func TestLangServer_symbols_basic(t *testing.T) {
+	tmpDir := TempDir(t)
+	InitPluginCache(t, tmpDir.Dir())
+
+	ls := langserver.NewLangServerMock(t, NewMockSession(&MockSessionInput{
+		RootModules: map[string]*rootmodule.RootModuleMock{
+			tmpDir.Dir(): {
+				TfExecFactory: validTfMockCalls(),
+			},
+		},
+	}))
+	stop := ls.Start(t)
+	defer stop()
+
+	ls.Call(t, &langserver.CallRequest{
+		Method: "initialize",
+		ReqParams: fmt.Sprintf(`{
+	    "capabilities": {},
+	    "rootUri": %q,
+	    "processId": 12345
+	}`, tmpDir.URI())})
+	ls.Notify(t, &langserver.CallRequest{
+		Method:    "initialized",
+		ReqParams: "{}",
+	})
+	ls.Call(t, &langserver.CallRequest{
+		Method: "textDocument/didOpen",
+		ReqParams: fmt.Sprintf(`{
+		"textDocument": {
+			"version": 0,
+			"languageId": "terraform",
+			"text": "provider \"github\"\n\n}\n",
+			"uri": "%s/main.tf"
+		}
+	}`, tmpDir.URI())})
+
+	ls.Call(t, &langserver.CallRequest{
+		Method: "textDocument/documentSymbol",
+		ReqParams: fmt.Sprintf(`{
+		"textDocument": {
+			"uri": "%s/main.tf"
+		}
+	}`, tmpDir.URI())})
+}


### PR DESCRIPTION
We previously ignored all diagnostics, which includes both minor and major, the latter of which prevent the HCL parser from parsing anything and therefore resulting in `nil` being returned from `ParseBlockFromTokens` which was then unexpected outcome for `Blocks()`.

_Example of such invalid config_

```hcl
provider "aws"
  access_key = "value"
}
```

The crash didn't occur during completion because it uses some other position-based methods which would already stop before stepping further into the parser internals and in particular into `ParseBlockFromTokens`. Symbol listing however is not position based and so listing symbols on an invalid config leads to a crash.