### PR TITLE
Capture editor.action.triggerSuggest to avoid errors

### DIFF
--- a/langserver/handlers/execute_command.go
+++ b/langserver/handlers/execute_command.go
@@ -44,6 +44,13 @@ func (h executeCommandHandlers) Get(name, commandPrefix string) (executeCommandH
 }
 
 func (lh *logHandler) WorkspaceExecuteCommand(ctx context.Context, params lsp.ExecuteCommandParams) (interface{}, error) {
+	if params.Command == "editor.action.triggerSuggest" {
+		// If this was actually received by the server, it means the client
+		// does not support explicit suggest triggering, so we fail silently
+		// TODO: Revisit once https://github.com/microsoft/language-server-protocol/issues/1117 is addressed
+		return nil, nil
+	}
+
 	commandPrefix, _ := lsctx.CommandPrefix(ctx)
 	handler, ok := handlers.Get(params.Command, commandPrefix)
 	if !ok {


### PR DESCRIPTION
This action is actually sent from the server with the expectation that (some) clients will catch it and open the completion box, as demonstrated in #300 

However the clients which do not catch it will just pass it back to the server and assume that it's just another valid command.

Here we avoid "registering" that command alongside others (as we don't want to confuse clients like VS Code which do support it), but we just catch the request, if it makes it back to the server and ignore it.

Fixes #306 