### PR TITLE
Support variable `default`

### DIFF
--- a/internal/terraform/module/module_manager.go
+++ b/internal/terraform/module/module_manager.go
@@ -143,6 +143,7 @@ func schemaForModule(mod *state.Module, schemaReader state.SchemaReader) (*schem
 		CoreRequirements:     coreRequirements,
 		ProviderRequirements: mod.Meta.ProviderRequirements,
 		ProviderReferences:   mod.Meta.ProviderReferences,
+		Variables:            mod.Meta.Variables,
 	}
 
 	return sm.SchemaForModule(meta)


### PR DESCRIPTION
So that completion/hover/highlighting is available for variable
`default`.

Fixes #537

## Example

![2021-06-10 11 40 01](https://user-images.githubusercontent.com/287584/121511574-aef3c280-c9e0-11eb-9644-7b9c86b38dc3.gif)
