### PR TITLE
Refactor command handlers

### DIFF
--- a/internal/langserver/cmd/cmd.go
+++ b/internal/langserver/cmd/cmd.go
@@ -1,0 +1,34 @@
+package cmd
+
+import (
+	"context"
+	"strings"
+)
+
+type Handler func(context.Context, CommandArgs) (interface{}, error)
+type Handlers map[string]Handler
+
+const langServerPrefix = "terraform-ls."
+
+func Name(name string) string {
+	return langServerPrefix + name
+}
+
+func (h Handlers) Names(commandPrefix string) (names []string) {
+	if commandPrefix != "" {
+		commandPrefix += "."
+	}
+	for name := range h {
+		names = append(names, commandPrefix+name)
+	}
+	return names
+}
+
+func (h Handlers) Get(name, commandPrefix string) (Handler, bool) {
+	if commandPrefix != "" {
+		commandPrefix += "."
+	}
+	name = strings.TrimPrefix(name, commandPrefix)
+	handler, ok := h[name]
+	return handler, ok
+}

--- a/internal/langserver/cmd/cmd_args.go
+++ b/internal/langserver/cmd/cmd_args.go
@@ -1,0 +1,85 @@
+package cmd
+
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+)
+
+type CommandArgs map[string]interface{}
+
+func (c CommandArgs) GetString(variable string) (string, bool) {
+	vRaw, ok := c[variable]
+	if !ok {
+		return "", false
+	}
+	v, ok := vRaw.(string)
+	if !ok {
+		return "", false
+	}
+	return v, true
+}
+
+func (c CommandArgs) GetNumber(variable string) (float64, bool) {
+	vRaw, ok := c[variable]
+	if !ok {
+		return 0, false
+	}
+	v, ok := vRaw.(float64)
+	if !ok {
+		return 0, false
+	}
+	return v, true
+}
+
+func (c CommandArgs) GetBool(variable string) (bool, bool) {
+	vRaw, ok := c[variable]
+	if !ok {
+		return false, false
+	}
+	v, ok := vRaw.(bool)
+	if !ok {
+		return false, false
+	}
+	return v, true
+}
+
+func ParseCommandArgs(arguments []json.RawMessage) CommandArgs {
+	args := make(map[string]interface{})
+	if arguments == nil {
+		return args
+	}
+	for _, rawArg := range arguments {
+		var arg string
+		err := json.Unmarshal(rawArg, &arg)
+		if err != nil {
+			// TODO: Log error
+			continue
+		}
+		if arg == "" {
+			continue
+		}
+
+		pair := strings.SplitN(arg, "=", 2)
+		if len(pair) != 2 {
+			continue
+		}
+
+		variable := strings.ToLower(pair[0])
+		value := pair[1]
+		if value == "" {
+			args[variable] = value
+			continue
+		}
+
+		if f, err := strconv.ParseFloat(value, 64); err == nil {
+			args[variable] = f
+		} else if b, err := strconv.ParseBool(value); err == nil {
+			args[variable] = b
+		} else {
+			args[variable] = value
+		}
+
+	}
+	return args
+}

--- a/internal/langserver/handlers/command/rootmodules.go
+++ b/internal/langserver/handlers/command/rootmodules.go
@@ -1,4 +1,4 @@
-package handlers
+package command
 
 import (
 	"context"
@@ -7,6 +7,7 @@ import (
 
 	"github.com/creachadair/jrpc2/code"
 	lsctx "github.com/hashicorp/terraform-ls/internal/context"
+	"github.com/hashicorp/terraform-ls/internal/langserver/cmd"
 	ilsp "github.com/hashicorp/terraform-ls/internal/lsp"
 	lsp "github.com/hashicorp/terraform-ls/internal/protocol"
 	"github.com/hashicorp/terraform-ls/internal/uri"
@@ -24,7 +25,7 @@ type rootModuleInfo struct {
 	URI string `json:"uri"`
 }
 
-func executeCommandRootModulesHandler(ctx context.Context, args commandArgs) (interface{}, error) {
+func RootModulesHandler(ctx context.Context, args cmd.CommandArgs) (interface{}, error) {
 	walker, err := lsctx.RootModuleWalker(ctx)
 	if err != nil {
 		return nil, err

--- a/internal/langserver/handlers/execute_command_rootmodules_test.go
+++ b/internal/langserver/handlers/execute_command_rootmodules_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/creachadair/jrpc2/code"
 	"github.com/hashicorp/terraform-ls/internal/langserver"
+	"github.com/hashicorp/terraform-ls/internal/langserver/cmd"
 	"github.com/hashicorp/terraform-ls/internal/lsp"
 	"github.com/hashicorp/terraform-ls/internal/terraform/rootmodule"
 )
@@ -52,7 +53,7 @@ func TestLangServer_workspaceExecuteCommand_rootmodules_argumentError(t *testing
 		Method: "workspace/executeCommand",
 		ReqParams: fmt.Sprintf(`{
 		"command": %q
-	}`, prefixCommandName("rootmodules"))}, code.InvalidParams.Err())
+	}`, cmd.Name("rootmodules"))}, code.InvalidParams.Err())
 }
 
 func TestLangServer_workspaceExecuteCommand_rootmodules_basic(t *testing.T) {
@@ -97,7 +98,7 @@ func TestLangServer_workspaceExecuteCommand_rootmodules_basic(t *testing.T) {
 		ReqParams: fmt.Sprintf(`{
 		"command": %q,
 		"arguments": ["uri=%s"] 
-	}`, prefixCommandName("rootmodules"), testFileURI)}, fmt.Sprintf(`{
+	}`, cmd.Name("rootmodules"), testFileURI)}, fmt.Sprintf(`{
 		"jsonrpc": "2.0",
 		"id": 3,
 		"result": {
@@ -160,7 +161,7 @@ func TestLangServer_workspaceExecuteCommand_rootmodules_multiple(t *testing.T) {
 		ReqParams: fmt.Sprintf(`{
 		"command": %q,
 		"arguments": ["uri=%s"] 
-	}`, prefixCommandName("rootmodules"), module.URI())}, fmt.Sprintf(`{
+	}`, cmd.Name("rootmodules"), module.URI())}, fmt.Sprintf(`{
 		"jsonrpc": "2.0",
 		"id": 2,
 		"result": {


### PR DESCRIPTION
This is mostly to decouple the helper functions away from the handler and make extra folder/package for command handlers as that should make it easier to find commands in the hierarchy as we add more of them.

I'd love for the command handler tests to also live in that package, but it means we'd have to extract some functions as "test utils" somewhere so it can be used outside of the `handlers` package, but similar to other PRs - I'm taking one step at a time.
