### PR TITLE
ilsp: Fix miscalculated semantic tokens

### DIFF
--- a/internal/lsp/token_encoder.go
+++ b/internal/lsp/token_encoder.go
@@ -78,13 +78,16 @@ func (te *TokenEncoder) encodeTokenOfIndex(i int) []float64 {
 	previousStartChar := 0
 	if i > 0 {
 		previousLine = te.Tokens[i-1].Range.End.Line - 1
-		previousStartChar = te.Tokens[i-1].Range.Start.Column - 1
+		currentLine := te.Tokens[i].Range.End.Line - 1
+		if currentLine == previousLine {
+			previousStartChar = te.Tokens[i-1].Range.Start.Column - 1
+		}
 	}
 
 	if tokenLineDelta == 0 || false /* te.clientCaps.MultilineTokenSupport */ {
 		deltaLine := token.Range.Start.Line - 1 - previousLine
-		deltaStartChar := token.Range.Start.Column - 1
 		tokenLength := token.Range.End.Byte - token.Range.Start.Byte
+		deltaStartChar := token.Range.Start.Column - 1 - previousStartChar
 
 		data = append(data, []float64{
 			float64(deltaLine),


### PR DESCRIPTION
Fixes #387 

This affects most cases where there is more than 2 tokens on the same line (typically blocks with 2 labels, like resources and data sources), in which case the `deltaStartChar` was being miscalculated.

### Before

![Screenshot 2021-02-03 at 11 49 33](https://user-images.githubusercontent.com/287584/106743152-e65af880-6615-11eb-900c-159c0dd8f40e.png)

### After

![Screenshot 2021-02-03 at 11 48 56](https://user-images.githubusercontent.com/287584/106743161-e955e900-6615-11eb-983f-cdd5028ed5c9.png)
