### PR TITLE
Unique command names

### DIFF
--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -30,6 +30,26 @@ of the target platform (e.g. `\` on Windows, or `/` on Unix),
 symlinks are followed, trailing slashes automatically removed,
 and `~` is replaced with your home directory.
 
+## `commandPrefix`
+
+Some clients such as VS code keep a global registry of commands published by language
+servers, and the names must be unique, even between terraform-ls instances. Setting
+this allows multiple servers to run side by side, albeit the client is now responsible
+for routing commands to the correct server. Users should not need to worry about
+this, the frontend client extension should manage it.
+
+The prefix will be applied to the front of the command name, which already contains
+a `terraform-ls` prefix.
+
+`commandPrefix.terraform-ls.commandName`
+
+Or if left empty
+
+`terraform-ls.commandName`
+
+This setting should be deprecated once the language server supports multiple workspaces,
+as this arises in VS code because a server instance is started per VS code workspace.
+
 ## How to pass settings
 
 The server expects static settings to be passed as part of LSP `initialize` call,

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -32,7 +32,7 @@ and `~` is replaced with your home directory.
 
 ## `commandPrefix`
 
-Some clients such as VS code keep a global registry of commands published by language
+Some clients such as VS Code keep a global registry of commands published by language
 servers, and the names must be unique, even between terraform-ls instances. Setting
 this allows multiple servers to run side by side, albeit the client is now responsible
 for routing commands to the correct server. Users should not need to worry about
@@ -48,7 +48,7 @@ Or if left empty
 `terraform-ls.commandName`
 
 This setting should be deprecated once the language server supports multiple workspaces,
-as this arises in VS code because a server instance is started per VS code workspace.
+as this arises in VS code because a server instance is started per VS Code workspace.
 
 ## How to pass settings
 

--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -34,6 +34,7 @@ var (
 	ctxRootModuleWalker  = &contextKey{"root module walker"}
 	ctxRootModuleLoader  = &contextKey{"root module loader"}
 	ctxRootDir           = &contextKey{"root directory"}
+	ctxCommandPrefix     = &contextKey{"command prefix"}
 	ctxDiags             = &contextKey{"diagnostics"}
 )
 
@@ -188,6 +189,28 @@ func RootDirectory(ctx context.Context) (string, bool) {
 		return "", false
 	}
 	return *rootDir, true
+}
+
+func WithCommandPrefix(ctx context.Context, prefix *string) context.Context {
+	return context.WithValue(ctx, ctxCommandPrefix, prefix)
+}
+
+func SetCommandPrefix(ctx context.Context, prefix string) error {
+	commandPrefix, ok := ctx.Value(ctxCommandPrefix).(*string)
+	if !ok {
+		return missingContextErr(ctxCommandPrefix)
+	}
+
+	*commandPrefix = prefix
+	return nil
+}
+
+func CommandPrefix(ctx context.Context) (string, bool) {
+	commandPrefix, ok := ctx.Value(ctxCommandPrefix).(*string)
+	if !ok {
+		return "", false
+	}
+	return *commandPrefix, true
 }
 
 func WithRootModuleWalker(ctx context.Context, w *rootmodule.Walker) context.Context {

--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -35,6 +35,7 @@ var (
 	ctxRootModuleLoader  = &contextKey{"root module loader"}
 	ctxRootDir           = &contextKey{"root directory"}
 	ctxDiags             = &contextKey{"diagnostics"}
+	ctxServerID          = &contextKey{"servier id"}
 )
 
 func missingContextErr(ctxKey *contextKey) *MissingContextErr {
@@ -188,6 +189,28 @@ func RootDirectory(ctx context.Context) (string, bool) {
 		return "", false
 	}
 	return *rootDir, true
+}
+
+func WithServerID(ctx context.Context, id *string) context.Context {
+	return context.WithValue(ctx, ctxServerID, id)
+}
+
+func SetServerID(ctx context.Context, id string) error {
+	serverID, ok := ctx.Value(ctxServerID).(*string)
+	if !ok {
+		return missingContextErr(ctxServerID)
+	}
+
+	*serverID = id
+	return nil
+}
+
+func ServerID(ctx context.Context) (string, bool) {
+	serverID, ok := ctx.Value(ctxServerID).(*string)
+	if !ok {
+		return "", false
+	}
+	return *serverID, true
 }
 
 func WithRootModuleWalker(ctx context.Context, w *rootmodule.Walker) context.Context {

--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -35,7 +35,7 @@ var (
 	ctxRootModuleLoader  = &contextKey{"root module loader"}
 	ctxRootDir           = &contextKey{"root directory"}
 	ctxDiags             = &contextKey{"diagnostics"}
-	ctxServerID          = &contextKey{"servier id"}
+	ctxServerID          = &contextKey{"server id"}
 )
 
 func missingContextErr(ctxKey *contextKey) *MissingContextErr {

--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -35,7 +35,7 @@ var (
 	ctxRootModuleLoader  = &contextKey{"root module loader"}
 	ctxRootDir           = &contextKey{"root directory"}
 	ctxDiags             = &contextKey{"diagnostics"}
-	ctxServerID          = &contextKey{"server id"}
+	ctxCommandPrefix     = &contextKey{"command prefix"}
 )
 
 func missingContextErr(ctxKey *contextKey) *MissingContextErr {
@@ -191,26 +191,8 @@ func RootDirectory(ctx context.Context) (string, bool) {
 	return *rootDir, true
 }
 
-func WithServerID(ctx context.Context, id *string) context.Context {
-	return context.WithValue(ctx, ctxServerID, id)
-}
-
-func SetServerID(ctx context.Context, id string) error {
-	serverID, ok := ctx.Value(ctxServerID).(*string)
-	if !ok {
-		return missingContextErr(ctxServerID)
-	}
-
-	*serverID = id
-	return nil
-}
-
-func ServerID(ctx context.Context) (string, bool) {
-	serverID, ok := ctx.Value(ctxServerID).(*string)
-	if !ok {
-		return "", false
-	}
-	return *serverID, true
+func WithCommandPrefix(ctx context.Context, prefix *string) context.Context {
+	return context.WithValue(ctx, ctxCommandPrefix, prefix)
 }
 
 func WithRootModuleWalker(ctx context.Context, w *rootmodule.Walker) context.Context {

--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -35,7 +35,6 @@ var (
 	ctxRootModuleLoader  = &contextKey{"root module loader"}
 	ctxRootDir           = &contextKey{"root directory"}
 	ctxDiags             = &contextKey{"diagnostics"}
-	ctxCommandPrefix     = &contextKey{"command prefix"}
 )
 
 func missingContextErr(ctxKey *contextKey) *MissingContextErr {
@@ -189,10 +188,6 @@ func RootDirectory(ctx context.Context) (string, bool) {
 		return "", false
 	}
 	return *rootDir, true
-}
-
-func WithCommandPrefix(ctx context.Context, prefix *string) context.Context {
-	return context.WithValue(ctx, ctxCommandPrefix, prefix)
 }
 
 func WithRootModuleWalker(ctx context.Context, w *rootmodule.Walker) context.Context {

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -10,7 +10,7 @@ type Options struct {
 	// RootModulePaths describes a list of absolute paths to root modules
 	RootModulePaths    []string `mapstructure:"rootModulePaths"`
 	ExcludeModulePaths []string `mapstructure:"excludeModulePaths"`
-	ID                 string   `mapstructure:"id"`
+	CommandPrefix      string   `mapstructure:"commandPrefix"`
 
 	// TODO: Need to check for conflict with CLI flags
 	// TerraformExecPath string

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -2,6 +2,7 @@ package settings
 
 import (
 	"fmt"
+
 	"github.com/mitchellh/mapstructure"
 )
 
@@ -9,6 +10,7 @@ type Options struct {
 	// RootModulePaths describes a list of absolute paths to root modules
 	RootModulePaths    []string `mapstructure:"rootModulePaths"`
 	ExcludeModulePaths []string `mapstructure:"excludeModulePaths"`
+	ID                 string   `mapstructure:"id"`
 
 	// TODO: Need to check for conflict with CLI flags
 	// TerraformExecPath string

--- a/langserver/handlers/execute_command.go
+++ b/langserver/handlers/execute_command.go
@@ -27,10 +27,8 @@ func prefix(name string) string {
 }
 
 func (h executeCommandHandlers) Init(p string) executeCommandHandlers {
-	if len(h) == 0 {
-		commandPrefix = p
-		h[prefix("rootmodules")] = executeCommandRootModulesHandler
-	}
+	commandPrefix = p
+	h[prefix("rootmodules")] = executeCommandRootModulesHandler
 	return h
 }
 

--- a/langserver/handlers/execute_command.go
+++ b/langserver/handlers/execute_command.go
@@ -17,10 +17,10 @@ type executeCommandHandlers map[string]executeCommandHandler
 const langServerPrefix = "terraform-ls."
 
 var handlers = executeCommandHandlers{
-	prefix("rootmodules"): executeCommandRootModulesHandler,
+	prefixCommandName("rootmodules"): executeCommandRootModulesHandler,
 }
 
-func prefix(name string) string {
+func prefixCommandName(name string) string {
 	return langServerPrefix + name
 }
 

--- a/langserver/handlers/execute_command_rootmodules_test.go
+++ b/langserver/handlers/execute_command_rootmodules_test.go
@@ -50,9 +50,9 @@ func TestLangServer_workspaceExecuteCommand_rootmodules_argumentError(t *testing
 
 	ls.CallAndExpectError(t, &langserver.CallRequest{
 		Method: "workspace/executeCommand",
-		ReqParams: `{
-		"command": "rootmodules"
-	}`}, code.InvalidParams.Err())
+		ReqParams: fmt.Sprintf(`{
+		"command": "terraform-ls.rootmodules.%s"
+	}`, tmpDir.URI())}, code.InvalidParams.Err())
 }
 
 func TestLangServer_workspaceExecuteCommand_rootmodules_basic(t *testing.T) {
@@ -95,9 +95,9 @@ func TestLangServer_workspaceExecuteCommand_rootmodules_basic(t *testing.T) {
 	ls.CallAndExpectResponse(t, &langserver.CallRequest{
 		Method: "workspace/executeCommand",
 		ReqParams: fmt.Sprintf(`{
-		"command": "rootmodules",
+		"command": "terraform-ls.rootmodules.%s",
 		"arguments": ["uri=%s"] 
-	}`, testFileURI)}, fmt.Sprintf(`{
+	}`, tmpDir.URI(), testFileURI)}, fmt.Sprintf(`{
 		"jsonrpc": "2.0",
 		"id": 3,
 		"result": {
@@ -158,9 +158,9 @@ func TestLangServer_workspaceExecuteCommand_rootmodules_multiple(t *testing.T) {
 	ls.CallAndExpectResponse(t, &langserver.CallRequest{
 		Method: "workspace/executeCommand",
 		ReqParams: fmt.Sprintf(`{
-		"command": "rootmodules",
+		"command": "terraform-ls.rootmodules.%s",
 		"arguments": ["uri=%s"] 
-	}`, module.URI())}, fmt.Sprintf(`{
+	}`, root.URI(), module.URI())}, fmt.Sprintf(`{
 		"jsonrpc": "2.0",
 		"id": 2,
 		"result": {

--- a/langserver/handlers/execute_command_rootmodules_test.go
+++ b/langserver/handlers/execute_command_rootmodules_test.go
@@ -31,10 +31,7 @@ func TestLangServer_workspaceExecuteCommand_rootmodules_argumentError(t *testing
 		ReqParams: fmt.Sprintf(`{
 	    "capabilities": {},
 	    "rootUri": %q,
-		"processId": 12345,
-		"initializationOptions": {
-			"id": "1"
-		}
+		"processId": 12345
 	}`, tmpDir.URI())})
 	ls.Notify(t, &langserver.CallRequest{
 		Method:    "initialized",
@@ -54,8 +51,8 @@ func TestLangServer_workspaceExecuteCommand_rootmodules_argumentError(t *testing
 	ls.CallAndExpectError(t, &langserver.CallRequest{
 		Method: "workspace/executeCommand",
 		ReqParams: fmt.Sprintf(`{
-		"command": "terraform-ls.rootmodules.1"
-	}`)}, code.InvalidParams.Err())
+		"command": %q
+	}`, prefix("rootmodules"))}, code.InvalidParams.Err())
 }
 
 func TestLangServer_workspaceExecuteCommand_rootmodules_basic(t *testing.T) {
@@ -78,10 +75,7 @@ func TestLangServer_workspaceExecuteCommand_rootmodules_basic(t *testing.T) {
 		ReqParams: fmt.Sprintf(`{
 	    "capabilities": {},
 	    "rootUri": %q,
-		"processId": 12345,
-		"initializationOptions": {
-			"id": "1"
-		}
+		"processId": 12345
 	}`, tmpDir.URI())})
 	ls.Notify(t, &langserver.CallRequest{
 		Method:    "initialized",
@@ -101,9 +95,9 @@ func TestLangServer_workspaceExecuteCommand_rootmodules_basic(t *testing.T) {
 	ls.CallAndExpectResponse(t, &langserver.CallRequest{
 		Method: "workspace/executeCommand",
 		ReqParams: fmt.Sprintf(`{
-		"command": "terraform-ls.rootmodules.1",
+		"command": %q,
 		"arguments": ["uri=%s"] 
-	}`, testFileURI)}, fmt.Sprintf(`{
+	}`, prefix("rootmodules"), testFileURI)}, fmt.Sprintf(`{
 		"jsonrpc": "2.0",
 		"id": 3,
 		"result": {
@@ -152,10 +146,7 @@ func TestLangServer_workspaceExecuteCommand_rootmodules_multiple(t *testing.T) {
 		ReqParams: fmt.Sprintf(`{
 	    "capabilities": {},
 	    "rootUri": %q,
-		"processId": 12345,
-		"initializationOptions": {
-			"id": "1"
-		}
+		"processId": 12345
 	}`, root.URI())})
 	ls.Notify(t, &langserver.CallRequest{
 		Method:    "initialized",
@@ -167,9 +158,9 @@ func TestLangServer_workspaceExecuteCommand_rootmodules_multiple(t *testing.T) {
 	ls.CallAndExpectResponse(t, &langserver.CallRequest{
 		Method: "workspace/executeCommand",
 		ReqParams: fmt.Sprintf(`{
-		"command": "terraform-ls.rootmodules.1",
+		"command": %q,
 		"arguments": ["uri=%s"] 
-	}`, module.URI())}, fmt.Sprintf(`{
+	}`, prefix("rootmodules"), module.URI())}, fmt.Sprintf(`{
 		"jsonrpc": "2.0",
 		"id": 2,
 		"result": {

--- a/langserver/handlers/execute_command_rootmodules_test.go
+++ b/langserver/handlers/execute_command_rootmodules_test.go
@@ -31,7 +31,10 @@ func TestLangServer_workspaceExecuteCommand_rootmodules_argumentError(t *testing
 		ReqParams: fmt.Sprintf(`{
 	    "capabilities": {},
 	    "rootUri": %q,
-	    "processId": 12345
+		"processId": 12345,
+		"initializationOptions": {
+			"id": "1"
+		}
 	}`, tmpDir.URI())})
 	ls.Notify(t, &langserver.CallRequest{
 		Method:    "initialized",
@@ -51,8 +54,8 @@ func TestLangServer_workspaceExecuteCommand_rootmodules_argumentError(t *testing
 	ls.CallAndExpectError(t, &langserver.CallRequest{
 		Method: "workspace/executeCommand",
 		ReqParams: fmt.Sprintf(`{
-		"command": "terraform-ls.rootmodules.%s"
-	}`, tmpDir.URI())}, code.InvalidParams.Err())
+		"command": "terraform-ls.rootmodules.1"
+	}`)}, code.InvalidParams.Err())
 }
 
 func TestLangServer_workspaceExecuteCommand_rootmodules_basic(t *testing.T) {
@@ -75,7 +78,10 @@ func TestLangServer_workspaceExecuteCommand_rootmodules_basic(t *testing.T) {
 		ReqParams: fmt.Sprintf(`{
 	    "capabilities": {},
 	    "rootUri": %q,
-	    "processId": 12345
+		"processId": 12345,
+		"initializationOptions": {
+			"id": "1"
+		}
 	}`, tmpDir.URI())})
 	ls.Notify(t, &langserver.CallRequest{
 		Method:    "initialized",
@@ -95,9 +101,9 @@ func TestLangServer_workspaceExecuteCommand_rootmodules_basic(t *testing.T) {
 	ls.CallAndExpectResponse(t, &langserver.CallRequest{
 		Method: "workspace/executeCommand",
 		ReqParams: fmt.Sprintf(`{
-		"command": "terraform-ls.rootmodules.%s",
+		"command": "terraform-ls.rootmodules.1",
 		"arguments": ["uri=%s"] 
-	}`, tmpDir.URI(), testFileURI)}, fmt.Sprintf(`{
+	}`, testFileURI)}, fmt.Sprintf(`{
 		"jsonrpc": "2.0",
 		"id": 3,
 		"result": {
@@ -146,7 +152,10 @@ func TestLangServer_workspaceExecuteCommand_rootmodules_multiple(t *testing.T) {
 		ReqParams: fmt.Sprintf(`{
 	    "capabilities": {},
 	    "rootUri": %q,
-	    "processId": 12345
+		"processId": 12345,
+		"initializationOptions": {
+			"id": "1"
+		}
 	}`, root.URI())})
 	ls.Notify(t, &langserver.CallRequest{
 		Method:    "initialized",
@@ -158,9 +167,9 @@ func TestLangServer_workspaceExecuteCommand_rootmodules_multiple(t *testing.T) {
 	ls.CallAndExpectResponse(t, &langserver.CallRequest{
 		Method: "workspace/executeCommand",
 		ReqParams: fmt.Sprintf(`{
-		"command": "terraform-ls.rootmodules.%s",
+		"command": "terraform-ls.rootmodules.1",
 		"arguments": ["uri=%s"] 
-	}`, root.URI(), module.URI())}, fmt.Sprintf(`{
+	}`, module.URI())}, fmt.Sprintf(`{
 		"jsonrpc": "2.0",
 		"id": 2,
 		"result": {

--- a/langserver/handlers/execute_command_rootmodules_test.go
+++ b/langserver/handlers/execute_command_rootmodules_test.go
@@ -52,7 +52,7 @@ func TestLangServer_workspaceExecuteCommand_rootmodules_argumentError(t *testing
 		Method: "workspace/executeCommand",
 		ReqParams: fmt.Sprintf(`{
 		"command": %q
-	}`, prefix("rootmodules"))}, code.InvalidParams.Err())
+	}`, prefixCommandName("rootmodules"))}, code.InvalidParams.Err())
 }
 
 func TestLangServer_workspaceExecuteCommand_rootmodules_basic(t *testing.T) {
@@ -97,7 +97,7 @@ func TestLangServer_workspaceExecuteCommand_rootmodules_basic(t *testing.T) {
 		ReqParams: fmt.Sprintf(`{
 		"command": %q,
 		"arguments": ["uri=%s"] 
-	}`, prefix("rootmodules"), testFileURI)}, fmt.Sprintf(`{
+	}`, prefixCommandName("rootmodules"), testFileURI)}, fmt.Sprintf(`{
 		"jsonrpc": "2.0",
 		"id": 3,
 		"result": {
@@ -160,7 +160,7 @@ func TestLangServer_workspaceExecuteCommand_rootmodules_multiple(t *testing.T) {
 		ReqParams: fmt.Sprintf(`{
 		"command": %q,
 		"arguments": ["uri=%s"] 
-	}`, prefix("rootmodules"), module.URI())}, fmt.Sprintf(`{
+	}`, prefixCommandName("rootmodules"), module.URI())}, fmt.Sprintf(`{
 		"jsonrpc": "2.0",
 		"id": 2,
 		"result": {

--- a/langserver/handlers/handlers_test.go
+++ b/langserver/handlers/handlers_test.go
@@ -17,8 +17,8 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-func initializeResponse(t *testing.T, rootUri string) string {
-	jsonArray, err := json.Marshal(handlers.Names("." + rootUri))
+func initializeResponse(t *testing.T, commandSuffix string) string {
+	jsonArray, err := json.Marshal(handlers.Names("." + commandSuffix))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -58,8 +58,11 @@ func TestInitalizeAndShutdown(t *testing.T) {
 		ReqParams: fmt.Sprintf(`{
 	    "capabilities": {},
 	    "rootUri": %q,
-	    "processId": 12345
-	}`, tmpDir.URI())}, initializeResponse(t, tmpDir.URI()))
+		"processId": 12345,
+		"initializationOptions": {
+			"id": "1"
+		}
+	}`, tmpDir.URI())}, initializeResponse(t, "1"))
 	ls.CallAndExpectResponse(t, &langserver.CallRequest{
 		Method: "shutdown", ReqParams: `{}`},
 		`{
@@ -85,8 +88,11 @@ func TestEOF(t *testing.T) {
 		ReqParams: fmt.Sprintf(`{
 	    "capabilities": {},
 	    "rootUri": %q,
-	    "processId": 12345
-	}`, tmpDir.URI())}, initializeResponse(t, tmpDir.URI()))
+		"processId": 12345,
+		"initializationOptions": {
+			"id": "1"
+		}
+	}`, tmpDir.URI())}, initializeResponse(t, "1"))
 
 	ls.CloseClientStdout(t)
 

--- a/langserver/handlers/handlers_test.go
+++ b/langserver/handlers/handlers_test.go
@@ -17,8 +17,8 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-func initializeResponse(t *testing.T) string {
-	jsonArray, err := json.Marshal(handlers.Names())
+func initializeResponse(t *testing.T, commandPrefix string) string {
+	jsonArray, err := json.Marshal(handlers.Names(commandPrefix))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -44,8 +44,6 @@ func initializeResponse(t *testing.T) string {
 }
 
 func TestInitalizeAndShutdown(t *testing.T) {
-	handlers = make(executeCommandHandlers)
-	handlers.Init("")
 	tmpDir := TempDir(t)
 
 	ls := langserver.NewLangServerMock(t, NewMockSession(&MockSessionInput{
@@ -61,7 +59,7 @@ func TestInitalizeAndShutdown(t *testing.T) {
 	    "capabilities": {},
 	    "rootUri": %q,
 		"processId": 12345
-	}`, tmpDir.URI())}, initializeResponse(t))
+	}`, tmpDir.URI())}, initializeResponse(t, ""))
 	ls.CallAndExpectResponse(t, &langserver.CallRequest{
 		Method: "shutdown", ReqParams: `{}`},
 		`{
@@ -72,8 +70,6 @@ func TestInitalizeAndShutdown(t *testing.T) {
 }
 
 func TestInitalizeWithCommandPrefix(t *testing.T) {
-	handlers = make(executeCommandHandlers)
-	handlers.Init("1")
 	tmpDir := TempDir(t)
 
 	ls := langserver.NewLangServerMock(t, NewMockSession(&MockSessionInput{
@@ -92,12 +88,10 @@ func TestInitalizeWithCommandPrefix(t *testing.T) {
 		"initializationOptions": {
 			"commandPrefix": "1"
 		}
-	}`, tmpDir.URI())}, initializeResponse(t))
+	}`, tmpDir.URI())}, initializeResponse(t, "1"))
 }
 
 func TestEOF(t *testing.T) {
-	handlers = make(executeCommandHandlers)
-	handlers.Init("")
 	tmpDir := TempDir(t)
 
 	ms := newMockSession(&MockSessionInput{
@@ -114,7 +108,7 @@ func TestEOF(t *testing.T) {
 	    "capabilities": {},
 	    "rootUri": %q,
 		"processId": 12345
-	}`, tmpDir.URI())}, initializeResponse(t))
+	}`, tmpDir.URI())}, initializeResponse(t, ""))
 
 	ls.CloseClientStdout(t)
 

--- a/langserver/handlers/handlers_test.go
+++ b/langserver/handlers/handlers_test.go
@@ -17,8 +17,8 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-func initializeResponse(t *testing.T, prefix string) string {
-	jsonArray, err := json.Marshal(handlers.Init(prefix).Names())
+func initializeResponse(t *testing.T) string {
+	jsonArray, err := json.Marshal(handlers.Names())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -44,6 +44,8 @@ func initializeResponse(t *testing.T, prefix string) string {
 }
 
 func TestInitalizeAndShutdown(t *testing.T) {
+	handlers = make(executeCommandHandlers)
+	handlers.Init("")
 	tmpDir := TempDir(t)
 
 	ls := langserver.NewLangServerMock(t, NewMockSession(&MockSessionInput{
@@ -59,7 +61,7 @@ func TestInitalizeAndShutdown(t *testing.T) {
 	    "capabilities": {},
 	    "rootUri": %q,
 		"processId": 12345
-	}`, tmpDir.URI())}, initializeResponse(t, ""))
+	}`, tmpDir.URI())}, initializeResponse(t))
 	ls.CallAndExpectResponse(t, &langserver.CallRequest{
 		Method: "shutdown", ReqParams: `{}`},
 		`{
@@ -70,6 +72,8 @@ func TestInitalizeAndShutdown(t *testing.T) {
 }
 
 func TestInitalizeWithCommandPrefix(t *testing.T) {
+	handlers = make(executeCommandHandlers)
+	handlers.Init("1")
 	tmpDir := TempDir(t)
 
 	ls := langserver.NewLangServerMock(t, NewMockSession(&MockSessionInput{
@@ -88,10 +92,12 @@ func TestInitalizeWithCommandPrefix(t *testing.T) {
 		"initializationOptions": {
 			"commandPrefix": "1"
 		}
-	}`, tmpDir.URI())}, initializeResponse(t, "1"))
+	}`, tmpDir.URI())}, initializeResponse(t))
 }
 
 func TestEOF(t *testing.T) {
+	handlers = make(executeCommandHandlers)
+	handlers.Init("")
 	tmpDir := TempDir(t)
 
 	ms := newMockSession(&MockSessionInput{
@@ -108,7 +114,7 @@ func TestEOF(t *testing.T) {
 	    "capabilities": {},
 	    "rootUri": %q,
 		"processId": 12345
-	}`, tmpDir.URI())}, initializeResponse(t, ""))
+	}`, tmpDir.URI())}, initializeResponse(t))
 
 	ls.CloseClientStdout(t)
 

--- a/langserver/handlers/handlers_test.go
+++ b/langserver/handlers/handlers_test.go
@@ -69,6 +69,28 @@ func TestInitalizeAndShutdown(t *testing.T) {
 	}`)
 }
 
+func TestInitalizeWithCommandPrefix(t *testing.T) {
+	tmpDir := TempDir(t)
+
+	ls := langserver.NewLangServerMock(t, NewMockSession(&MockSessionInput{
+		RootModules: map[string]*rootmodule.RootModuleMock{
+			tmpDir.Dir(): {TfExecFactory: validTfMockCalls()},
+		}}))
+	stop := ls.Start(t)
+	defer stop()
+
+	ls.CallAndExpectResponse(t, &langserver.CallRequest{
+		Method: "initialize",
+		ReqParams: fmt.Sprintf(`{
+	    "capabilities": {},
+	    "rootUri": %q,
+		"processId": 12345,
+		"initializationOptions": {
+			"commandPrefix": "1"
+		}
+	}`, tmpDir.URI())}, initializeResponse(t, "1"))
+}
+
 func TestEOF(t *testing.T) {
 	tmpDir := TempDir(t)
 

--- a/langserver/handlers/handlers_test.go
+++ b/langserver/handlers/handlers_test.go
@@ -17,8 +17,8 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-func initializeResponse(t *testing.T, commandSuffix string) string {
-	jsonArray, err := json.Marshal(handlers.Names("." + commandSuffix))
+func initializeResponse(t *testing.T, prefix string) string {
+	jsonArray, err := json.Marshal(handlers.Init(prefix).Names())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -58,11 +58,8 @@ func TestInitalizeAndShutdown(t *testing.T) {
 		ReqParams: fmt.Sprintf(`{
 	    "capabilities": {},
 	    "rootUri": %q,
-		"processId": 12345,
-		"initializationOptions": {
-			"id": "1"
-		}
-	}`, tmpDir.URI())}, initializeResponse(t, "1"))
+		"processId": 12345
+	}`, tmpDir.URI())}, initializeResponse(t, ""))
 	ls.CallAndExpectResponse(t, &langserver.CallRequest{
 		Method: "shutdown", ReqParams: `{}`},
 		`{
@@ -88,11 +85,8 @@ func TestEOF(t *testing.T) {
 		ReqParams: fmt.Sprintf(`{
 	    "capabilities": {},
 	    "rootUri": %q,
-		"processId": 12345,
-		"initializationOptions": {
-			"id": "1"
-		}
-	}`, tmpDir.URI())}, initializeResponse(t, "1"))
+		"processId": 12345
+	}`, tmpDir.URI())}, initializeResponse(t, ""))
 
 	ls.CloseClientStdout(t)
 

--- a/langserver/handlers/initialize.go
+++ b/langserver/handlers/initialize.go
@@ -75,14 +75,9 @@ func (lh *logHandler) Initialize(ctx context.Context, params lsp.InitializeParam
 		return serverCaps, err
 	}
 
-	// set server ID
-	err = lsctx.SetServerID(ctx, out.Options.ID)
-	if err != nil {
-		return serverCaps, err
-	}
-	// apply suffix to executeCommand handler names
+	// apply prefix to executeCommand handler names
 	serverCaps.Capabilities.ExecuteCommandProvider = &lsp.ExecuteCommandOptions{
-		Commands: handlers.Names(out.Options.ID),
+		Commands: handlers.Init(out.Options.CommandPrefix).Names(),
 	}
 	if len(out.UnusedKeys) > 0 {
 		jrpc2.PushNotify(ctx, "window/showMessage", &lsp.ShowMessageParams{

--- a/langserver/handlers/initialize.go
+++ b/langserver/handlers/initialize.go
@@ -29,7 +29,7 @@ func (lh *logHandler) Initialize(ctx context.Context, params lsp.InitializeParam
 			DocumentFormattingProvider: true,
 			DocumentSymbolProvider:     true,
 			ExecuteCommandProvider: &lsp.ExecuteCommandOptions{
-				Commands: handlers.Names(),
+				Commands: handlers.Names("." + string(params.RootURI)),
 			},
 		},
 	}

--- a/langserver/handlers/initialize.go
+++ b/langserver/handlers/initialize.go
@@ -28,9 +28,6 @@ func (lh *logHandler) Initialize(ctx context.Context, params lsp.InitializeParam
 			},
 			DocumentFormattingProvider: true,
 			DocumentSymbolProvider:     true,
-			ExecuteCommandProvider: &lsp.ExecuteCommandOptions{
-				Commands: handlers.Names("." + string(params.RootURI)),
-			},
 		},
 	}
 
@@ -76,6 +73,16 @@ func (lh *logHandler) Initialize(ctx context.Context, params lsp.InitializeParam
 	err = out.Options.Validate()
 	if err != nil {
 		return serverCaps, err
+	}
+
+	// set server ID
+	err = lsctx.SetServerID(ctx, out.Options.ID)
+	if err != nil {
+		return serverCaps, err
+	}
+	// apply suffix to executeCommand handler names
+	serverCaps.Capabilities.ExecuteCommandProvider = &lsp.ExecuteCommandOptions{
+		Commands: handlers.Names(out.Options.ID),
 	}
 	if len(out.UnusedKeys) > 0 {
 		jrpc2.PushNotify(ctx, "window/showMessage", &lsp.ShowMessageParams{

--- a/langserver/handlers/initialize.go
+++ b/langserver/handlers/initialize.go
@@ -75,10 +75,13 @@ func (lh *logHandler) Initialize(ctx context.Context, params lsp.InitializeParam
 		return serverCaps, err
 	}
 
+	// set commandPrefix for session
+	lsctx.SetCommandPrefix(ctx, out.Options.CommandPrefix)
 	// apply prefix to executeCommand handler names
 	serverCaps.Capabilities.ExecuteCommandProvider = &lsp.ExecuteCommandOptions{
-		Commands: handlers.Init(out.Options.CommandPrefix).Names(),
+		Commands: handlers.Names(out.Options.CommandPrefix),
 	}
+
 	if len(out.UnusedKeys) > 0 {
 		jrpc2.PushNotify(ctx, "window/showMessage", &lsp.ShowMessageParams{
 			Type:    lsp.MTWarning,

--- a/langserver/handlers/service.go
+++ b/langserver/handlers/service.go
@@ -145,6 +145,7 @@ func (svc *service) Assigner() (jrpc2.Assigner, error) {
 	diags := diagnostics.NewNotifier(svc.sessCtx, svc.logger)
 
 	rootDir := ""
+	commandPrefix := ""
 
 	m := map[string]rpch.Func{
 		"initialize": func(ctx context.Context, req *jrpc2.Request) (interface{}, error) {
@@ -157,6 +158,7 @@ func (svc *service) Assigner() (jrpc2.Assigner, error) {
 			ctx = lsctx.WithWatcher(ctx, ww)
 			ctx = lsctx.WithRootModuleWalker(ctx, svc.walker)
 			ctx = lsctx.WithRootDirectory(ctx, &rootDir)
+			ctx = lsctx.WithCommandPrefix(ctx, &commandPrefix)
 			ctx = lsctx.WithRootModuleManager(ctx, svc.modMgr)
 			ctx = lsctx.WithRootModuleLoader(ctx, rmLoader)
 
@@ -240,6 +242,7 @@ func (svc *service) Assigner() (jrpc2.Assigner, error) {
 				return nil, err
 			}
 
+			ctx = lsctx.WithCommandPrefix(ctx, &commandPrefix)
 			ctx = lsctx.WithRootModuleCandidateFinder(ctx, svc.modMgr)
 			ctx = lsctx.WithRootModuleWalker(ctx, svc.walker)
 

--- a/langserver/handlers/service.go
+++ b/langserver/handlers/service.go
@@ -145,7 +145,6 @@ func (svc *service) Assigner() (jrpc2.Assigner, error) {
 	diags := diagnostics.NewNotifier(svc.sessCtx, svc.logger)
 
 	rootDir := ""
-	serverID := ""
 
 	m := map[string]rpch.Func{
 		"initialize": func(ctx context.Context, req *jrpc2.Request) (interface{}, error) {
@@ -158,7 +157,6 @@ func (svc *service) Assigner() (jrpc2.Assigner, error) {
 			ctx = lsctx.WithWatcher(ctx, ww)
 			ctx = lsctx.WithRootModuleWalker(ctx, svc.walker)
 			ctx = lsctx.WithRootDirectory(ctx, &rootDir)
-			ctx = lsctx.WithServerID(ctx, &serverID)
 			ctx = lsctx.WithRootModuleManager(ctx, svc.modMgr)
 			ctx = lsctx.WithRootModuleLoader(ctx, rmLoader)
 
@@ -242,7 +240,6 @@ func (svc *service) Assigner() (jrpc2.Assigner, error) {
 				return nil, err
 			}
 
-			ctx = lsctx.WithServerID(ctx, &serverID)
 			ctx = lsctx.WithRootModuleCandidateFinder(ctx, svc.modMgr)
 			ctx = lsctx.WithRootModuleWalker(ctx, svc.walker)
 

--- a/langserver/handlers/service.go
+++ b/langserver/handlers/service.go
@@ -145,6 +145,7 @@ func (svc *service) Assigner() (jrpc2.Assigner, error) {
 	diags := diagnostics.NewNotifier(svc.sessCtx, svc.logger)
 
 	rootDir := ""
+	serverID := ""
 
 	m := map[string]rpch.Func{
 		"initialize": func(ctx context.Context, req *jrpc2.Request) (interface{}, error) {
@@ -157,6 +158,7 @@ func (svc *service) Assigner() (jrpc2.Assigner, error) {
 			ctx = lsctx.WithWatcher(ctx, ww)
 			ctx = lsctx.WithRootModuleWalker(ctx, svc.walker)
 			ctx = lsctx.WithRootDirectory(ctx, &rootDir)
+			ctx = lsctx.WithServerID(ctx, &serverID)
 			ctx = lsctx.WithRootModuleManager(ctx, svc.modMgr)
 			ctx = lsctx.WithRootModuleLoader(ctx, rmLoader)
 
@@ -240,7 +242,7 @@ func (svc *service) Assigner() (jrpc2.Assigner, error) {
 				return nil, err
 			}
 
-			ctx = lsctx.WithRootDirectory(ctx, &rootDir)
+			ctx = lsctx.WithServerID(ctx, &serverID)
 			ctx = lsctx.WithRootModuleCandidateFinder(ctx, svc.modMgr)
 			ctx = lsctx.WithRootModuleWalker(ctx, svc.walker)
 


### PR DESCRIPTION
This PR ensures the uniqueness of the exported commands across different language servers (with a `terraform-ls.` prefix, this is a common practice) and an additional `<commandPrefix>.`, this latter ensures multiple instances of the language server can run side by side, it will become the clients responsibility to send requests with the correct command name, the `commandPrefix` is only enabled if specified in the `initializationOptions` for the server.
```
"executeCommandProvider": {
    "commands": ["1234.terraform-ls.rootmodules"]
}
```

Closes #278 