### PR TITLE
goreleaser: Generate key ID suffixed sig files

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -75,6 +75,13 @@ checksum:
 
 signs:
   -
+    id: with_key_id
+    signature: "${artifact}.{{ .Env.PGP_USER_ID }}.sig"
+    args: ["-u", "{{ .Env.PGP_USER_ID }}", "--output", "${signature}", "--detach-sign", "${artifact}"]
+    artifacts: checksum
+  -
+    id: default
+    signature: "${artifact}.sig"
     args: ["-u", "{{ .Env.PGP_USER_ID }}", "--output", "${signature}", "--detach-sign", "${artifact}"]
     artifacts: checksum
 


### PR DESCRIPTION
We'll generate both for backwards compatibility, although js-releases (which VS Code extension specifically uses) should only require the suffixed variant once https://github.com/hashicorp/js-releases/pull/9 is merged