### PR TITLE
Avoid ignoring schema for uninitialized module

### DIFF
--- a/internal/terraform/rootmodule/root_module_manager.go
+++ b/internal/terraform/rootmodule/root_module_manager.go
@@ -142,7 +142,13 @@ func (rmm *rootModuleManager) SchemaForPath(path string) (*schema.BodySchema, er
 			return schema, nil
 		}
 	}
-	return nil, fmt.Errorf("failed to find schema for %s", path)
+
+	rm, err := rmm.RootModuleByPath(path)
+	if err != nil {
+		return nil, err
+	}
+
+	return rm.MergedSchema()
 }
 
 func (rmm *rootModuleManager) rootModuleByPath(dir string) (*rootModule, bool) {

--- a/internal/terraform/rootmodule/root_module_manager_test.go
+++ b/internal/terraform/rootmodule/root_module_manager_test.go
@@ -457,6 +457,27 @@ func TestRootModuleManager_RootModuleCandidatesByPath(t *testing.T) {
 	}
 }
 
+func TestSchemaForPath_uninitialized(t *testing.T) {
+	rmm := testRootModuleManager(t)
+
+	testData, err := filepath.Abs("testdata")
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(testData, "uninitialized-root")
+
+	// model is added automatically during didOpen
+	_, err = rmm.AddAndStartLoadingRootModule(context.Background(), path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = rmm.SchemaForPath(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func testRootModuleManager(t *testing.T) *rootModuleManager {
 	fs := filesystem.NewFilesystem()
 	rmm := newRootModuleManager(fs)

--- a/internal/terraform/rootmodule/testdata/README.md
+++ b/internal/terraform/rootmodule/testdata/README.md
@@ -23,3 +23,7 @@ which the language server supports and is tested against.
  - `multi-root-no-modules`
  - `multi-root-local-modules-down`
  - `multi-root-local-modules-up` - e.g. https://github.com/terraform-aws-modules/terraform-aws-security-group
+
+## Uninitialized Root
+
+ - `uninitialized-root`

--- a/internal/terraform/rootmodule/testdata/uninitialized-root/main.tf
+++ b/internal/terraform/rootmodule/testdata/uninitialized-root/main.tf
@@ -1,0 +1,3 @@
+variable "meal" {
+  default = "delicious"
+}


### PR DESCRIPTION
This was just overlooked in the big PR https://github.com/hashicorp/terraform-ls/pull/281

#281 did (correctly) provide basic schema in cases where e.g. modules were initialized, but no provider schema available (e.g. because of backend auth).

This patch just delivers on the originally stated promise as mentioned in the changelog - i.e. to provide limited schema even to folks which have not initialized anything at all, i.e. there is no `.terraform` folder.