### PR TITLE
schemas: Exclude oktadeveloper/okta

### DIFF
--- a/internal/schemas/gen/gen.go
+++ b/internal/schemas/gen/gen.go
@@ -248,6 +248,7 @@ var ignore = map[string]bool{
 	"zerotier/zerotier":      true,
 	"nirmata/nirmata":        true,
 	"datastax/astra":         true,
+	"oktadeveloper/okta":     true,
 }
 
 func filter(providers []provider) (filtered []provider) {


### PR DESCRIPTION
This is due to the old namespace having a broken build without linux/amd64 for some reason:

https://github.com/okta/terraform-provider-okta/issues/480
