### PR TITLE
build: Fix release job by passing HOME to hc-releases

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -102,6 +102,8 @@ publishers:
   - name: "hc-releases"
     checksum: true
     signature: true
+    env:
+      - HOME="{{ .Env.HOME }}"
     cmd: hc-releases upload-file {{ abs .ArtifactPath }}
 
 changelog:


### PR DESCRIPTION
This was unfortunately missed in #392

Custom publishers in GoReleaser do not inherit any environment variables by default, which includes (crucially) `$HOME` variable which in turn is used by the new AWS auth mechanism and that's causing the following failure on release attempt:

```
      • custom publisher 
         • publishing                cmd=[hc-releases upload-file /home/runner/work/terraform-ls/terraform-ls/dist/terraform-ls_0.14.0_SHA256SUMS.sig]
         • publishing                cmd=[hc-releases upload-file /home/runner/work/terraform-ls/terraform-ls/dist/terraform-ls_0.14.0_freebsd_amd64.zip]
         • Verifying S3 credentials...
 cmd=hc-releases
         • Verifying S3 credentials...
 cmd=hc-releases
         ⨯ NoCredentialProviders: no valid providers in chain
caused by: EnvAccessKeyNotFound: AWS_ACCESS_KEY_ID or AWS_ACCESS_KEY not found in environment
UserHomeNotFound: user home directory not found.
EC2RoleRequestError: no EC2 instance role found
```