### PR TITLE
Provide (less verbose) step-based completion

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/go-memdb v1.3.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-version v1.3.0
-	github.com/hashicorp/hcl-lang v0.0.0-20210616121206-bd34ebcc883b
+	github.com/hashicorp/hcl-lang v0.0.0-20210625122313-29045f308402
 	github.com/hashicorp/hcl/v2 v2.10.0
 	github.com/hashicorp/terraform-exec v0.13.3
 	github.com/hashicorp/terraform-json v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -188,8 +188,9 @@ github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+l
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/hashicorp/hcl-lang v0.0.0-20210616121206-bd34ebcc883b h1:KnQ9z7sjAD6mwqJR6vpCrkAU6GygOnnFnmgxW7bkmb4=
 github.com/hashicorp/hcl-lang v0.0.0-20210616121206-bd34ebcc883b/go.mod h1:uMsq6wV8ZXEH8qndov4tncXlHDYnZ8aHsGmS4T74e2o=
+github.com/hashicorp/hcl-lang v0.0.0-20210625122313-29045f308402 h1:dS/j/zM6hK7Be3BruXFFBOdmevskvTg7iCNfZHY3/ZE=
+github.com/hashicorp/hcl-lang v0.0.0-20210625122313-29045f308402/go.mod h1:rDEzcPJU1AYRanWbpH9AZEik9i+jv1aoKkwqjfs7NyA=
 github.com/hashicorp/hcl/v2 v2.10.0 h1:1S1UnuhDGlv3gRFV4+0EdwB+znNP5HmcGbIqwnSCByg=
 github.com/hashicorp/hcl/v2 v2.10.0/go.mod h1:FwWsfWEjyV/CMj8s/gqAuiviY72rJ1/oayI9WftqcKg=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=

--- a/internal/langserver/handlers/handlers_test.go
+++ b/internal/langserver/handlers/handlers_test.go
@@ -32,7 +32,9 @@ func initializeResponse(t *testing.T, commandPrefix string) string {
 					"change": 2,
 					"save": {}
 				},
-				"completionProvider": {},
+				"completionProvider": {
+					"triggerCharacters": [".", "["]
+				},
 				"hoverProvider": true,
 				"signatureHelpProvider": {},
 				"documentSymbolProvider": true,

--- a/internal/langserver/handlers/initialize.go
+++ b/internal/langserver/handlers/initialize.go
@@ -22,7 +22,8 @@ func (lh *logHandler) Initialize(ctx context.Context, params lsp.InitializeParam
 				Change:    lsp.Incremental,
 			},
 			CompletionProvider: lsp.CompletionOptions{
-				ResolveProvider: false,
+				ResolveProvider:   false,
+				TriggerCharacters: []string{".", "["},
 			},
 			CodeLensProvider:           lsp.CodeLensOptions{},
 			HoverProvider:              true,


### PR DESCRIPTION
Fixes #492

Step-based completion basically offers only the top-most reference (from hierarchy perspective) that matches what is already written (any characters after `=`). In other words completion for empty expression such as `attribute = # HERE` would bring up only top-level references.

Additionally this patch also provides decoding for references to addressable elements within some non-primitive types - namely attributes within object expressions, map entries, and list entries.

Depends on https://github.com/hashicorp/hcl-lang/pull/56

## Before

![2021-06-23 18 02 58](https://user-images.githubusercontent.com/287584/123139631-54318080-d44e-11eb-881b-d44281840fb7.gif)

![2021-06-23 18 09 59](https://user-images.githubusercontent.com/287584/123139644-5693da80-d44e-11eb-85a1-852d27cde80b.gif)

## After

![2021-06-25 13 19 36](https://user-images.githubusercontent.com/287584/123424138-5879ad00-d5b8-11eb-91f0-27aa1751a8a4.gif)

![2021-06-25 13 21 35](https://user-images.githubusercontent.com/287584/123424140-5adc0700-d5b8-11eb-8678-b1407a7a0bbe.gif)

