### PR TITLE
Utilize CPU better when loading modules

### DIFF
--- a/internal/terraform/module/module_loader.go
+++ b/internal/terraform/module/module_loader.go
@@ -22,21 +22,44 @@ type moduleLoader struct {
 }
 
 func newModuleLoader() *moduleLoader {
-	nonPrioParallelism := 2 * runtime.NumCPU()
-	prioParallelism := 1 * runtime.NumCPU()
-
+	p := loaderParallelism(runtime.NumCPU())
 	plc, lc := int64(0), int64(0)
 	ml := &moduleLoader{
 		queue:              newModuleOpsQueue(),
 		logger:             defaultLogger,
-		nonPrioParallelism: int64(nonPrioParallelism),
-		prioParallelism:    int64(prioParallelism),
+		nonPrioParallelism: p.NonPriority,
+		prioParallelism:    p.Priority,
 		opsToDispatch:      make(chan ModuleOperation, 1),
 		loadingCount:       &lc,
 		prioLoadingCount:   &plc,
 	}
 
 	return ml
+}
+
+type parallelism struct {
+	NonPriority, Priority int64
+}
+
+func loaderParallelism(cpu int) parallelism {
+	// Cap utilization for powerful machines
+	if cpu >= 4 {
+		return parallelism{
+			NonPriority: int64(3),
+			Priority:    int64(1),
+		}
+	}
+	if cpu == 3 {
+		return parallelism{
+			NonPriority: int64(2),
+			Priority:    int64(1),
+		}
+	}
+
+	return parallelism{
+		NonPriority: 1,
+		Priority:    1,
+	}
 }
 
 func (ml *moduleLoader) SetLogger(logger *log.Logger) {


### PR DESCRIPTION
Closes #186

While the number of operations in parallel is capped, we can still _overutilize_ the available CPU as per 
https://github.com/hashicorp/terraform-ls/blob/d31f6b4bdd99a3e6b889ac0b0a9aac5fc5a6bb84/internal/terraform/module/module_manager.go#L46

(prior to #385)

and now

https://github.com/hashicorp/terraform-ls/blob/f5ddf9ac740469f762b3aa9175b40187e0e44a7e/internal/terraform/module/module_loader.go#L25-L26

This patch therefore ensures  that except for single-core we never run more threads than there is CPUs available, which should provide some relief to users with many modules in the hierarchy.