### PR TITLE
module loader: Avoid deadlock

### DIFF
--- a/internal/terraform/module/module_ops_queue.go
+++ b/internal/terraform/module/module_ops_queue.go
@@ -27,13 +27,17 @@ func (q *moduleOpsQueue) PushOp(op ModuleOperation) {
 
 }
 
-func (q *moduleOpsQueue) PopOp() ModuleOperation {
+func (q *moduleOpsQueue) PopOp() (ModuleOperation, bool) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 
+	if q.q.Len() == 0 {
+		return ModuleOperation{}, false
+	}
+
 	item := heap.Pop(&q.q)
 	modOp := item.(ModuleOperation)
-	return modOp
+	return modOp, true
 }
 
 func (q *moduleOpsQueue) Len() int {
@@ -41,14 +45,6 @@ func (q *moduleOpsQueue) Len() int {
 	defer q.mu.Unlock()
 
 	return q.q.Len()
-}
-
-func (q *moduleOpsQueue) Peek() interface{} {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-
-	item := q.q.Peek()
-	return item
 }
 
 type queue []ModuleOperation
@@ -70,11 +66,6 @@ func (q *queue) Pop() interface{} {
 	item := old[n-1]
 	*q = old[0 : n-1]
 	return item
-}
-
-func (q queue) Peek() interface{} {
-	n := len(q)
-	return q[n-1]
 }
 
 func (q queue) Len() int {

--- a/internal/terraform/module/module_ops_queue_test.go
+++ b/internal/terraform/module/module_ops_queue_test.go
@@ -45,7 +45,7 @@ func TestModuleOpsQueue_modulePriority(t *testing.T) {
 		mq.PushOp(op)
 	}
 
-	firstOp := mq.PopOp()
+	firstOp, _ := mq.PopOp()
 
 	expectedFirstPath := filepath.Join(dir, "beta")
 	firstPath := firstOp.Module.Path()
@@ -54,7 +54,7 @@ func TestModuleOpsQueue_modulePriority(t *testing.T) {
 			expectedFirstPath, firstPath)
 	}
 
-	secondOp := mq.PopOp()
+	secondOp, _ := mq.PopOp()
 	expectedSecondPath := filepath.Join(dir, "gamma")
 	secondPath := secondOp.Module.Path()
 	if secondPath != expectedSecondPath {


### PR DESCRIPTION
This fixes a number of bugs I found while testing this both manually in VS Code and by running tests with high enough `-count`.

1. Deadlock could occur when retry of dispatch is attempted, because while `run()` is executing, another goroutine (e.g. one executing a different operation) could have finished and triggered another `tryDispatchingModuleOp` which then filled the channel and the next `tryDispatchingModuleOp` triggered from `run()` as a result of retry would block, therefore blocking the main loop.
   - This was resolved by running retry `tryDispatchingModuleOp` in an additional goroutine
2. `tryDispatchingModuleOp` can get triggered by many threads at the same time and its original implementation left an opportunity for race condition due to `queue.Peek()` relying on `queue.Len()` but the reliance was not guaranteed in any way. Additionally `Peek` could have "peeked" at the exact same operation more than once, which then resulted in that duplicate operation being dispatched.
   - This was resolved by getting rid of `Peek` method entirely and ensuring we never pop from an empty queue by utilizing the internal mutex. Retries should be rare enough that (especially with the 100ms delay) shouldn't cause concern wrt resource consumption by repeated push/pop.
3. `tryDispatchingModuleOp` was triggered from inside of `executeModuleOp`, but loading counters were being decremented via `defer` _after_, which could've caused the dispatch attempt to fail when the queue was full, just because the two operations were done in the wrong order.
   - This was resolved by getting rid of `defer` and calling `tryDispatchingModuleOp` from the main loop in `run()` where we can better control the order.