### PR TITLE
fix issue when hoverData is nil

### DIFF
--- a/internal/lsp/hover.go
+++ b/internal/lsp/hover.go
@@ -5,7 +5,10 @@ import (
 	lsp "github.com/hashicorp/terraform-ls/internal/protocol"
 )
 
-func HoverData(data *lang.HoverData, cc lsp.TextDocumentClientCapabilities) lsp.Hover {
+func HoverData(data *lang.HoverData, cc lsp.TextDocumentClientCapabilities) *lsp.Hover {
+	if data == nil {
+		return nil
+	}
 	mdSupported := len(cc.Hover.ContentFormat) > 0 &&
 		cc.Hover.ContentFormat[0] == "markdown"
 
@@ -15,7 +18,7 @@ func HoverData(data *lang.HoverData, cc lsp.TextDocumentClientCapabilities) lsp.
 	//
 	// We choose to follow gopls' approach (i.e. cut off old clients).
 
-	return lsp.Hover{
+	return &lsp.Hover{
 		Contents: markupContent(data.Content, mdSupported),
 		Range:    HCLRangeToLSP(data.Range),
 	}

--- a/langserver/handlers/hover.go
+++ b/langserver/handlers/hover.go
@@ -8,54 +8,52 @@ import (
 	lsp "github.com/hashicorp/terraform-ls/internal/protocol"
 )
 
-func (h *logHandler) TextDocumentHover(ctx context.Context, params lsp.TextDocumentPositionParams) (lsp.Hover, error) {
-	var data lsp.Hover
-
+func (h *logHandler) TextDocumentHover(ctx context.Context, params lsp.TextDocumentPositionParams) (*lsp.Hover, error) {
 	fs, err := lsctx.DocumentStorage(ctx)
 	if err != nil {
-		return data, err
+		return nil, err
 	}
 
 	cc, err := lsctx.ClientCapabilities(ctx)
 	if err != nil {
-		return data, err
+		return nil, err
 	}
 
 	rmf, err := lsctx.RootModuleFinder(ctx)
 	if err != nil {
-		return data, err
+		return nil, err
 	}
 
 	file, err := fs.GetDocument(ilsp.FileHandlerFromDocumentURI(params.TextDocument.URI))
 	if err != nil {
-		return data, err
+		return nil, err
 	}
 
 	rm, err := rmf.RootModuleByPath(file.Dir())
 	if err != nil {
-		return data, err
+		return nil, err
 	}
 
 	schema, err := rmf.SchemaForPath(file.Dir())
 	if err != nil {
-		return data, err
+		return nil, err
 	}
 
 	d, err := rm.DecoderWithSchema(schema)
 	if err != nil {
-		return data, err
+		return nil, err
 	}
 
 	fPos, err := ilsp.FilePositionFromDocumentPosition(params, file)
 	if err != nil {
-		return data, err
+		return nil, err
 	}
 
 	h.logger.Printf("Looking for hover data at %q -> %#v", file.Filename(), fPos.Position())
 	hoverData, err := d.HoverAtPos(file.Filename(), fPos.Position())
-	h.logger.Printf("received hover data: %#v", data)
+	h.logger.Printf("received hover data: %#v", hoverData)
 	if err != nil {
-		return data, err
+		return nil, err
 	}
 
 	return ilsp.HoverData(hoverData, cc.TextDocument), nil


### PR DESCRIPTION
fix #317

tried to return empty `lsp.Hover`, however, the vscode client will complain: `unsupported Markup content received. Kind is: `
![Capture](https://user-images.githubusercontent.com/2786738/100204351-bbca3080-2f3e-11eb-8c44-0d3dd3116c9f.PNG)

The official recommendation is just return `null` from here: https://github.com/Microsoft/language-server-protocol/issues/261

generally two ways：
* make lsp protocol model fields be pointer type.
* in handle function, just return pointer type result

It seems we generate the lsp protocol model, so I just choose the second way.
everything seems fine:
![image](https://user-images.githubusercontent.com/2786738/100204831-5296ed00-2f3f-11eb-97c0-2fa17d166246.png)
