### PR TITLE
Add workspace-wide symbol navigation

### DIFF
--- a/internal/langserver/handlers/handlers_test.go
+++ b/internal/langserver/handlers/handlers_test.go
@@ -38,6 +38,7 @@ func initializeResponse(t *testing.T, commandPrefix string) string {
 				"documentSymbolProvider": true,
 				"codeLensProvider": {},
 				"documentLinkProvider": {},
+				"workspaceSymbolProvider": true,
 				"documentFormattingProvider": true,
 				"documentOnTypeFormattingProvider": {
 					"firstTriggerCharacter": ""

--- a/internal/langserver/handlers/initialize.go
+++ b/internal/langserver/handlers/initialize.go
@@ -27,6 +27,7 @@ func (lh *logHandler) Initialize(ctx context.Context, params lsp.InitializeParam
 			HoverProvider:              true,
 			DocumentFormattingProvider: true,
 			DocumentSymbolProvider:     true,
+			WorkspaceSymbolProvider:    true,
 		},
 	}
 

--- a/internal/langserver/handlers/service.go
+++ b/internal/langserver/handlers/service.go
@@ -296,6 +296,18 @@ func (svc *service) Assigner() (jrpc2.Assigner, error) {
 
 			return handle(ctx, req, lh.WorkspaceExecuteCommand)
 		},
+		"workspace/symbol": func(ctx context.Context, req *jrpc2.Request) (interface{}, error) {
+			err := session.CheckInitializationIsConfirmed()
+			if err != nil {
+				return nil, err
+			}
+
+			ctx = lsctx.WithDocumentStorage(ctx, svc.fs)
+			ctx = lsctx.WithClientCapabilities(ctx, cc)
+			ctx = lsctx.WithModuleFinder(ctx, svc.modMgr)
+
+			return handle(ctx, req, lh.WorkspaceSymbol)
+		},
 		"shutdown": func(ctx context.Context, req *jrpc2.Request) (interface{}, error) {
 			err := session.Shutdown(req)
 			if err != nil {

--- a/internal/langserver/handlers/workspace_symbol.go
+++ b/internal/langserver/handlers/workspace_symbol.go
@@ -1,0 +1,42 @@
+package handlers
+
+import (
+	"context"
+
+	lsctx "github.com/hashicorp/terraform-ls/internal/context"
+	"github.com/hashicorp/terraform-ls/internal/decoder"
+	ilsp "github.com/hashicorp/terraform-ls/internal/lsp"
+	lsp "github.com/hashicorp/terraform-ls/internal/protocol"
+)
+
+func (h *logHandler) WorkspaceSymbol(ctx context.Context, params lsp.WorkspaceSymbolParams) ([]lsp.SymbolInformation, error) {
+	var symbols []lsp.SymbolInformation
+
+	mm, err := lsctx.ModuleFinder(ctx)
+	if err != nil {
+		return symbols, err
+	}
+
+	cc, err := lsctx.ClientCapabilities(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	modules := mm.ListModules()
+	for _, mod := range modules {
+		d, err := decoder.DecoderForModule(ctx, mod)
+		if err != nil {
+			return symbols, err
+		}
+
+		modSymbols, err := d.Symbols(params.Query)
+		if err != nil {
+			continue
+		}
+
+		symbols = append(symbols, ilsp.SymbolInformation(mod.Path(), modSymbols,
+			cc.Workspace.WorkspaceClientCapabilities.Symbol)...)
+	}
+
+	return symbols, nil
+}

--- a/internal/langserver/handlers/workspace_symbol_test.go
+++ b/internal/langserver/handlers/workspace_symbol_test.go
@@ -1,0 +1,148 @@
+package handlers
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-ls/internal/langserver"
+	"github.com/hashicorp/terraform-ls/internal/terraform/exec"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestLangServer_workspace_symbol_basic(t *testing.T) {
+	tmpDir := TempDir(t)
+	InitPluginCache(t, tmpDir.Dir())
+
+	ls := langserver.NewLangServerMock(t, NewMockSession(&MockSessionInput{
+		TerraformCalls: &exec.TerraformMockCalls{
+			PerWorkDir: map[string][]*mock.Call{
+				tmpDir.Dir(): validTfMockCalls(),
+			},
+		},
+	}))
+	stop := ls.Start(t)
+	defer stop()
+
+	ls.Call(t, &langserver.CallRequest{
+		Method: "initialize",
+		ReqParams: fmt.Sprintf(`{
+		"capabilities": {
+			"workspace": {
+				"symbol": {
+					"symbolKind": {
+						"valueSet": [
+							1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+							11, 12, 13, 14, 15, 16, 17, 18,
+							19, 20, 21, 22, 23, 24, 25, 26
+						]
+					},
+					"tagSupport": {
+						"valueSet": [ 1 ]
+					}
+				}
+			}
+		},
+		"rootUri": %q,
+		"processId": 12345
+	}`, tmpDir.URI())})
+	ls.Notify(t, &langserver.CallRequest{
+		Method:    "initialized",
+		ReqParams: "{}",
+	})
+	ls.Call(t, &langserver.CallRequest{
+		Method: "textDocument/didOpen",
+		ReqParams: fmt.Sprintf(`{
+		"textDocument": {
+			"version": 0,
+			"languageId": "terraform",
+			"text": "provider \"github\" {}",
+			"uri": "%s/first.tf"
+		}
+	}`, tmpDir.URI())})
+	ls.Call(t, &langserver.CallRequest{
+		Method: "textDocument/didOpen",
+		ReqParams: fmt.Sprintf(`{
+		"textDocument": {
+			"version": 0,
+			"languageId": "terraform",
+			"text": "provider \"google\" {}",
+			"uri": "%s/second.tf"
+		}
+	}`, tmpDir.URI())})
+	ls.Call(t, &langserver.CallRequest{
+		Method: "textDocument/didOpen",
+		ReqParams: fmt.Sprintf(`{
+		"textDocument": {
+			"version": 0,
+			"languageId": "terraform",
+			"text": "myblock \"custom\" {}",
+			"uri": "%s/blah/third.tf"
+		}
+	}`, tmpDir.URI())})
+
+	ls.CallAndExpectResponse(t, &langserver.CallRequest{
+		Method: "workspace/symbol",
+		ReqParams: `{
+		"query": ""
+	}`}, fmt.Sprintf(`{
+		"jsonrpc": "2.0",
+		"id": 5,
+		"result": [
+			{
+				"name": "provider \"github\"",
+				"kind": 5,
+				"location": {
+					"uri": "%s/first.tf",
+					"range": {
+						"start": {"line": 0, "character": 0},
+						"end": {"line": 0, "character": 20}
+					}
+				}
+			},
+			{
+				"name": "provider \"google\"",
+				"kind": 5,
+				"location": {
+					"uri": "%s/second.tf",
+					"range": {
+						"start": {"line": 0, "character": 0},
+						"end": {"line": 0, "character": 20}
+					}
+				}
+			},
+			{
+				"name": "myblock \"custom\"",
+				"kind": 5,
+				"location": {
+					"uri": "%s/blah/third.tf",
+					"range": {
+						"start": {"line": 0, "character": 0},
+						"end": {"line": 0, "character": 19}
+					}
+				}
+			}
+		]
+	}`, tmpDir.URI(), tmpDir.URI(), tmpDir.URI()))
+
+	ls.CallAndExpectResponse(t, &langserver.CallRequest{
+		Method: "workspace/symbol",
+		ReqParams: `{
+		"query": "myb"
+	}`}, fmt.Sprintf(`{
+		"jsonrpc": "2.0",
+		"id": 6,
+		"result": [
+			{
+				"name": "myblock \"custom\"",
+				"kind": 5,
+				"location": {
+					"uri": "%s/blah/third.tf",
+					"range": {
+						"start": {"line": 0, "character": 0},
+						"end": {"line": 0, "character": 19}
+					}
+				}
+			}
+		]
+	}`, tmpDir.URI()))
+}

--- a/internal/terraform/module/types.go
+++ b/internal/terraform/module/types.go
@@ -30,6 +30,7 @@ type ModuleFinder interface {
 	ModuleByPath(path string) (Module, error)
 	SchemaForModule(path string) (*schema.BodySchema, error)
 	SchemaSourcesForModule(path string) ([]SchemaSource, error)
+	ListModules() []Module
 }
 
 type ModuleLoader func(dir string) (Module, error)
@@ -41,7 +42,6 @@ type ModuleManager interface {
 	AddModule(modPath string) (Module, error)
 	EnqueueModuleOp(modPath string, opType OpType) error
 	EnqueueModuleOpWait(modPath string, opType OpType) error
-	ListModules() []Module
 	CancelLoading()
 }
 


### PR DESCRIPTION
Depends on #411 

--- 

Closes #315 
Closes #423 

## Example Usage in VS Code

![Screenshot 2021-02-26 at 12 45 42](https://user-images.githubusercontent.com/287584/109301962-93e5b400-7830-11eb-92d2-80bd62aa76d1.png)


![Screenshot 2021-02-26 at 12 44 01](https://user-images.githubusercontent.com/287584/109301885-757fb880-7830-11eb-96d4-4dfe1136d0b7.png)
