### PR TITLE
Fix detection of client semantic token support

### DIFF
--- a/internal/langserver/handlers/semantic_tokens.go
+++ b/internal/langserver/handlers/semantic_tokens.go
@@ -25,6 +25,7 @@ func (lh *logHandler) TextDocumentSemanticTokensFull(ctx context.Context, params
 		// This would indicate a buggy client which sent a request
 		// it didn't claim to support, so we just strictly follow
 		// the protocol here and avoid serving buggy clients.
+		lh.logger.Printf("semantic tokens full request support not announced by client")
 		return tks, code.MethodNotFound.Err()
 	}
 

--- a/internal/langserver/handlers/semantic_tokens_test.go
+++ b/internal/langserver/handlers/semantic_tokens_test.go
@@ -119,3 +119,112 @@ func TestSemanticTokensFull(t *testing.T) {
 			}
 		}`)
 }
+
+func TestSemanticTokensFull_clientSupportsDelta(t *testing.T) {
+	tmpDir := TempDir(t)
+	InitPluginCache(t, tmpDir.Dir())
+
+	var testSchema tfjson.ProviderSchemas
+	err := json.Unmarshal([]byte(testSchemaOutput), &testSchema)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ls := langserver.NewLangServerMock(t, NewMockSession(&MockSessionInput{
+		RootModules: map[string]*rootmodule.RootModuleMock{
+			tmpDir.Dir(): {
+				TfExecFactory: exec.NewMockExecutor([]*mock.Call{
+					{
+						Method:        "Version",
+						Repeatability: 1,
+						Arguments: []interface{}{
+							mock.AnythingOfType(""),
+						},
+						ReturnArguments: []interface{}{
+							version.Must(version.NewVersion("0.12.0")),
+							nil,
+							nil,
+						},
+					},
+					{
+						Method:        "GetExecPath",
+						Repeatability: 1,
+						ReturnArguments: []interface{}{
+							"",
+						},
+					},
+					{
+						Method:        "ProviderSchemas",
+						Repeatability: 1,
+						Arguments: []interface{}{
+							mock.AnythingOfType(""),
+						},
+						ReturnArguments: []interface{}{
+							&testSchema,
+							nil,
+						},
+					},
+				}),
+			},
+		}}))
+	stop := ls.Start(t)
+	defer stop()
+
+	ls.Call(t, &langserver.CallRequest{
+		Method: "initialize",
+		ReqParams: fmt.Sprintf(`{
+		"capabilities": {
+			"textDocument": {
+				"semanticTokens": {
+					"tokenTypes": [
+						"type",
+						"property",
+						"string"
+					],
+					"tokenModifiers": [
+						"deprecated",
+						"modification"
+					],
+					"requests": {
+						"full": {
+							"delta": true
+						}
+					}
+				}
+			}
+		},
+		"rootUri": %q,
+		"processId": 12345
+	}`, TempDir(t).URI())})
+	ls.Notify(t, &langserver.CallRequest{
+		Method:    "initialized",
+		ReqParams: "{}",
+	})
+	ls.Call(t, &langserver.CallRequest{
+		Method: "textDocument/didOpen",
+		ReqParams: fmt.Sprintf(`{
+		"textDocument": {
+			"version": 0,
+			"languageId": "terraform",
+			"text": "provider \"test\" {\n\n}\n",
+			"uri": "%s/main.tf"
+		}
+	}`, TempDir(t).URI())})
+
+	ls.CallAndExpectResponse(t, &langserver.CallRequest{
+		Method: "textDocument/semanticTokens/full",
+		ReqParams: fmt.Sprintf(`{
+			"textDocument": {
+				"uri": "%s/main.tf"
+			}
+		}`, TempDir(t).URI())}, `{
+			"jsonrpc": "2.0",
+			"id": 3,
+			"result": {
+				"data": [
+					0,0,8,0,0,
+					0,9,6,1,2
+				]
+			}
+		}`)
+}

--- a/internal/lsp/semantic_tokens.go
+++ b/internal/lsp/semantic_tokens.go
@@ -4,10 +4,6 @@ import (
 	lsp "github.com/hashicorp/terraform-ls/internal/protocol"
 )
 
-type semanticTokensFull struct {
-	Delta bool `json:"delta,omitempty"`
-}
-
 type SemanticTokensClientCapabilities struct {
 	lsp.SemanticTokensClientCapabilities
 }
@@ -16,7 +12,7 @@ func (c SemanticTokensClientCapabilities) FullRequest() bool {
 	switch full := c.Requests.Full.(type) {
 	case bool:
 		return full
-	case semanticTokensFull:
+	case map[string]interface{}:
 		return true
 	}
 	return false


### PR DESCRIPTION
This is a follow-up to a recently merged (but not yet released 😅 ) #331 which I discovered by manually testing the server with VS Code extension, which supports deltas.

Attached test describes the scenario and fails without the patch:

```
--- FAIL: TestSemanticTokensFull_clientSupportsDelta (0.00s)
    langserver_mock.go:121: [-32601] method not found
```