### PR TITLE
github: Enable dependabot for Go dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels: ["dependencies"]


### PR DESCRIPTION
Closes #64 

I chose dependabot as that seems most popular choice based on anecdotal evidence from Terraform provider repositories (which also migrated to dependabot from Renovate) and also because it seems to have reached parity of features which we need (`go mod tidy` namely) with Renovate.

I looked briefly at Snyk and concluded it doesn't support Go yet: https://support.snyk.io/hc/en-us/articles/360006581898-Upgrading-dependencies-with-automatic-PRs