### PR TITLE
fix flaky test: Increase delay in watcher test

### DIFF
--- a/internal/terraform/module/watcher_test.go
+++ b/internal/terraform/module/watcher_test.go
@@ -117,7 +117,7 @@ resource "aws_vpc" "example" {
 	}
 
 	// Give watcher some time to react
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(250 * time.Millisecond)
 
 	ps, err := mod.ProviderSchema()
 	if err != nil {


### PR DESCRIPTION
This test showed up as flaky here https://github.com/hashicorp/terraform-ls/pull/427/checks?check_run_id=2089364081#step:10:34 which presumably was just a result of the short delay.