### PR TITLE
build: Reduce scope of GHA token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 env:
   GOPROXY: https://proxy.golang.org/
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
 
+permissions:
+  contents: write
+
 env:
   GOPROXY: https://proxy.golang.org/
 


### PR DESCRIPTION
This is to take advantage of recently announced changes:
https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/