### PR TITLE
schemas: Exclude datastax/astra from pre-generated schemas

### DIFF
--- a/internal/schemas/gen/gen.go
+++ b/internal/schemas/gen/gen.go
@@ -247,6 +247,7 @@ var ignore = map[string]bool{
 	"HewlettPackard/oneview": true,
 	"zerotier/zerotier":      true,
 	"nirmata/nirmata":        true,
+	"datastax/astra":         true,
 }
 
 func filter(providers []provider) (filtered []provider) {


### PR DESCRIPTION
```
Error: Failed to query available provider packages

Could not retrieve the list of available versions for provider
datastax/astra: no available releases match the given constraints 

```