### PR TITLE
fix: increase walker queue buffer & start walking early

### DIFF
--- a/internal/langserver/handlers/initialize_test.go
+++ b/internal/langserver/handlers/initialize_test.go
@@ -92,3 +92,30 @@ func TestInitialize_withInvalidRootURI(t *testing.T) {
 	    "rootUri": "meh"
 	}`}, code.SystemError.Err())
 }
+
+func TestInitialize_multipleFolders(t *testing.T) {
+	rootDir := TempDir(t)
+	ls := langserver.NewLangServerMock(t, NewMockSession(&MockSessionInput{
+		TerraformCalls: &exec.TerraformMockCalls{
+			PerWorkDir: map[string][]*mock.Call{
+				rootDir.Dir(): validTfMockCalls(),
+			},
+		},
+	}))
+	stop := ls.Start(t)
+	defer stop()
+
+	ls.Call(t, &langserver.CallRequest{
+		Method: "initialize",
+		ReqParams: fmt.Sprintf(`{
+	    "capabilities": {},
+	    "rootUri": %q,
+	    "processId": 12345,
+	    "workspaceFolders": [
+	    	{
+	    		"uri": %q,
+	    		"name": "root"
+	    	}
+	    ]
+	}`, rootDir.URI(), rootDir.URI())})
+}


### PR DESCRIPTION
This was introduced as part of https://github.com/hashicorp/terraform-ls/pull/502 (i.e. the bug thankfully isn't part of a release)

--- 

Due to limited channel buffer size, the walker queueing would be blocked on any 2nd path here:

https://github.com/hashicorp/terraform-ls/blob/cf0650f2b75415b135f222f6bd4d1ab787409064/internal/langserver/handlers/initialize.go#L153

or here

https://github.com/hashicorp/terraform-ls/blob/cf0650f2b75415b135f222f6bd4d1ab787409064/internal/langserver/handlers/initialize.go#L190

and it would remain blocked forever as it would also block starting the walker and therefore consumption from the channel.

Attached test times out without the patch.
