### PR TITLE
cmd/module.callers: Remove rel_path field

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -87,7 +87,6 @@ can be used to hint the user e.g. where to run `init` or `validate` from.
  - `v` - describes version of the format; Will be used in the future to communicate format changes.
  - `callers` - array of any modules found in the workspace which call the module in question
    - `uri` - URI of the directory (absolute path)
-   - `rel_path` - path relative to the module in question, suitable to display in any UI elements
 
 ```json
 {
@@ -95,11 +94,9 @@ can be used to hint the user e.g. where to run `init` or `validate` from.
 	"callers": [
 		{
 			"uri": "file:///path/to/dev",
-			"rel_path": "../dev"
 		},
 		{
 			"uri": "file:///path/to/prod",
-			"rel_path": "../prod"
 		}
 	]
 }

--- a/internal/langserver/handlers/command/module_callers.go
+++ b/internal/langserver/handlers/command/module_callers.go
@@ -3,7 +3,6 @@ package command
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 	"sort"
 
 	"github.com/creachadair/jrpc2/code"
@@ -20,8 +19,7 @@ type moduleCallersResponse struct {
 }
 
 type moduleCaller struct {
-	URI          string `json:"uri"`
-	RelativePath string `json:"rel_path"`
+	URI string `json:"uri"`
 }
 
 func ModuleCallersHandler(ctx context.Context, args cmd.CommandArgs) (interface{}, error) {
@@ -47,13 +45,8 @@ func ModuleCallersHandler(ctx context.Context, args cmd.CommandArgs) (interface{
 
 	callers := make([]moduleCaller, 0)
 	for _, caller := range modCallers {
-		relPath, err := filepath.Rel(modPath, caller.Path)
-		if err != nil {
-			return nil, err
-		}
 		callers = append(callers, moduleCaller{
-			URI:          uri.FromPath(caller.Path),
-			RelativePath: relPath,
+			URI: uri.FromPath(caller.Path),
 		})
 	}
 	sort.SliceStable(callers, func(i, j int) bool {

--- a/internal/langserver/handlers/execute_command_module_callers_test.go
+++ b/internal/langserver/handlers/execute_command_module_callers_test.go
@@ -98,10 +98,6 @@ func TestLangServer_workspaceExecuteCommand_moduleCallers_basic(t *testing.T) {
 		}
 	}`, fmt.Sprintf("%s/main.tf", baseDirUri))})
 
-	devName := filepath.Join("..", "dev")
-	prodName := filepath.Join("..", "prod")
-	stagingName := filepath.Join("..", "staging")
-
 	ls.CallAndExpectResponse(t, &langserver.CallRequest{
 		Method: "workspace/executeCommand",
 		ReqParams: fmt.Sprintf(`{
@@ -114,20 +110,17 @@ func TestLangServer_workspaceExecuteCommand_moduleCallers_basic(t *testing.T) {
 			"v": 0,
 			"callers": [
 				{
-					"uri": "%s/dev",
-					"rel_path": %q
+					"uri": "%s/dev"
 				},
 				{
-					"uri": "%s/prod",
-					"rel_path": %q
+					"uri": "%s/prod"
 				},
 				{
-					"uri": "%s/staging",
-					"rel_path": %q
+					"uri": "%s/staging"
 				}
 			]
 		}
-	}`, rootUri, devName, rootUri, prodName, rootUri, stagingName))
+	}`, rootUri, rootUri, rootUri))
 }
 
 func createModuleCalling(t *testing.T, src, modPath string) {


### PR DESCRIPTION
As discussed this field is actually no longer needed by the VS Code extension and so it's better to keep the API minimal.

https://github.com/hashicorp/vscode-terraform/pull/633#issuecomment-843592045