### PR TITLE
langserver/handlers: Increase delay to avoid flaky test

### DIFF
--- a/internal/langserver/handlers/handlers_test.go
+++ b/internal/langserver/handlers/handlers_test.go
@@ -145,7 +145,7 @@ func TestEOF(t *testing.T) {
 
 	// Session is stopped after all other operations stop
 	// which may take some time
-	time.Sleep(1 * time.Millisecond)
+	time.Sleep(250 * time.Millisecond)
 
 	if !ms.StopFuncCalled() {
 		t.Fatal("Expected session to stop on EOF")


### PR DESCRIPTION
This is to address this test failure:

https://github.com/hashicorp/terraform-ls/runs/2089667487#step:10:17