### PR TITLE
ci: Fix broken key importing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
           hc-releases version
       -
         name: Import key for archive signing
-        run: echo -e "${{ secrets.GPG_PRIVATE_KEY }}" | gpg --import
+        run: echo -e "${{ secrets.GPG_PRIVATE_KEY }}" | gpg --import --batch --no-tty
       - 
         name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1


### PR DESCRIPTION
gpg apparently uses tty for printing warnings (in this case likely about trust level for the new key)

Because there's no valid tty in GitHub Actions (or any other CI) we reflect that by passing extra flags to gpg.

This should address the following error during release:

```
gpg: key 34365D9472D7468F/B0B441097685B676: error sending to agent: Inappropriate ioctl for device
gpg: error reading '[stdin]': Inappropriate ioctl for device
gpg: import from '[stdin]' failed: Inappropriate ioctl for device
```

If this doesn't work then we can consider swapping that `echo | gpg` command for https://github.com/hashicorp/ghaction-import-gpg which is used by most Terraform providers AFAIK.