### PR TITLE
handler/formatting: Remove unused module query

### DIFF
--- a/internal/langserver/handlers/command/init.go
+++ b/internal/langserver/handlers/command/init.go
@@ -39,7 +39,7 @@ func TerraformInitHandler(ctx context.Context, args cmd.CommandArgs) (interface{
 		}
 	}
 
-	tfExec, err := module.TerraformExecutorForModule(ctx, mod)
+	tfExec, err := module.TerraformExecutorForModule(ctx, mod.Path)
 	if err != nil {
 		return nil, errors.EnrichTfExecError(err)
 	}

--- a/internal/langserver/handlers/command/validate.go
+++ b/internal/langserver/handlers/command/validate.go
@@ -40,7 +40,7 @@ func TerraformValidateHandler(ctx context.Context, args cmd.CommandArgs) (interf
 		}
 	}
 
-	tfExec, err := module.TerraformExecutorForModule(ctx, mod)
+	tfExec, err := module.TerraformExecutorForModule(ctx, mod.Path)
 	if err != nil {
 		return nil, errors.EnrichTfExecError(err)
 	}

--- a/internal/langserver/handlers/formatting.go
+++ b/internal/langserver/handlers/formatting.go
@@ -19,19 +19,9 @@ func (h *logHandler) TextDocumentFormatting(ctx context.Context, params lsp.Docu
 		return edits, err
 	}
 
-	mf, err := lsctx.ModuleFinder(ctx)
-	if err != nil {
-		return edits, err
-	}
-
 	fh := ilsp.FileHandlerFromDocumentURI(params.TextDocument.URI)
 
-	mod, err := mf.ModuleByPath(fh.Dir())
-	if err != nil {
-		return edits, err
-	}
-
-	tfExec, err := module.TerraformExecutorForModule(ctx, mod)
+	tfExec, err := module.TerraformExecutorForModule(ctx, fh.Dir())
 	if err != nil {
 		return edits, errors.EnrichTfExecError(err)
 	}

--- a/internal/langserver/handlers/service.go
+++ b/internal/langserver/handlers/service.go
@@ -255,7 +255,6 @@ func (svc *service) Assigner() (jrpc2.Assigner, error) {
 			}
 
 			ctx = lsctx.WithDocumentStorage(ctx, svc.fs)
-			ctx = lsctx.WithModuleFinder(ctx, svc.modMgr)
 			ctx = exec.WithExecutorOpts(ctx, execOpts)
 			ctx = exec.WithExecutorFactory(ctx, svc.tfExecFactory)
 

--- a/internal/terraform/module/module_ops.go
+++ b/internal/terraform/module/module_ops.go
@@ -54,7 +54,7 @@ func GetTerraformVersion(ctx context.Context, modStore *state.ModuleStore, modPa
 	}
 	defer modStore.SetTerraformVersionState(modPath, op.OpStateLoaded)
 
-	tfExec, err := TerraformExecutorForModule(ctx, mod)
+	tfExec, err := TerraformExecutorForModule(ctx, mod.Path)
 	if err != nil {
 		sErr := modStore.UpdateTerraformVersion(modPath, nil, nil, err)
 		if err != nil {
@@ -97,7 +97,7 @@ func ObtainSchema(ctx context.Context, modStore *state.ModuleStore, schemaStore 
 		return err
 	}
 
-	tfExec, err := TerraformExecutorForModule(ctx, mod)
+	tfExec, err := TerraformExecutorForModule(ctx, mod.Path)
 	if err != nil {
 		sErr := modStore.FinishProviderSchemaLoading(modPath, err)
 		if sErr != nil {

--- a/internal/terraform/module/terraform_executor.go
+++ b/internal/terraform/module/terraform_executor.go
@@ -7,18 +7,18 @@ import (
 	"github.com/hashicorp/terraform-ls/internal/terraform/exec"
 )
 
-func TerraformExecutorForModule(ctx context.Context, mod Module) (exec.TerraformExecutor, error) {
+func TerraformExecutorForModule(ctx context.Context, modPath string) (exec.TerraformExecutor, error) {
 	newExecutor, ok := exec.ExecutorFactoryFromContext(ctx)
 	if !ok {
 		return nil, fmt.Errorf("no terraform executor provided")
 	}
 
-	execPath, err := TerraformExecPath(ctx, mod)
+	execPath, err := TerraformExecPath(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	tfExec, err := newExecutor(mod.Path, execPath)
+	tfExec, err := newExecutor(modPath, execPath)
 	if err != nil {
 		return nil, err
 	}
@@ -34,7 +34,7 @@ func TerraformExecutorForModule(ctx context.Context, mod Module) (exec.Terraform
 	return tfExec, nil
 }
 
-func TerraformExecPath(ctx context.Context, mod Module) (string, error) {
+func TerraformExecPath(ctx context.Context) (string, error) {
 	opts, ok := exec.ExecutorOptsFromContext(ctx)
 	if ok && opts.ExecPath != "" {
 		return opts.ExecPath, nil


### PR DESCRIPTION
We used to track Terraform exec path alongside each module which is because technically every module may require different TF version and relatedly different exec path. However that exec path was in practice always the same for all modules, which is also why the new module state store doesn't store it anymore.

It is possible that we'll revisit this idea of tracking exec path per module, but for now it's just better to remove it.