### PR TITLE
Mock out code lens support

### DIFF
--- a/internal/langserver/handlers/code_lens.go
+++ b/internal/langserver/handlers/code_lens.go
@@ -1,0 +1,12 @@
+package handlers
+
+import (
+	"context"
+
+	lsp "github.com/hashicorp/terraform-ls/internal/protocol"
+)
+
+func (h *logHandler) TextDocumentCodeLens(ctx context.Context, params lsp.CodeLensParams) ([]lsp.CodeLens, error) {
+	// TODO: Implement code lens
+	return []lsp.CodeLens{}, nil
+}

--- a/internal/langserver/handlers/initialize.go
+++ b/internal/langserver/handlers/initialize.go
@@ -24,6 +24,7 @@ func (lh *logHandler) Initialize(ctx context.Context, params lsp.InitializeParam
 			CompletionProvider: lsp.CompletionOptions{
 				ResolveProvider: false,
 			},
+			CodeLensProvider:           lsp.CodeLensOptions{},
 			HoverProvider:              true,
 			DocumentFormattingProvider: true,
 			DocumentSymbolProvider:     true,

--- a/internal/langserver/handlers/service.go
+++ b/internal/langserver/handlers/service.go
@@ -256,6 +256,14 @@ func (svc *service) Assigner() (jrpc2.Assigner, error) {
 
 			return handle(ctx, req, lh.TextDocumentHover)
 		},
+		"textDocument/codeLens": func(ctx context.Context, req *jrpc2.Request) (interface{}, error) {
+			err := session.CheckInitializationIsConfirmed()
+			if err != nil {
+				return nil, err
+			}
+
+			return handle(ctx, req, lh.TextDocumentCodeLens)
+		},
 		"textDocument/formatting": func(ctx context.Context, req *jrpc2.Request) (interface{}, error) {
 			err := session.CheckInitializationIsConfirmed()
 			if err != nil {


### PR DESCRIPTION
Because it is not trivial to omit codeLens support from the server capabilities with gopls' LSP structs, we just pretend that we support it but don't return any.

Fixes #560 