### PR TITLE
Avoid panic by initing universal schema early

### DIFF
--- a/internal/terraform/rootmodule/root_module_manager.go
+++ b/internal/terraform/rootmodule/root_module_manager.go
@@ -219,15 +219,6 @@ func (rmm *rootModuleManager) RootModuleByPath(path string) (RootModule, error) 
 	return nil, &RootModuleNotFoundErr{path}
 }
 
-func (rmm *rootModuleManager) IsCoreSchemaLoaded(path string) (bool, error) {
-	rm, err := rmm.RootModuleByPath(path)
-	if err != nil {
-		return false, err
-	}
-
-	return rm.IsCoreSchemaLoaded(), nil
-}
-
 func (rmm *rootModuleManager) IsProviderSchemaLoaded(path string) (bool, error) {
 	rm, err := rmm.RootModuleByPath(path)
 	if err != nil {

--- a/internal/terraform/rootmodule/types.go
+++ b/internal/terraform/rootmodule/types.go
@@ -77,7 +77,6 @@ type RootModule interface {
 	IsParsed() bool
 	ParseFiles() error
 	ParsedDiagnostics() map[string]hcl.Diagnostics
-	IsCoreSchemaLoaded() bool
 	TerraformFormatter() (exec.Formatter, error)
 	HasTerraformDiscoveryFinished() bool
 	IsTerraformAvailable() bool


### PR DESCRIPTION
This fixes a race condition which is difficult to reproduce, but https://github.com/hashicorp/terraform-schema/issues/7 has the relevant panic trace.

This practically delivers on the promise mentioned here https://github.com/hashicorp/terraform-ls/blob/612cceb828a8e2abc89088582a6fd6c10c3ca509/internal/terraform/rootmodule/root_module.go#L245-L249

In other words I thought this was already done but I must have missed it in https://github.com/hashicorp/terraform-ls/pull/281