### PR TITLE
internal/schemas: Bump TF version requirement to ~> 1

### DIFF
--- a/internal/schemas/gen/gen.go
+++ b/internal/schemas/gen/gen.go
@@ -21,7 +21,7 @@ import (
 )
 
 const terraformBlock = `terraform {
-	required_version = "~> 0.13"
+	required_version = "~> 1"
   required_providers {
   {{ range $i, $p := . }}
     {{ $p.Name }}-{{ $i }} = {


### PR DESCRIPTION
This should address the following CI failure:

https://github.com/hashicorp/terraform-ls/pull/555/checks?check_run_id=2848589136#step:6:63

```
error: terraform core version not supported by configuration
```