### PR TITLE
fix: prevent crash for legacy provider lookups

### DIFF
--- a/internal/langserver/handlers/service.go
+++ b/internal/langserver/handlers/service.go
@@ -110,6 +110,7 @@ func (svc *service) Assigner() (jrpc2.Assigner, error) {
 	if err != nil {
 		return nil, err
 	}
+	store.SetLogger(svc.logger)
 
 	err = schemas.PreloadSchemasToStore(store.ProviderSchemas)
 	if err != nil {

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -1,6 +1,9 @@
 package state
 
 import (
+	"io/ioutil"
+	"log"
+
 	"github.com/hashicorp/go-memdb"
 	"github.com/hashicorp/go-version"
 	tfaddr "github.com/hashicorp/terraform-registry-address"
@@ -52,6 +55,7 @@ type StateStore struct {
 type ModuleStore struct {
 	db        *memdb.MemDB
 	tableName string
+	logger    *log.Logger
 }
 
 type ModuleReader interface {
@@ -63,6 +67,7 @@ type ModuleReader interface {
 type ProviderSchemaStore struct {
 	db        *memdb.MemDB
 	tableName string
+	logger    *log.Logger
 }
 
 type SchemaReader interface {
@@ -79,10 +84,19 @@ func NewStateStore() (*StateStore, error) {
 		Modules: &ModuleStore{
 			db:        db,
 			tableName: moduleTableName,
+			logger:    defaultLogger,
 		},
 		ProviderSchemas: &ProviderSchemaStore{
 			db:        db,
 			tableName: providerSchemaTableName,
+			logger:    defaultLogger,
 		},
 	}, nil
 }
+
+func (s *StateStore) SetLogger(logger *log.Logger) {
+	s.Modules.logger = logger
+	s.ProviderSchemas.logger = logger
+}
+
+var defaultLogger = log.New(ioutil.Discard, "", 0)


### PR DESCRIPTION
Fixes #479 

This accounts for a case where users don't have explicit provider requirement in their configuration, but use Terraform 0.13+ (which outputs provider schemas with new addresses).

Generally `ProviderSchema()` is not meant to ever return `nil, nil`, which other logic in `terraform-schema` relies on:

https://github.com/hashicorp/terraform-schema/blob/ad0461b4382716039f6d35e8fd9bd8599458285c/schema/schema_merge.go#L70-L77

I also added some extra logging in "hot paths" which users are likely to hit and where knowing more may aid debugging in the future.

Legacy addresses will unfortunately not be eliminated in the near future, despite how we refer to them (legacy) as there's currently no plan for making explicit `source` argument required in Terraform v1.

We can guide people to help eliminate it https://github.com/hashicorp/terraform-ls/issues/480 and convert legacy addresses ourselves https://github.com/hashicorp/terraform-ls/issues/458

Regardless though we need to be able to deal with such legacy addresses in the meantime.