### PR TITLE
schemas: Exclude zerotier from schema preload list

### DIFF
--- a/internal/schemas/gen/gen.go
+++ b/internal/schemas/gen/gen.go
@@ -245,6 +245,7 @@ var ignore = map[string]bool{
 	"a10networks/vthunder":   true,
 	"jradtilbrook/buildkite": true,
 	"HewlettPackard/oneview": true,
+	"zerotier/zerotier":      true,
 }
 
 func filter(providers []provider) (filtered []provider) {


### PR DESCRIPTION
This is to address recent failures caused by what is likely a broken release:

```
Error: Failed to install provider

Error while installing zerotier/zerotier v0.1.47: checksum list has unexpected
SHA-256 hash 4db7c72387a4c0332067706e46598acc0f55991edfe63aeb63af699289977cbd
(expected 3b29b99e109b817b031239ef491d8f9ddafc4264439224fe89d72cead45678a6)
```