### PR TITLE
Validate On Save

### DIFF
--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -50,6 +50,16 @@ Or if left empty
 This setting should be deprecated once the language server supports multiple workspaces,
 as this arises in VS code because a server instance is started per VS Code workspace.
 
+## `experimentalFeatures`
+
+This setting contains inner settings used to opt into experimental features not yet ready to be on by default.
+
+### `experimentalFeatures.validateOnSave`
+
+Enabling this feature will run terraform validate within the folder of the file saved. This comes with some user experience caveats.
+ - Validation is not run on file open, only once it's saved.
+ - When editing a module file, validation is not run due to not knowing which "rootmodule" to run validation from (there could be multiple). This creates an awkward workflow where when saving a file in a rootmodule, a diagnostic is raised in a module file. Editing the module file will not clear the diagnostic for the reason mentioned above, it will only clear once a file is saved back in the original "rootmodule". We will continue to attempt improve this user experience.
+
 ## How to pass settings
 
 The server expects static settings to be passed as part of LSP `initialize` call,

--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-ls/internal/filesystem"
 	"github.com/hashicorp/terraform-ls/internal/langserver/diagnostics"
 	lsp "github.com/hashicorp/terraform-ls/internal/protocol"
+	"github.com/hashicorp/terraform-ls/internal/settings"
 	"github.com/hashicorp/terraform-ls/internal/terraform/rootmodule"
 	"github.com/hashicorp/terraform-ls/internal/watcher"
 )
@@ -37,6 +38,7 @@ var (
 	ctxDiags             = &contextKey{"diagnostics"}
 	ctxLsVersion         = &contextKey{"language server version"}
 	ctxProgressToken     = &contextKey{"progress token"}
+	ctxOptIn             = &contextKey{"opt-in"}
 )
 
 func missingContextErr(ctxKey *contextKey) *MissingContextErr {
@@ -261,4 +263,26 @@ func ProgressToken(ctx context.Context) (lsp.ProgressToken, bool) {
 		return "", false
 	}
 	return pt, true
+}
+
+func WithOptIn(ctx context.Context, optIn *settings.OptIn) context.Context {
+	return context.WithValue(ctx, ctxOptIn, optIn)
+}
+
+func SetOptIn(ctx context.Context, optIn settings.OptIn) error {
+	o, ok := ctx.Value(ctxOptIn).(*settings.OptIn)
+	if !ok {
+		return missingContextErr(ctxOptIn)
+	}
+
+	*o = optIn
+	return nil
+}
+
+func OptIn(ctx context.Context) (settings.OptIn, error) {
+	optIn, ok := ctx.Value(ctxOptIn).(*settings.OptIn)
+	if !ok {
+		return settings.OptIn{}, missingContextErr(ctxOptIn)
+	}
+	return *optIn, nil
 }

--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -21,24 +21,24 @@ func (k *contextKey) String() string {
 }
 
 var (
-	ctxDs                = &contextKey{"document storage"}
-	ctxClientCapsSetter  = &contextKey{"client capabilities setter"}
-	ctxClientCaps        = &contextKey{"client capabilities"}
-	ctxTfExecPath        = &contextKey{"terraform executable path"}
-	ctxTfExecLogPath     = &contextKey{"terraform executor log path"}
-	ctxTfExecTimeout     = &contextKey{"terraform execution timeout"}
-	ctxWatcher           = &contextKey{"watcher"}
-	ctxRootModuleMngr    = &contextKey{"root module manager"}
-	ctxTfFormatterFinder = &contextKey{"terraform formatter finder"}
-	ctxRootModuleCaFi    = &contextKey{"root module candidate finder"}
-	ctxRootModuleWalker  = &contextKey{"root module walker"}
-	ctxRootModuleLoader  = &contextKey{"root module loader"}
-	ctxRootDir           = &contextKey{"root directory"}
-	ctxCommandPrefix     = &contextKey{"command prefix"}
-	ctxDiags             = &contextKey{"diagnostics"}
-	ctxLsVersion         = &contextKey{"language server version"}
-	ctxProgressToken     = &contextKey{"progress token"}
-	ctxOptIn             = &contextKey{"opt-in"}
+	ctxDs                   = &contextKey{"document storage"}
+	ctxClientCapsSetter     = &contextKey{"client capabilities setter"}
+	ctxClientCaps           = &contextKey{"client capabilities"}
+	ctxTfExecPath           = &contextKey{"terraform executable path"}
+	ctxTfExecLogPath        = &contextKey{"terraform executor log path"}
+	ctxTfExecTimeout        = &contextKey{"terraform execution timeout"}
+	ctxWatcher              = &contextKey{"watcher"}
+	ctxRootModuleMngr       = &contextKey{"root module manager"}
+	ctxTfFormatterFinder    = &contextKey{"terraform formatter finder"}
+	ctxRootModuleCaFi       = &contextKey{"root module candidate finder"}
+	ctxRootModuleWalker     = &contextKey{"root module walker"}
+	ctxRootModuleLoader     = &contextKey{"root module loader"}
+	ctxRootDir              = &contextKey{"root directory"}
+	ctxCommandPrefix        = &contextKey{"command prefix"}
+	ctxDiags                = &contextKey{"diagnostics"}
+	ctxLsVersion            = &contextKey{"language server version"}
+	ctxProgressToken        = &contextKey{"progress token"}
+	ctxExperimentalFeatures = &contextKey{"experimental features"}
 )
 
 func missingContextErr(ctxKey *contextKey) *MissingContextErr {
@@ -265,24 +265,24 @@ func ProgressToken(ctx context.Context) (lsp.ProgressToken, bool) {
 	return pt, true
 }
 
-func WithOptIn(ctx context.Context, optIn *settings.OptIn) context.Context {
-	return context.WithValue(ctx, ctxOptIn, optIn)
+func WithExperimentalFeatures(ctx context.Context, expFeatures *settings.ExperimentalFeatures) context.Context {
+	return context.WithValue(ctx, ctxExperimentalFeatures, expFeatures)
 }
 
-func SetOptIn(ctx context.Context, optIn settings.OptIn) error {
-	o, ok := ctx.Value(ctxOptIn).(*settings.OptIn)
+func SetExperimentalFeatures(ctx context.Context, expFeatures settings.ExperimentalFeatures) error {
+	e, ok := ctx.Value(ctxExperimentalFeatures).(*settings.ExperimentalFeatures)
 	if !ok {
-		return missingContextErr(ctxOptIn)
+		return missingContextErr(ctxExperimentalFeatures)
 	}
 
-	*o = optIn
+	*e = expFeatures
 	return nil
 }
 
-func OptIn(ctx context.Context) (settings.OptIn, error) {
-	optIn, ok := ctx.Value(ctxOptIn).(*settings.OptIn)
+func ExperimentalFeatures(ctx context.Context) (settings.ExperimentalFeatures, error) {
+	expFeatures, ok := ctx.Value(ctxExperimentalFeatures).(*settings.ExperimentalFeatures)
 	if !ok {
-		return settings.OptIn{}, missingContextErr(ctxOptIn)
+		return settings.ExperimentalFeatures{}, missingContextErr(ctxExperimentalFeatures)
 	}
-	return *optIn, nil
+	return *expFeatures, nil
 }

--- a/internal/langserver/handlers/command/init.go
+++ b/internal/langserver/handlers/command/init.go
@@ -7,6 +7,7 @@ import (
 	"github.com/creachadair/jrpc2/code"
 	lsctx "github.com/hashicorp/terraform-ls/internal/context"
 	"github.com/hashicorp/terraform-ls/internal/langserver/cmd"
+	"github.com/hashicorp/terraform-ls/internal/langserver/progress"
 	ilsp "github.com/hashicorp/terraform-ls/internal/lsp"
 	lsp "github.com/hashicorp/terraform-ls/internal/protocol"
 )
@@ -29,18 +30,18 @@ func TerraformInitHandler(ctx context.Context, args cmd.CommandArgs) (interface{
 		return nil, err
 	}
 
-	progressBegin(ctx, "Initializing")
+	progress.Begin(ctx, "Initializing")
 	defer func() {
-		progressEnd(ctx, "Finished")
+		progress.End(ctx, "Finished")
 	}()
 
-	progressReport(ctx, "Running terraform init ...")
+	progress.Report(ctx, "Running terraform init ...")
 	err = rm.ExecuteTerraformInit(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	progressReport(ctx, "Detecting paths to watch ...")
+	progress.Report(ctx, "Detecting paths to watch ...")
 	paths := rm.PathsToWatch()
 
 	w, err := lsctx.Watcher(ctx)

--- a/internal/langserver/handlers/command/validate.go
+++ b/internal/langserver/handlers/command/validate.go
@@ -7,6 +7,7 @@ import (
 	"github.com/creachadair/jrpc2/code"
 	lsctx "github.com/hashicorp/terraform-ls/internal/context"
 	"github.com/hashicorp/terraform-ls/internal/langserver/cmd"
+	"github.com/hashicorp/terraform-ls/internal/langserver/progress"
 	ilsp "github.com/hashicorp/terraform-ls/internal/lsp"
 	lsp "github.com/hashicorp/terraform-ls/internal/protocol"
 )
@@ -42,11 +43,11 @@ func TerraformValidateHandler(ctx context.Context, args cmd.CommandArgs) (interf
 		return nil, err
 	}
 
-	progressBegin(ctx, "Validating")
+	progress.Begin(ctx, "Validating")
 	defer func() {
-		progressEnd(ctx, "Finished")
+		progress.End(ctx, "Finished")
 	}()
-	progressReport(ctx, "Running terraform validate ...")
+	progress.Report(ctx, "Running terraform validate ...")
 	hclDiags, err := rm.ExecuteTerraformValidate(ctx)
 	if err != nil {
 		return nil, err

--- a/internal/langserver/handlers/did_save.go
+++ b/internal/langserver/handlers/did_save.go
@@ -1,0 +1,30 @@
+package handlers
+
+import (
+	"context"
+
+	lsctx "github.com/hashicorp/terraform-ls/internal/context"
+	"github.com/hashicorp/terraform-ls/internal/langserver/cmd"
+	"github.com/hashicorp/terraform-ls/internal/langserver/handlers/command"
+	ilsp "github.com/hashicorp/terraform-ls/internal/lsp"
+	lsp "github.com/hashicorp/terraform-ls/internal/protocol"
+)
+
+func (lh *logHandler) TextDocumentDidSave(ctx context.Context, params lsp.DidSaveTextDocumentParams) error {
+	optIn, err := lsctx.OptIn(ctx)
+	if err != nil {
+		return err
+	}
+	if !optIn.ValidateOnSave {
+		return nil
+	}
+
+	fh := ilsp.FileHandlerFromDocumentURI(params.TextDocument.URI)
+	dh := ilsp.FileHandlerFromDirPath(fh.Dir())
+
+	_, err = command.TerraformValidateHandler(ctx, cmd.CommandArgs{
+		"uri": dh.URI(),
+	})
+
+	return err
+}

--- a/internal/langserver/handlers/did_save.go
+++ b/internal/langserver/handlers/did_save.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (lh *logHandler) TextDocumentDidSave(ctx context.Context, params lsp.DidSaveTextDocumentParams) error {
-	optIn, err := lsctx.OptIn(ctx)
+	optIn, err := lsctx.ExperimentalFeatures(ctx)
 	if err != nil {
 		return err
 	}

--- a/internal/langserver/handlers/did_save.go
+++ b/internal/langserver/handlers/did_save.go
@@ -11,11 +11,11 @@ import (
 )
 
 func (lh *logHandler) TextDocumentDidSave(ctx context.Context, params lsp.DidSaveTextDocumentParams) error {
-	optIn, err := lsctx.ExperimentalFeatures(ctx)
+	expFeatures, err := lsctx.ExperimentalFeatures(ctx)
 	if err != nil {
 		return err
 	}
-	if !optIn.ValidateOnSave {
+	if !expFeatures.ValidateOnSave {
 		return nil
 	}
 

--- a/internal/langserver/handlers/initialize.go
+++ b/internal/langserver/handlers/initialize.go
@@ -105,8 +105,8 @@ func (lh *logHandler) Initialize(ctx context.Context, params lsp.InitializeParam
 		},
 	}
 
-	// set opt-in flags
-	lsctx.SetOptIn(ctx, out.Options.OptIn)
+	// set experimental feature flags
+	lsctx.SetExperimentalFeatures(ctx, out.Options.ExperimentalFeatures)
 
 	if len(out.UnusedKeys) > 0 {
 		jrpc2.PushNotify(ctx, "window/showMessage", &lsp.ShowMessageParams{

--- a/internal/langserver/handlers/initialize.go
+++ b/internal/langserver/handlers/initialize.go
@@ -105,6 +105,9 @@ func (lh *logHandler) Initialize(ctx context.Context, params lsp.InitializeParam
 		},
 	}
 
+	// set opt-in flags
+	lsctx.SetOptIn(ctx, out.Options.OptIn)
+
 	if len(out.UnusedKeys) > 0 {
 		jrpc2.PushNotify(ctx, "window/showMessage", &lsp.ShowMessageParams{
 			Type:    lsp.Warning,

--- a/internal/langserver/handlers/service.go
+++ b/internal/langserver/handlers/service.go
@@ -151,7 +151,7 @@ func (svc *service) Assigner() (jrpc2.Assigner, error) {
 
 	rootDir := ""
 	commandPrefix := ""
-	var optIn settings.OptIn
+	var optIn settings.ExperimentalFeatures
 
 	m := map[string]rpch.Func{
 		"initialize": func(ctx context.Context, req *jrpc2.Request) (interface{}, error) {
@@ -167,7 +167,7 @@ func (svc *service) Assigner() (jrpc2.Assigner, error) {
 			ctx = lsctx.WithCommandPrefix(ctx, &commandPrefix)
 			ctx = lsctx.WithRootModuleManager(ctx, svc.modMgr)
 			ctx = lsctx.WithRootModuleLoader(ctx, rmLoader)
-			ctx = lsctx.WithOptIn(ctx, &optIn)
+			ctx = lsctx.WithExperimentalFeatures(ctx, &optIn)
 
 			version, ok := lsctx.LanguageServerVersion(svc.srvCtx)
 			if ok {
@@ -282,7 +282,7 @@ func (svc *service) Assigner() (jrpc2.Assigner, error) {
 			}
 
 			ctx = lsctx.WithDiagnostics(ctx, diags)
-			ctx = lsctx.WithOptIn(ctx, &optIn)
+			ctx = lsctx.WithExperimentalFeatures(ctx, &optIn)
 			ctx = lsctx.WithRootModuleFinder(ctx, svc.modMgr)
 
 			return handle(ctx, req, lh.TextDocumentDidSave)

--- a/internal/langserver/handlers/service.go
+++ b/internal/langserver/handlers/service.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-ls/internal/langserver/diagnostics"
 	"github.com/hashicorp/terraform-ls/internal/langserver/session"
 	lsp "github.com/hashicorp/terraform-ls/internal/protocol"
+	"github.com/hashicorp/terraform-ls/internal/settings"
 	"github.com/hashicorp/terraform-ls/internal/terraform/rootmodule"
 	"github.com/hashicorp/terraform-ls/internal/watcher"
 )
@@ -150,6 +151,7 @@ func (svc *service) Assigner() (jrpc2.Assigner, error) {
 
 	rootDir := ""
 	commandPrefix := ""
+	var optIn settings.OptIn
 
 	m := map[string]rpch.Func{
 		"initialize": func(ctx context.Context, req *jrpc2.Request) (interface{}, error) {
@@ -165,6 +167,7 @@ func (svc *service) Assigner() (jrpc2.Assigner, error) {
 			ctx = lsctx.WithCommandPrefix(ctx, &commandPrefix)
 			ctx = lsctx.WithRootModuleManager(ctx, svc.modMgr)
 			ctx = lsctx.WithRootModuleLoader(ctx, rmLoader)
+			ctx = lsctx.WithOptIn(ctx, &optIn)
 
 			version, ok := lsctx.LanguageServerVersion(svc.srvCtx)
 			if ok {
@@ -271,6 +274,18 @@ func (svc *service) Assigner() (jrpc2.Assigner, error) {
 			ctx = lsctx.WithRootModuleFinder(ctx, svc.modMgr)
 
 			return handle(ctx, req, lh.TextDocumentSemanticTokensFull)
+		},
+		"textDocument/didSave": func(ctx context.Context, req *jrpc2.Request) (interface{}, error) {
+			err := session.CheckInitializationIsConfirmed()
+			if err != nil {
+				return nil, err
+			}
+
+			ctx = lsctx.WithDiagnostics(ctx, diags)
+			ctx = lsctx.WithOptIn(ctx, &optIn)
+			ctx = lsctx.WithRootModuleFinder(ctx, svc.modMgr)
+
+			return handle(ctx, req, lh.TextDocumentDidSave)
 		},
 		"workspace/executeCommand": func(ctx context.Context, req *jrpc2.Request) (interface{}, error) {
 			err := session.CheckInitializationIsConfirmed()

--- a/internal/langserver/handlers/service.go
+++ b/internal/langserver/handlers/service.go
@@ -151,7 +151,7 @@ func (svc *service) Assigner() (jrpc2.Assigner, error) {
 
 	rootDir := ""
 	commandPrefix := ""
-	var optIn settings.ExperimentalFeatures
+	var expFeatures settings.ExperimentalFeatures
 
 	m := map[string]rpch.Func{
 		"initialize": func(ctx context.Context, req *jrpc2.Request) (interface{}, error) {
@@ -167,7 +167,7 @@ func (svc *service) Assigner() (jrpc2.Assigner, error) {
 			ctx = lsctx.WithCommandPrefix(ctx, &commandPrefix)
 			ctx = lsctx.WithRootModuleManager(ctx, svc.modMgr)
 			ctx = lsctx.WithRootModuleLoader(ctx, rmLoader)
-			ctx = lsctx.WithExperimentalFeatures(ctx, &optIn)
+			ctx = lsctx.WithExperimentalFeatures(ctx, &expFeatures)
 
 			version, ok := lsctx.LanguageServerVersion(svc.srvCtx)
 			if ok {
@@ -282,7 +282,7 @@ func (svc *service) Assigner() (jrpc2.Assigner, error) {
 			}
 
 			ctx = lsctx.WithDiagnostics(ctx, diags)
-			ctx = lsctx.WithExperimentalFeatures(ctx, &optIn)
+			ctx = lsctx.WithExperimentalFeatures(ctx, &expFeatures)
 			ctx = lsctx.WithRootModuleFinder(ctx, svc.modMgr)
 
 			return handle(ctx, req, lh.TextDocumentDidSave)

--- a/internal/langserver/progress/progress.go
+++ b/internal/langserver/progress/progress.go
@@ -1,4 +1,4 @@
-package command
+package progress
 
 import (
 	"context"
@@ -8,7 +8,7 @@ import (
 	lsp "github.com/hashicorp/terraform-ls/internal/protocol"
 )
 
-func progressBegin(ctx context.Context, title string) error {
+func Begin(ctx context.Context, title string) error {
 	token, ok := lsctx.ProgressToken(ctx)
 	if !ok {
 		return nil
@@ -23,7 +23,7 @@ func progressBegin(ctx context.Context, title string) error {
 	})
 }
 
-func progressReport(ctx context.Context, message string) error {
+func Report(ctx context.Context, message string) error {
 	token, ok := lsctx.ProgressToken(ctx)
 	if !ok {
 		return nil
@@ -38,7 +38,7 @@ func progressReport(ctx context.Context, message string) error {
 	})
 }
 
-func progressEnd(ctx context.Context, message string) error {
+func End(ctx context.Context, message string) error {
 	token, ok := lsctx.ProgressToken(ctx)
 	if !ok {
 		return nil

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -6,11 +6,18 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
+type OptIn struct {
+	ValidateOnSave bool `mapstructure:"validateOnSave"`
+}
+
 type Options struct {
 	// RootModulePaths describes a list of absolute paths to root modules
 	RootModulePaths    []string `mapstructure:"rootModulePaths"`
 	ExcludeModulePaths []string `mapstructure:"excludeModulePaths"`
 	CommandPrefix      string   `mapstructure:"commandPrefix"`
+
+	// OptIn encapsulates features users can opt into.
+	OptIn OptIn `mapstructure:"optIn"`
 
 	// TODO: Need to check for conflict with CLI flags
 	// TerraformExecPath string

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -6,7 +6,7 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
-type OptIn struct {
+type ExperimentalFeatures struct {
 	ValidateOnSave bool `mapstructure:"validateOnSave"`
 }
 
@@ -16,8 +16,8 @@ type Options struct {
 	ExcludeModulePaths []string `mapstructure:"excludeModulePaths"`
 	CommandPrefix      string   `mapstructure:"commandPrefix"`
 
-	// OptIn encapsulates features users can opt into.
-	OptIn OptIn `mapstructure:"optIn"`
+	// ExperimentalFeatures encapsulates experimental features users can opt into.
+	ExperimentalFeatures ExperimentalFeatures `mapstructure:"experimentalFeatures"`
 
 	// TODO: Need to check for conflict with CLI flags
 	// TerraformExecPath string


### PR DESCRIPTION
This creates a new configuration object for the language server called `ExperimentalFeatures` which allows users to opt into specific features which may not be ready to be on by default. The first feature is calling `terraform validate` on save (with the saved file as the target directory).

This does work as expected, however the user experience is a bit awkward in 2 cases:

 - Validate is not run on open, only on save. This makes it awkward when opening your project, you will not see any validation errors for the file in focus until you save.
 - Modules is supported, but the experience isn't ideal. For simplicity, in #323 we do not run `terraform validate` when a module file is saved. This is because it could be referenced/downstream from multiple root modules (we don't know which root module to call terraform validate in? Could lead to weird duplicate diagnostics). `terraform validate` does of course provide diagnostics for any referenced modules when saving a file in a root module (great! as expected).
   - The problem is that when "fixing" the mistake in the module file and saving, the diagnostic is not cleared, since for reasons mentioned above, we don't run terraform validate from within the module folder
   
<img width="715" alt="Screen Shot 2020-12-16 at 3 34 27 PM" src="https://user-images.githubusercontent.com/36832285/102403519-5d7bf500-3fb4-11eb-9fb0-01ee8fec2750.png">


I think with the right messaging, and the fact that the feature is opt-in, that this UX is okay for now, but could use improvement.

**To be clear** this clearing issue only affects saves of modules, not of regular files of "rootmodules" (side note we really need to fixup our nomenclature on this topic)

In contrast, when we enable calling validate from the command palette on the client side, we would ask the user to specify which folder to run validate in, from a quick-picker style dialog. This experience is smoother since I think intuitively the user will always pick the right spot and won't experience this awkward clearing deficiency.
