### PR TITLE
Improve messaging when TF installation is not found

### DIFF
--- a/internal/langserver/errors/errors.go
+++ b/internal/langserver/errors/errors.go
@@ -1,0 +1,15 @@
+package errors
+
+import (
+	e "errors"
+
+	"github.com/hashicorp/terraform-ls/internal/terraform/module"
+)
+
+func EnrichTfExecError(err error) error {
+	if module.IsTerraformNotFound(err) {
+		return e.New("Terraform (CLI) is required. " +
+			"Please install Terraform or make it available in $PATH")
+	}
+	return err
+}

--- a/internal/langserver/handlers/command/init.go
+++ b/internal/langserver/handlers/command/init.go
@@ -7,6 +7,7 @@ import (
 	"github.com/creachadair/jrpc2/code"
 	lsctx "github.com/hashicorp/terraform-ls/internal/context"
 	"github.com/hashicorp/terraform-ls/internal/langserver/cmd"
+	"github.com/hashicorp/terraform-ls/internal/langserver/errors"
 	"github.com/hashicorp/terraform-ls/internal/langserver/progress"
 	ilsp "github.com/hashicorp/terraform-ls/internal/lsp"
 	lsp "github.com/hashicorp/terraform-ls/internal/protocol"
@@ -40,7 +41,7 @@ func TerraformInitHandler(ctx context.Context, args cmd.CommandArgs) (interface{
 
 	tfExec, err := module.TerraformExecutorForModule(ctx, mod)
 	if err != nil {
-		return nil, err
+		return nil, errors.EnrichTfExecError(err)
 	}
 
 	progress.Begin(ctx, "Initializing")

--- a/internal/langserver/handlers/command/validate.go
+++ b/internal/langserver/handlers/command/validate.go
@@ -8,6 +8,7 @@ import (
 	lsctx "github.com/hashicorp/terraform-ls/internal/context"
 	"github.com/hashicorp/terraform-ls/internal/langserver/cmd"
 	"github.com/hashicorp/terraform-ls/internal/langserver/diagnostics"
+	"github.com/hashicorp/terraform-ls/internal/langserver/errors"
 	"github.com/hashicorp/terraform-ls/internal/langserver/progress"
 	ilsp "github.com/hashicorp/terraform-ls/internal/lsp"
 	lsp "github.com/hashicorp/terraform-ls/internal/protocol"
@@ -41,7 +42,7 @@ func TerraformValidateHandler(ctx context.Context, args cmd.CommandArgs) (interf
 
 	tfExec, err := module.TerraformExecutorForModule(ctx, mod)
 	if err != nil {
-		return nil, err
+		return nil, errors.EnrichTfExecError(err)
 	}
 
 	notifier, err := lsctx.Diagnostics(ctx)

--- a/internal/langserver/handlers/formatting.go
+++ b/internal/langserver/handlers/formatting.go
@@ -5,6 +5,7 @@ import (
 
 	lsctx "github.com/hashicorp/terraform-ls/internal/context"
 	"github.com/hashicorp/terraform-ls/internal/hcl"
+	"github.com/hashicorp/terraform-ls/internal/langserver/errors"
 	ilsp "github.com/hashicorp/terraform-ls/internal/lsp"
 	lsp "github.com/hashicorp/terraform-ls/internal/protocol"
 	"github.com/hashicorp/terraform-ls/internal/terraform/module"
@@ -32,7 +33,7 @@ func (h *logHandler) TextDocumentFormatting(ctx context.Context, params lsp.Docu
 
 	tfExec, err := module.TerraformExecutorForModule(ctx, mod)
 	if err != nil {
-		return edits, err
+		return edits, errors.EnrichTfExecError(err)
 	}
 
 	file, err := fs.GetDocument(fh)

--- a/internal/terraform/module/errors.go
+++ b/internal/terraform/module/errors.go
@@ -22,3 +22,17 @@ func IsModuleNotFound(err error) bool {
 	_, ok := err.(*ModuleNotFoundErr)
 	return ok
 }
+
+type NoTerraformExecPathErr struct{}
+
+func (NoTerraformExecPathErr) Error() string {
+	return "No exec path provided for terraform"
+}
+
+func IsTerraformNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	_, ok := err.(NoTerraformExecPathErr)
+	return ok
+}


### PR DESCRIPTION
Closes #398 

I did initially consider printing out the `$PATH` too, but then I realized it may not even fit in a popup such as the one VS Code uses, or that it can't be formatted in any useful way.
