### PR TITLE
schema preload: Ensure provider names are unique

### DIFF
--- a/internal/schemas/gen/gen.go
+++ b/internal/schemas/gen/gen.go
@@ -23,8 +23,8 @@ import (
 const terraformBlock = `terraform {
 	required_version = "~> 0.13"
   required_providers {
-  {{ range $p := . }}
-    {{ $p.Name }} = {
+  {{ range $i, $p := . }}
+    {{ $p.Name }}-{{ $i }} = {
       source = "{{ $p.Source }}"
     }
   {{ end }}

--- a/internal/schemas/gen/gen.go
+++ b/internal/schemas/gen/gen.go
@@ -229,31 +229,26 @@ func listProviders(tier string) ([]provider, error) {
 }
 
 // these providers fail to download
-// Error: Failed to query available provider packages
 
 // Could not retrieve the list of available versions for provider icinga/icinga2:
 // no available releases match the given constraints
-
-// Error: Failed to install provider
 
 // Error while installing a10networks/vthunder v0.4.21: could not query provider
 // registry for registry.terraform.io/a10networks/vthunder: failed to retrieve
 // authentication checksums for provider: 404 Not Found
 
-// Error: Failed to install provider
-
-// Error while installing sematext/sematext v0.1.9: checksum list has unexpected
-// SHA-256 hash f323df96ca63ead7cd57e2f58e2061199cd36568837863fde44af2e60949c5c2
-// (expected ce87fc7c44222b5f679d7dc1e2cbff7984e5a05fb011739ff92b747b39ea1528)
+// Error while installing jradtilbrook/buildkite v0.1.0: provider
+// registry.terraform.io/jradtilbrook/buildkite 0.1.0 is not available for
+// linux_amd64
 var ignore = map[string]bool{
-	"icinga2":  true,
-	"vthunder": true,
-	"sematext": true,
+	"Icinga/icinga2":         true,
+	"a10networks/vthunder":   true,
+	"jradtilbrook/buildkite": true,
 }
 
 func filter(providers []provider) (filtered []provider) {
 	for _, provider := range providers {
-		if ok := ignore[provider.Attributes.Name]; ok {
+		if ok := ignore[provider.Source()]; ok {
 			continue
 		}
 		filtered = append(filtered, provider)


### PR DESCRIPTION
This is to address a situation where two providers of the same `Name` (but different namespace) appear in the list.

Currently this would result in
```tf
    buildkite = {
      source = "buildkite/buildkite"
    }
  
    buildkite = {
      source = "jradtilbrook/buildkite"
    }
```
which is invalid due to the duplication.

Hence this patch just appends a number to make it unique, i.e. the above becomes

```tf
    buildkite-47 = {
      source = "buildkite/buildkite"
    }
  
    buildkite-48 = {
      source = "jradtilbrook/buildkite"
    }
```