### PR TITLE
preloaded schemas: ignore nirmata/nirmata

### DIFF
--- a/internal/schemas/gen/gen.go
+++ b/internal/schemas/gen/gen.go
@@ -246,6 +246,7 @@ var ignore = map[string]bool{
 	"jradtilbrook/buildkite": true,
 	"HewlettPackard/oneview": true,
 	"zerotier/zerotier":      true,
+	"nirmata/nirmata":        true,
 }
 
 func filter(providers []provider) (filtered []provider) {


### PR DESCRIPTION
With the list being a moving target I'm thinking if it's worth looking into checking via the API the availability/init-ability somehow, before attempting `init`. 🤔 

But this is just a quick solution to unblock releases for now.

```
Error: Failed to query available provider packages

Could not retrieve the list of available versions for provider
nirmata/nirmata: no available releases match the given constraints 
```