### PR TITLE
github: bump GoReleaser Action to v2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
         run: echo -e "${{ secrets.PGP_SIGNING_KEY }}" | gpg --import
       -
         name: Release
-        uses: goreleaser/goreleaser-action@v1
+        uses: goreleaser/goreleaser-action@v2
         with:
           version: latest
           args: release


### PR DESCRIPTION
According to the [Changelog](https://github.com/goreleaser/goreleaser-action/blob/master/CHANGELOG.md#changelog) there are no changes which would affect us, but we will confirm that soon enough during the next release.
