### PR TITLE
goreleaser: Fix templating in signs

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -76,13 +76,11 @@ checksum:
 signs:
   -
     id: with_key_id
-    signature: "${artifact}.{{ .Env.GPG_KEY_ID }}.sig"
-    args: ["--batch", "--no-tty", "-u", "{{ .Env.GPG_KEY_ID }}", "--output", "${signature}", "--detach-sign", "${artifact}"]
+    args: ["--batch", "--no-tty", "-u", "{{ .Env.GPG_KEY_ID }}", "--output", "${artifact}.{{ .Env.GPG_KEY_ID }}.sig", "--detach-sign", "${artifact}"]
     artifacts: checksum
   -
     id: default
-    signature: "${artifact}.sig"
-    args: ["--batch", "--no-tty", "-u", "{{ .Env.GPG_KEY_ID }}", "--output", "${signature}", "--detach-sign", "${artifact}"]
+    args: ["--batch", "--no-tty", "-u", "{{ .Env.GPG_KEY_ID }}", "--output", "${artifact}.sig", "--detach-sign", "${artifact}"]
     artifacts: checksum
 
 brews:


### PR DESCRIPTION
GoReleaser doesn't seem to support templating in the `signature` field (yet), so we can instead just pass the sig filename directly in `args` where templating _is_ supported.