### PR TITLE
fix: pass dir handler to init command

### DIFF
--- a/internal/langserver/handlers/did_open.go
+++ b/internal/langserver/handlers/did_open.go
@@ -79,8 +79,9 @@ func (lh *logHandler) TextDocumentDidOpen(ctx context.Context, params lsp.DidOpe
 		lh.logger.Printf("walker has not finished walking yet, data may be inaccurate for %s", f.FullPath())
 	} else if len(candidates) == 0 {
 		// TODO: Only notify once per f.Dir() per session
+		dh := ilsp.FileHandlerFromDirPath(f.Dir())
 		go func() {
-			err := askInitForEmptyRootModule(ctx, rootDir, f)
+			err := askInitForEmptyRootModule(ctx, rootDir, dh)
 			if err != nil {
 				jrpc2.PushNotify(ctx, "window/showMessage", lsp.ShowMessageParams{
 					Type:    lsp.Error,


### PR DESCRIPTION
This is just fixing an unforeseen side effect of https://github.com/hashicorp/terraform-ls/pull/333
<img width="448" alt="Screenshot 2020-12-09 at 11 09 58" src="https://user-images.githubusercontent.com/287584/101616004-b96bda00-3a06-11eb-8bff-f8ec93f3723a.png">

where we'd pass full file path to `askInitForEmptyRootModule` treating it like a directory path, when it isn't.

I guess the cleanest way of prevent similar bugs would be to have clearer separation between file handlers and dir handlers, instead of interfaces hiding parts of the "universal" handler.
