### PR TITLE
ci: Remove codecov

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -1,5 +1,0 @@
-comment: false
-coverage:
-  status:
-    project: off
-    patch: off

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,10 +96,4 @@ jobs:
         run: make fmt
       -
         name: Run tests
-        run: go test -coverprofile="coverage.txt" -covermode=atomic -race ./...
-      -
-        name: Upload code coverage report
-        uses: codecov/codecov-action@v1
-        with:
-          file: coverage.txt
-          env_vars: "GOOS,GOARCH"
+        run: go test -cover -covermode=atomic -race ./...


### PR DESCRIPTION
Codecov was disabled org-wide as a part of responding to the security incident [HCSEC-2021-12](https://discuss.hashicorp.com/t/hcsec-2021-12-codecov-security-event-and-hashicorp-gpg-key-exposure/23512).

This is a follow-up PR to remove the integration which no longer works due to that.
