### PR TITLE
Add support for upcoming Terraform v0.14

### DIFF
--- a/internal/terraform/rootmodule/plugin_lock_file.go
+++ b/internal/terraform/rootmodule/plugin_lock_file.go
@@ -7,6 +7,10 @@ import (
 
 func pluginLockFilePaths(dir string) []string {
 	return []string{
+		// Terraform >= 0.14
+		filepath.Join(dir,
+			".terraform.lock.hcl",
+		),
 		// Terraform >= v0.13
 		filepath.Join(dir,
 			".terraform",


### PR DESCRIPTION
As mentioned in https://github.com/hashicorp/terraform-ls/issues/282 v0.14 uses different path for the plugin lock file. This PR reflects that.

Currently we only use the path to detect whether there are any plugins initialized and to detect plugin changes, i.e. we don't care about the file contents which made this change easier than originally expected.

Closes #282 

### Before
![Screenshot 2020-11-11 at 15 29 39](https://user-images.githubusercontent.com/287584/98830810-bb0ba780-2432-11eb-8ae2-025e73ea09e4.png)

### After

![Screenshot 2020-11-11 at 15 28 31](https://user-images.githubusercontent.com/287584/98830827-bfd05b80-2432-11eb-8afd-c13d502c5cfe.png)
