### PR TITLE
Use directory ilsp helper in init command

### DIFF
--- a/internal/langserver/handlers/command/init.go
+++ b/internal/langserver/handlers/command/init.go
@@ -12,19 +12,19 @@ import (
 )
 
 func TerraformInitHandler(ctx context.Context, args cmd.CommandArgs) (interface{}, error) {
-	fileUri, ok := args.GetString("uri")
-	if !ok || fileUri == "" {
-		return nil, fmt.Errorf("%w: expected uri argument to be set", code.InvalidParams.Err())
+	dirUri, ok := args.GetString("uri")
+	if !ok || dirUri == "" {
+		return nil, fmt.Errorf("%w: expected dir uri argument to be set", code.InvalidParams.Err())
 	}
 
-	fh := ilsp.FileHandlerFromDocumentURI(lsp.DocumentURI(fileUri))
+	dh := ilsp.FileHandlerFromDirURI(lsp.DocumentURI(dirUri))
 
 	cf, err := lsctx.RootModuleFinder(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	rm, err := cf.RootModuleByPath(fh.Dir())
+	rm, err := cf.RootModuleByPath(dh.Dir())
 	if err != nil {
 		return nil, err
 	}
@@ -49,7 +49,7 @@ func TerraformInitHandler(ctx context.Context, args cmd.CommandArgs) (interface{
 	}
 	err = w.AddPaths(paths)
 	if err != nil {
-		return nil, fmt.Errorf("failed to add watch for dir (%s): %+v", fh.Dir(), err)
+		return nil, fmt.Errorf("failed to add watch for dir (%s): %+v", dh.Dir(), err)
 	}
 
 	return nil, nil

--- a/internal/langserver/handlers/execute_command_init_test.go
+++ b/internal/langserver/handlers/execute_command_init_test.go
@@ -130,7 +130,7 @@ func TestLangServer_workspaceExecuteCommand_init_basic(t *testing.T) {
 		ReqParams: fmt.Sprintf(`{
 		"command": %q,
 		"arguments": ["uri=%s"]
-	}`, cmd.Name("terraform.init"), testFileURI)}, `{
+	}`, cmd.Name("terraform.init"), tmpDir.URI())}, `{
 		"jsonrpc": "2.0",
 		"id": 3,
 		"result": null


### PR DESCRIPTION
This may not have any practical difference, but I did notice the handler was using a helper for creating a file handler from a file uri. This change uses the directory helper. I was concerned that the calling code was passing a file URI as well, which I thought was not the ideal interface we wanted to expose.

As it turns out, the calling code does in fact pass a directory URI, so I think the intention was for the `uri` to be a folder all along