### PR TITLE
Fix: Add missing TF exec context for didOpen

### DIFF
--- a/internal/langserver/handlers/service.go
+++ b/internal/langserver/handlers/service.go
@@ -176,6 +176,8 @@ func (svc *service) Assigner() (jrpc2.Assigner, error) {
 			ctx = lsctx.WithModuleManager(ctx, svc.modMgr)
 			ctx = lsctx.WithModuleFinder(ctx, svc.modMgr)
 			ctx = lsctx.WithModuleWalker(ctx, svc.walker)
+			ctx = exec.WithExecutorOpts(ctx, execOpts)
+			ctx = exec.WithExecutorFactory(ctx, svc.tfExecFactory)
 			ctx = lsctx.WithWatcher(ctx, ww)
 			return handle(ctx, req, lh.TextDocumentDidOpen)
 		},


### PR DESCRIPTION
This fixes a bug which was introduced in the recently merged big PR #385 - presumably just oversight.

![Screenshot 2021-02-03 at 10 36 18](https://user-images.githubusercontent.com/287584/106735061-aabb3100-660b-11eb-9143-16817834b68a.png)
![Screenshot 2021-02-03 at 10 36 07](https://user-images.githubusercontent.com/287584/106735069-abec5e00-660b-11eb-8276-ee8c77b57672.png)
