### PR TITLE
Report progress for validate command

### DIFF
--- a/internal/langserver/handlers/command/validate.go
+++ b/internal/langserver/handlers/command/validate.go
@@ -42,6 +42,11 @@ func TerraformValidateHandler(ctx context.Context, args cmd.CommandArgs) (interf
 		return nil, err
 	}
 
+	progressBegin(ctx, "Validating")
+	defer func() {
+		progressEnd(ctx, "Finished")
+	}()
+	progressReport(ctx, "Running terraform validate ...")
 	hclDiags, err := rm.ExecuteTerraformValidate(ctx)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
It is hard to actually test this without the corresponding integration on the client side, but it's more or less copy-n-paste from the init command, which I did test through the server-initiated progress from the dialog opened in `didOpen`.