### PR TITLE
goreleaser: avoid producing duplicate sig files

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -76,10 +76,13 @@ checksum:
 signs:
   -
     id: with_key_id
+    # TODO: Replace with variable once goreleaser supports variables here
+    signature: "${artifact}.72D7468F.sig"
     args: ["--batch", "--no-tty", "-u", "{{ .Env.GPG_KEY_ID }}", "--output", "${artifact}.{{ .Env.GPG_KEY_ID }}.sig", "--detach-sign", "${artifact}"]
     artifacts: checksum
   -
     id: default
+    signature: "${artifact}.sig"
     args: ["--batch", "--no-tty", "-u", "{{ .Env.GPG_KEY_ID }}", "--output", "${artifact}.sig", "--detach-sign", "${artifact}"]
     artifacts: checksum
 


### PR DESCRIPTION
In an attempt to work around the unsupported templating in `signature` I didn't realize that steps following after `signs`, such as custom publishers will only pick up the files per `signature`, which - if left undefined are duplicate and cause releases to fail while uploading the same file twice to GitHub.