### PR TITLE
goreleaser: Fix broken signing

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -77,12 +77,12 @@ signs:
   -
     id: with_key_id
     signature: "${artifact}.{{ .Env.GPG_KEY_ID }}.sig"
-    args: ["-u", "{{ .Env.GPG_KEY_ID }}", "--output", "${signature}", "--detach-sign", "${artifact}"]
+    args: ["-u", "{{ .Env.GPG_KEY_ID }}", "--output", "${signature}", "--detach-sign", "${artifact}", "--batch", "--no-tty"]
     artifacts: checksum
   -
     id: default
     signature: "${artifact}.sig"
-    args: ["-u", "{{ .Env.GPG_KEY_ID }}", "--output", "${signature}", "--detach-sign", "${artifact}"]
+    args: ["-u", "{{ .Env.GPG_KEY_ID }}", "--output", "${signature}", "--detach-sign", "${artifact}", "--batch", "--no-tty"]
     artifacts: checksum
 
 brews:


### PR DESCRIPTION
This is to apply a patch similar to https://github.com/hashicorp/terraform-ls/pull/474 which should address the following failure observed during release:

```
 • signing artifacts
      • signing                   cmd=[gpg -u *** --output dist/terraform-ls_0.16.0_SHA256SUMS.sig --detach-sign dist/terraform-ls_0.16.0_SHA256SUMS]
      • signing                   cmd=[gpg -u *** --output dist/terraform-ls_0.16.0_SHA256SUMS.***.sig --detach-sign dist/terraform-ls_0.16.0_SHA256SUMS]
      • gpg: signing failed: Inappropriate ioctl for device
 cmd=gpg
      • gpg: signing failed: Inappropriate ioctl for device
 cmd=gpg
      • gpg: signing failed: Inappropriate ioctl for device
 cmd=gpg
      • gpg: signing failed: Inappropriate ioctl for device
 cmd=gpg
   ⨯ release failed after 867.67s error=sign: gpg failed
```