### PR TITLE
Exclude HPE OneView from preloaded providers

### DIFF
--- a/internal/schemas/gen/gen.go
+++ b/internal/schemas/gen/gen.go
@@ -244,6 +244,7 @@ var ignore = map[string]bool{
 	"Icinga/icinga2":         true,
 	"a10networks/vthunder":   true,
 	"jradtilbrook/buildkite": true,
+	"HewlettPackard/oneview": true,
 }
 
 func filter(providers []provider) (filtered []provider) {


### PR DESCRIPTION
The provider apparently created a Registry release entry, but haven't yet uploaded any artifacts due to what seems to be a cancelled release job:

https://github.com/HewlettPackard/terraform-provider-oneview/runs/1892292461
