### PR TITLE
watcher: Refresh versions when plugin lockfile changes

### DIFF
--- a/internal/terraform/module/watcher.go
+++ b/internal/terraform/module/watcher.go
@@ -127,6 +127,7 @@ func (w *watcher) processEvent(event fsnotify.Event) {
 			}
 			if containsPath(mod.Watchable.PluginLockFiles, eventPath) {
 				w.modMgr.EnqueueModuleOp(mod.Path, OpTypeObtainSchema)
+				w.modMgr.EnqueueModuleOp(mod.Path, OpTypeGetTerraformVersion)
 				return
 			}
 		}
@@ -150,7 +151,9 @@ func (w *watcher) processEvent(event fsnotify.Event) {
 						return w.modMgr.EnqueueModuleOp(mod.Path, OpTypeParseModuleManifest)
 					}
 					if containsPath(mod.Watchable.PluginLockFiles, path) {
-						return w.modMgr.EnqueueModuleOp(mod.Path, OpTypeObtainSchema)
+						w.modMgr.EnqueueModuleOp(mod.Path, OpTypeObtainSchema)
+						w.modMgr.EnqueueModuleOp(mod.Path, OpTypeGetTerraformVersion)
+						return nil
 					}
 					return nil
 				})
@@ -165,6 +168,7 @@ func (w *watcher) processEvent(event fsnotify.Event) {
 
 			if containsPath(mod.Watchable.PluginLockFiles, eventPath) {
 				w.modMgr.EnqueueModuleOp(mod.Path, OpTypeObtainSchema)
+				w.modMgr.EnqueueModuleOp(mod.Path, OpTypeGetTerraformVersion)
 				return
 			}
 		}

--- a/internal/terraform/module/watcher_test.go
+++ b/internal/terraform/module/watcher_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-json"
 	"github.com/hashicorp/terraform-ls/internal/filesystem"
 	"github.com/hashicorp/terraform-ls/internal/terraform/exec"
@@ -42,6 +43,17 @@ func TestWatcher_initFromScratch(t *testing.T) {
 						},
 						ReturnArguments: []interface{}{
 							psMock,
+							nil,
+						},
+					},
+					{
+						Method: "Version",
+						Arguments: []interface{}{
+							mock.AnythingOfType("*context.cancelCtx"),
+						},
+						ReturnArguments: []interface{}{
+							version.Must(version.NewVersion("1.0.0")),
+							nil,
 							nil,
 						},
 					},
@@ -113,5 +125,17 @@ resource "aws_vpc" "example" {
 	}
 	if diff := cmp.Diff(psMock, ps); diff != "" {
 		t.Fatalf("schema mismatch: %s", diff)
+	}
+
+	v, err := mod.TerraformVersion()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v == nil {
+		t.Fatal("expected non-nil version")
+	}
+	if v.String() != "1.0.0" {
+		t.Fatalf("version mismatch.\ngiven:   %q\nexpected: %q",
+			v.String(), "1.0.0")
 	}
 }


### PR DESCRIPTION
When lock file changes we always reload the schema but it is likely that provider versions may have also changed and therefore we need to reload that too.