### PR TITLE
Update goreleaser homebrew Git commit information

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -94,8 +94,8 @@ brews:
       token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
     url_template: "https://releases.hashicorp.com/terraform-ls/{{ .Version }}/{{ .ArtifactName }}"
     commit_author:
-      name: hashibot
-      email: hashibot-feedback@hashicorp.com
+      name: hc-espd-packager
+      email: team-product-delivery@hashicorp.com
     folder: Formula
     homepage: "https://github.com/hashicorp/terraform-ls"
     description: "Terraform Language Server"


### PR DESCRIPTION
To match upstream https://github.com/hashicorp/homebrew-tap/blob/afc17338a13fd83f623c83872fc03b4f386726d2/.github/workflows/publish-formula-update.yml#L40-L41 and prevent any confusion on hashibot performing the activity, which it is not.