### PR TITLE
Add support for linux/arm64

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,10 +14,15 @@ builds:
       - -trimpath
     ldflags:
       - '-s -w -X "main.version={{ .RawVersion }}" -X "main.prerelease={{ if .IsSnapshot }}snapshot.{{ .ShortCommit }}{{ else }}{{ .Prerelease }}{{ end }}"'
-    targets:
-      - darwin_amd64
-      - windows_386
-      - windows_amd64
+    goarch:
+      - '386'
+      - amd64
+    goos:
+      - darwin
+      - windows
+    ignore:
+      - goarch: '386'
+        goos: darwin
     hooks:
       post: |
         docker run
@@ -33,16 +38,20 @@ builds:
       - -trimpath
     ldflags:
       - '-s -w -X "main.version={{ .RawVersion }}" -X "main.prerelease={{ if .IsSnapshot }}snapshot.{{ .ShortCommit }}{{ else }}{{ .Prerelease }}{{ end }}"'
-    targets:
-      - freebsd_386
-      - freebsd_amd64
-      - freebsd_arm
-      - linux_386
-      - linux_amd64
-      - linux_arm
-      - openbsd_386
-      - openbsd_amd64
-      - solaris_amd64
+    goarch:
+      - '386'
+      - amd64
+      - arm
+    goos:
+      - freebsd
+      - openbsd
+      - linux
+      - solaris
+    ignore:
+      - goarch: '386'
+        goos: darwin
+      - goarch: arm
+        goos: openbsd
 
 archives:
   -

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -42,6 +42,7 @@ builds:
       - '386'
       - amd64
       - arm
+      - arm64
     goos:
       - freebsd
       - openbsd
@@ -52,6 +53,10 @@ builds:
         goos: darwin
       - goarch: arm
         goos: openbsd
+      - goarch: arm64
+        goos: openbsd
+      - goarch: arm64
+        goos: freebsd
 
 archives:
   -


### PR DESCRIPTION
This mimics build targets of latest Terraform (core) version, e.g.
https://releases.hashicorp.com/terraform/0.14.3/

Closes #342 