### PR TITLE
ci: Change secret name for GPG key

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
           hc-releases version
       -
         name: Import key for archive signing
-        run: echo -e "${{ secrets.GPG_PRIVATE_KEY }}" | gpg --import --batch --no-tty
+        run: echo -e "${{ secrets.GPG_PRIVATE_KEY_DECRYPTED }}" | gpg --import --batch --no-tty
       - 
         name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1


### PR DESCRIPTION
Apparently the TTY-related problems (which I attempted to fix in https://github.com/hashicorp/terraform-ls/pull/474 and https://github.com/hashicorp/terraform-ls/pull/475) surfaced as `Inappropriate ioctl for device` were caused by passphrase requirement on the key I wasn't aware of.

We could use the passphrased key, but there seems little benefit in terms of risk (when both are stored in the same place) and it increases complexity of the pipeline.