### PR TITLE
Add test for '$/cancelRequest' method

### DIFF
--- a/internal/langserver/handlers/cancel_request_test.go
+++ b/internal/langserver/handlers/cancel_request_test.go
@@ -1,0 +1,77 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/creachadair/jrpc2"
+	"github.com/creachadair/jrpc2/handler"
+	"github.com/hashicorp/terraform-ls/internal/langserver"
+)
+
+func TestLangServer_cancelRequest(t *testing.T) {
+	tmpDir := TempDir(t)
+
+	ls := langserver.NewLangServerMock(t, NewMockSession(&MockSessionInput{
+		AdditionalHandlers: map[string]handler.Func{
+			"$/sleepTicker": func(ctx context.Context, req *jrpc2.Request) (interface{}, error) {
+				ticker := time.NewTicker(100 * time.Millisecond)
+
+				ctx, cancelFunc := context.WithTimeout(ctx, 1*time.Second)
+				t.Cleanup(cancelFunc)
+
+				var wg sync.WaitGroup
+				wg.Add(1)
+				go func(ctx context.Context) {
+					defer wg.Done()
+					for {
+						select {
+						case <-ctx.Done():
+							ticker.Stop()
+							return
+						case <-ticker.C:
+							log.Printf("tick at %s", time.Now())
+						}
+					}
+				}(ctx)
+				wg.Wait()
+
+				return nil, ctx.Err()
+			},
+		},
+	}))
+	stop := ls.Start(t)
+	defer stop()
+
+	ls.Call(t, &langserver.CallRequest{
+		Method: "initialize",
+		ReqParams: fmt.Sprintf(`{
+	    "capabilities": {},
+	    "rootUri": %q,
+	    "processId": 12345
+	}`, tmpDir.URI())})
+	ls.Notify(t, &langserver.CallRequest{
+		Method:    "initialized",
+		ReqParams: "{}",
+	})
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		ls.CallAndExpectError(t, &langserver.CallRequest{
+			Method:    "$/sleepTicker",
+			ReqParams: `{}`,
+		}, context.Canceled)
+	}()
+	time.Sleep(100 * time.Millisecond)
+	ls.Call(t, &langserver.CallRequest{
+		Method:    "$/cancelRequest",
+		ReqParams: fmt.Sprintf(`{"id": %d}`, 2),
+	})
+	wg.Wait()
+}

--- a/internal/langserver/handlers/service.go
+++ b/internal/langserver/handlers/service.go
@@ -42,6 +42,8 @@ type service struct {
 	newWalker        module.WalkerFactory
 	tfDiscoFunc      discovery.DiscoveryFunc
 	tfExecFactory    exec.ExecutorFactory
+
+	additionalHandlers map[string]rpch.Func
 }
 
 var discardLogs = log.New(ioutil.Discard, "", 0)
@@ -342,6 +344,13 @@ func (svc *service) Assigner() (jrpc2.Assigner, error) {
 
 			return handle(ctx, req, CancelRequest)
 		},
+	}
+
+	// For use in tests, e.g. to test request cancellation
+	if len(svc.additionalHandlers) > 0 {
+		for methodName, handlerFunc := range svc.additionalHandlers {
+			m[methodName] = handlerFunc
+		}
 	}
 
 	return convertMap(m), nil


### PR DESCRIPTION
Cancellation was fixed via https://github.com/hashicorp/terraform-ls/pull/489

Here I'm just adding a test (which fails when concurrency is set to `1`).

Closes #314
