### PR TITLE
Add support for traversals/references

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,12 +11,12 @@ require (
 	github.com/hashicorp/go-memdb v1.3.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-version v1.3.0
-	github.com/hashicorp/hcl-lang v0.0.0-20210419185146-8556dd730bc7
+	github.com/hashicorp/hcl-lang v0.0.0-20210514214009-15d3afdead68
 	github.com/hashicorp/hcl/v2 v2.10.0
 	github.com/hashicorp/terraform-exec v0.13.3
 	github.com/hashicorp/terraform-json v0.11.0
 	github.com/hashicorp/terraform-registry-address v0.0.0-20210412075316-9b2996cce896
-	github.com/hashicorp/terraform-schema v0.0.0-20210428174709-ad0461b43827
+	github.com/hashicorp/terraform-schema v0.0.0-20210514214427-b947185f165d
 	github.com/mh-cbon/go-fmt-fail v0.0.0-20160815164508-67765b3fbcb5
 	github.com/mitchellh/cli v1.1.2
 	github.com/mitchellh/copystructure v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -188,10 +188,9 @@ github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uG
 github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f/go.mod h1:oZtUIOe8dh44I2q6ScRibXws4Ajl+d+nod3AaR9vL5w=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/hashicorp/hcl-lang v0.0.0-20210419185146-8556dd730bc7 h1:6ajS9kFs/7UnRcy3dHThUnmicqU7VjGUn0RLOT6Ewq0=
-github.com/hashicorp/hcl-lang v0.0.0-20210419185146-8556dd730bc7/go.mod h1:VRVfqufUmJSpWsoWDtYV/BejqCV+NNyS9V9vR0dcivs=
+github.com/hashicorp/hcl-lang v0.0.0-20210514214009-15d3afdead68 h1:Y5HxVHg9bKiS8Q4Q3dHOdETtF4DEmKNVdBh93o5K1L0=
+github.com/hashicorp/hcl-lang v0.0.0-20210514214009-15d3afdead68/go.mod h1:7BtIzYAy75UR501SFkNjL98xMZbvn5Vc7bj+dOgcH70=
 github.com/hashicorp/hcl/v2 v2.0.0/go.mod h1:oVVDG71tEinNGYCxinCYadcmKU9bglqW9pV3txagJ90=
-github.com/hashicorp/hcl/v2 v2.9.1/go.mod h1:FwWsfWEjyV/CMj8s/gqAuiviY72rJ1/oayI9WftqcKg=
 github.com/hashicorp/hcl/v2 v2.10.0 h1:1S1UnuhDGlv3gRFV4+0EdwB+znNP5HmcGbIqwnSCByg=
 github.com/hashicorp/hcl/v2 v2.10.0/go.mod h1:FwWsfWEjyV/CMj8s/gqAuiviY72rJ1/oayI9WftqcKg=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
@@ -207,8 +206,8 @@ github.com/hashicorp/terraform-json v0.11.0 h1:4zDqqW2F3kOysORIaYKFGgWDYIRA3hwqx
 github.com/hashicorp/terraform-json v0.11.0/go.mod h1:pmbq9o4EuL43db5+0ogX10Yofv1nozM+wskr/bGFJpI=
 github.com/hashicorp/terraform-registry-address v0.0.0-20210412075316-9b2996cce896 h1:1FGtlkJw87UsTMg5s8jrekrHmUPUJaMcu6ELiVhQrNw=
 github.com/hashicorp/terraform-registry-address v0.0.0-20210412075316-9b2996cce896/go.mod h1:bzBPnUIkI0RxauU8Dqo+2KrZZ28Cf48s8V6IHt3p4co=
-github.com/hashicorp/terraform-schema v0.0.0-20210428174709-ad0461b43827 h1:wf2hrzKEi5WOZkp5U0GGLKsslbFrGob2GJ35rjwMiO0=
-github.com/hashicorp/terraform-schema v0.0.0-20210428174709-ad0461b43827/go.mod h1:K3XjJOEolIgMNwNb/cVbSSO8nBxvO/JLDAuTOLbT7XQ=
+github.com/hashicorp/terraform-schema v0.0.0-20210514214427-b947185f165d h1:XFxb7PJ76yRdoo/IINuh2ASgujNL8jlhaeulXVbDVUA=
+github.com/hashicorp/terraform-schema v0.0.0-20210514214427-b947185f165d/go.mod h1:qzSjebjYVlcz56pBd2It3XmkOywXHNjnC/420WHSdaU=
 github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734 h1:HKLsbzeOsfXmKNpr3GiT18XAblV0BjCbzL8KQAMZGa0=
 github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734/go.mod h1:kNDNcF7sN4DocDLBkQYz73HGKwN1ANB1blq4lIYLYvg=
 github.com/huandu/xstrings v1.3.2 h1:L18LIDzqlW6xN2rEkpdV8+oL/IXWJ1APd+vsdYy4Wdw=
@@ -266,7 +265,6 @@ github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceT
 github.com/mitchellh/cli v1.1.2 h1:PvH+lL2B7IQ101xQL63Of8yFS2y+aDlsFcsqNc+u/Kw=
 github.com/mitchellh/cli v1.1.2/go.mod h1:6iaV0fGdElS6dPBx0EApTxHrcWvmJphyh2n8YBLPPZ4=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
-github.com/mitchellh/copystructure v1.1.2/go.mod h1:EBArHfARyrSWO/+Wyr9zwEkc6XMFB9XyNgFNmRkZZU4=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
@@ -284,7 +282,6 @@ github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh
 github.com/mitchellh/mapstructure v1.4.1 h1:CpVNEelQCZBooIPDn+AR3NpivK/TIKU8bDxdASFVQag=
 github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
-github.com/mitchellh/reflectwalk v1.0.1/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -383,7 +380,6 @@ github.com/zclconf/go-cty v1.1.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLE
 github.com/zclconf/go-cty v1.2.0/go.mod h1:hOPWgoHbaTUnI5k4D2ld+GRpFJSCe6bCM7m1q/N4PQ8=
 github.com/zclconf/go-cty v1.2.1/go.mod h1:hOPWgoHbaTUnI5k4D2ld+GRpFJSCe6bCM7m1q/N4PQ8=
 github.com/zclconf/go-cty v1.8.0/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
-github.com/zclconf/go-cty v1.8.1/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
 github.com/zclconf/go-cty v1.8.2/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
 github.com/zclconf/go-cty v1.8.3 h1:48gwZXrdSADU2UW9eZKHprxAI7APZGW9XmExpJpSjT0=
 github.com/zclconf/go-cty v1.8.3/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=

--- a/internal/decoder/decoder.go
+++ b/internal/decoder/decoder.go
@@ -5,12 +5,18 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/hcl-lang/decoder"
+	"github.com/hashicorp/hcl-lang/lang"
 	lsctx "github.com/hashicorp/terraform-ls/internal/context"
 	"github.com/hashicorp/terraform-ls/internal/terraform/module"
 )
 
 func DecoderForModule(ctx context.Context, mod module.Module) (*decoder.Decoder, error) {
 	d := decoder.NewDecoder()
+
+	d.SetReferenceReader(func() lang.References {
+		return mod.References
+	})
+
 	d.SetUtmSource("terraform-ls")
 	d.UseUtmContent(true)
 

--- a/internal/langserver/handlers/did_change.go
+++ b/internal/langserver/handlers/did_change.go
@@ -67,6 +67,10 @@ func TextDocumentDidChange(ctx context.Context, params lsp.DidChangeTextDocument
 	if err != nil {
 		return err
 	}
+	err = modMgr.EnqueueModuleOpWait(mod.Path, op.OpTypeDecodeReferences)
+	if err != nil {
+		return err
+	}
 
 	diags, err := lsctx.Diagnostics(ctx)
 	if err != nil {

--- a/internal/langserver/handlers/did_open.go
+++ b/internal/langserver/handlers/did_open.go
@@ -48,6 +48,7 @@ func (lh *logHandler) TextDocumentDidOpen(ctx context.Context, params lsp.DidOpe
 	// TODO: Do this only if we can verify the file differs?
 	modMgr.EnqueueModuleOpWait(mod.Path, op.OpTypeParseConfiguration)
 	modMgr.EnqueueModuleOpWait(mod.Path, op.OpTypeLoadModuleMetadata)
+	modMgr.EnqueueModuleOpWait(mod.Path, op.OpTypeDecodeReferences)
 
 	if mod.TerraformVersionState == op.OpStateUnknown {
 		modMgr.EnqueueModuleOp(mod.Path, op.OpTypeGetTerraformVersion)

--- a/internal/lsp/completion.go
+++ b/internal/lsp/completion.go
@@ -48,12 +48,14 @@ func toCompletionItem(candidate lang.Candidate, caps lsp.CompletionClientCapabil
 		kind = lsp.EnumCompletion
 	case lang.MapCandidateKind, lang.ObjectCandidateKind:
 		kind = lsp.StructCompletion
+	case lang.TraversalCandidateKind:
+		kind = lsp.VariableCompletion
 	}
 
 	// TODO: Omit item which uses kind unsupported by the client
 
 	var cmd *lsp.Command
-	if candidate.TriggerSuggest {
+	if candidate.TriggerSuggest && snippetSupport {
 		cmd = &lsp.Command{
 			Command: "editor.action.triggerSuggest",
 			Title:   "Suggest",

--- a/internal/lsp/token_encoder.go
+++ b/internal/lsp/token_encoder.go
@@ -47,6 +47,10 @@ func (te *TokenEncoder) encodeTokenOfIndex(i int) []float64 {
 		tokenType = TokenTypeParameter
 	case lang.TokenMapKey:
 		tokenType = TokenTypeParameter
+	case lang.TokenKeyword:
+		tokenType = TokenTypeVariable
+	case lang.TokenTraversalStep:
+		tokenType = TokenTypeVariable
 
 	default:
 		return []float64{}

--- a/internal/lsp/token_types.go
+++ b/internal/lsp/token_types.go
@@ -108,6 +108,7 @@ var (
 		TokenTypeKeyword,
 		TokenTypeNumber,
 		TokenTypeParameter,
+		TokenTypeVariable,
 	}
 	serverTokenModifiers = TokenModifiers{
 		TokenModifierDeprecated,

--- a/internal/terraform/module/builtin_references.go
+++ b/internal/terraform/module/builtin_references.go
@@ -1,0 +1,53 @@
+package module
+
+import (
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/zclconf/go-cty/cty"
+)
+
+var builtinScopeId = lang.ScopeId("builtin")
+
+func builtinReferences(modPath string) lang.References {
+	return lang.References{
+		{
+			Addr: lang.Address{
+				lang.RootStep{Name: "path"},
+				lang.AttrStep{Name: "module"},
+			},
+			ScopeId: builtinScopeId,
+			Type:    cty.String,
+			Description: lang.Markdown("The filesystem path of the module where the expression is placed\n\n" +
+				modPath),
+		},
+		{
+			Addr: lang.Address{
+				lang.RootStep{Name: "path"},
+				lang.AttrStep{Name: "root"},
+			},
+			ScopeId:     builtinScopeId,
+			Type:        cty.String,
+			Description: lang.Markdown("The filesystem path of the root module of the configuration"),
+		},
+		{
+			Addr: lang.Address{
+				lang.RootStep{Name: "path"},
+				lang.AttrStep{Name: "cwd"},
+			},
+			ScopeId: builtinScopeId,
+			Type:    cty.String,
+			Description: lang.Markdown("The filesystem path of the current working directory.\n\n" +
+				"In normal use of Terraform this is the same as `path.root`, " +
+				"but some advanced uses of Terraform run it from a directory " +
+				"other than the root module directory, causing these paths to be different."),
+		},
+		{
+			Addr: lang.Address{
+				lang.RootStep{Name: "terraform"},
+				lang.AttrStep{Name: "workspace"},
+			},
+			ScopeId:     builtinScopeId,
+			Type:        cty.String,
+			Description: lang.Markdown("The name of the currently selected workspace"),
+		},
+	}
+}

--- a/internal/terraform/module/module_manager.go
+++ b/internal/terraform/module/module_manager.go
@@ -103,6 +103,10 @@ func (mm *moduleManager) SchemaForModule(modPath string) (*schema.BodySchema, er
 		return nil, err
 	}
 
+	return schemaForModule(mod, mm.schemaStore)
+}
+
+func schemaForModule(mod *state.Module, schemaReader state.SchemaReader) (*schema.BodySchema, error) {
 	var coreSchema *schema.BodySchema
 	coreRequirements := make(version.Constraints, 0)
 	if mod.TerraformVersion != nil {
@@ -120,7 +124,7 @@ func (mm *moduleManager) SchemaForModule(modPath string) (*schema.BodySchema, er
 	}
 
 	sm := tfschema.NewSchemaMerger(coreSchema)
-	sm.SetSchemaReader(mm.schemaStore)
+	sm.SetSchemaReader(schemaReader)
 
 	meta := &tfmodule.Meta{
 		Path:                 mod.Path,

--- a/internal/terraform/module/operation/op_type_string.go
+++ b/internal/terraform/module/operation/op_type_string.go
@@ -14,11 +14,12 @@ func _() {
 	_ = x[OpTypeParseConfiguration-3]
 	_ = x[OpTypeParseModuleManifest-4]
 	_ = x[OpTypeLoadModuleMetadata-5]
+	_ = x[OpTypeDecodeReferences-6]
 }
 
-const _OpType_name = "OpTypeUnknownOpTypeGetTerraformVersionOpTypeObtainSchemaOpTypeParseConfigurationOpTypeParseModuleManifestOpTypeLoadModuleMetadata"
+const _OpType_name = "OpTypeUnknownOpTypeGetTerraformVersionOpTypeObtainSchemaOpTypeParseConfigurationOpTypeParseModuleManifestOpTypeLoadModuleMetadataOpTypeDecodeReferences"
 
-var _OpType_index = [...]uint8{0, 13, 38, 56, 80, 105, 129}
+var _OpType_index = [...]uint8{0, 13, 38, 56, 80, 105, 129, 151}
 
 func (i OpType) String() string {
 	if i >= OpType(len(_OpType_index)-1) {

--- a/internal/terraform/module/operation/operation.go
+++ b/internal/terraform/module/operation/operation.go
@@ -20,4 +20,5 @@ const (
 	OpTypeParseConfiguration
 	OpTypeParseModuleManifest
 	OpTypeLoadModuleMetadata
+	OpTypeDecodeReferences
 )


### PR DESCRIPTION
Builds on https://github.com/hashicorp/hcl-lang/pull/36
Builds on https://github.com/hashicorp/terraform-schema/pull/41

--- 

Some known (most likely desirable) features were intentionally left out from the MVP, but are tracked individually and will be eventually implemented:

- variable `type` declarations: https://github.com/hashicorp/terraform-ls/issues/490
- references to variables & locals (via `var.x` or `local.x`): https://github.com/hashicorp/terraform-ls/issues/491
- step-based completion: https://github.com/hashicorp/terraform-ls/issues/492
- showing interpolated expression value on hover: https://github.com/hashicorp/terraform-ls/issues/495
- recognition of individual expressions when nested: https://github.com/hashicorp/terraform-ls/issues/496
- references to `module` outputs & completion of inputs: https://github.com/hashicorp/terraform-ls/issues/93

Generally if something related to reference completion/hover etc. seems missing from that list, or the implementation I would suggest opening a new issue (rather than commenting here on this PR).

--- 

### Screenshots

![Screenshot 2021-05-17 at 21 00 34](https://user-images.githubusercontent.com/287584/118549906-055c4100-b754-11eb-8e86-adb77e413a4d.png)
![Screenshot 2021-05-17 at 21 00 46](https://user-images.githubusercontent.com/287584/118549911-05f4d780-b754-11eb-94f4-246367d8d7ce.png)
![Screenshot 2021-05-17 at 21 01 37](https://user-images.githubusercontent.com/287584/118549916-068d6e00-b754-11eb-84f3-08f5ecb4527f.png)
![Screenshot 2021-05-17 at 21 01 56](https://user-images.githubusercontent.com/287584/118549919-068d6e00-b754-11eb-9542-fe388b272a70.png)
