### PR TITLE
references: use innermost target instead of outermost

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/go-memdb v1.3.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-version v1.3.0
-	github.com/hashicorp/hcl-lang v0.0.0-20210706114807-f5820717eea2
+	github.com/hashicorp/hcl-lang v0.0.0-20210707112750-2f1f1d6a3355
 	github.com/hashicorp/hcl/v2 v2.10.0
 	github.com/hashicorp/terraform-exec v0.14.0
 	github.com/hashicorp/terraform-json v0.12.0
@@ -30,7 +30,7 @@ require (
 	github.com/spf13/afero v1.6.0
 	github.com/stretchr/testify v1.7.0
 	github.com/vektra/mockery/v2 v2.9.0
-	github.com/zclconf/go-cty v1.8.4
+	github.com/zclconf/go-cty v1.9.0
 	github.com/zclconf/go-cty-debug v0.0.0-20191215020915-b22d67c1ba0b
 	golang.org/x/tools v0.0.0-20200323144430-8dcfad9e016e
 )

--- a/go.sum
+++ b/go.sum
@@ -191,8 +191,8 @@ github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uG
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/hcl-lang v0.0.0-20210616121206-bd34ebcc883b/go.mod h1:uMsq6wV8ZXEH8qndov4tncXlHDYnZ8aHsGmS4T74e2o=
-github.com/hashicorp/hcl-lang v0.0.0-20210706114807-f5820717eea2 h1:0FDZNqlF1pRYf8CLr4nv8jdeYS/3l7M1nwjCSnW5WZI=
-github.com/hashicorp/hcl-lang v0.0.0-20210706114807-f5820717eea2/go.mod h1:rDEzcPJU1AYRanWbpH9AZEik9i+jv1aoKkwqjfs7NyA=
+github.com/hashicorp/hcl-lang v0.0.0-20210707112750-2f1f1d6a3355 h1:DF+5etYGgdAWMxbs2U8nwim7Rp49Wge8859f7SdGBk0=
+github.com/hashicorp/hcl-lang v0.0.0-20210707112750-2f1f1d6a3355/go.mod h1:A1Pj/o2k+ADlN0onToNuOJWNuWywxV7towLQmzU8dfU=
 github.com/hashicorp/hcl/v2 v2.10.0 h1:1S1UnuhDGlv3gRFV4+0EdwB+znNP5HmcGbIqwnSCByg=
 github.com/hashicorp/hcl/v2 v2.10.0/go.mod h1:FwWsfWEjyV/CMj8s/gqAuiviY72rJ1/oayI9WftqcKg=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
@@ -383,8 +383,9 @@ github.com/zclconf/go-cty v1.2.0/go.mod h1:hOPWgoHbaTUnI5k4D2ld+GRpFJSCe6bCM7m1q
 github.com/zclconf/go-cty v1.2.1/go.mod h1:hOPWgoHbaTUnI5k4D2ld+GRpFJSCe6bCM7m1q/N4PQ8=
 github.com/zclconf/go-cty v1.8.0/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
 github.com/zclconf/go-cty v1.8.3/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
-github.com/zclconf/go-cty v1.8.4 h1:pwhhz5P+Fjxse7S7UriBrMu6AUJSZM5pKqGem1PjGAs=
 github.com/zclconf/go-cty v1.8.4/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
+github.com/zclconf/go-cty v1.9.0 h1:IgJxw5b4LPXCPeqFjjhLaNEA8NKXMyaEUdAd399acts=
+github.com/zclconf/go-cty v1.9.0/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
 github.com/zclconf/go-cty-debug v0.0.0-20191215020915-b22d67c1ba0b h1:FosyBZYxY34Wul7O/MSKey3txpPYyCqVO5ZyceuQJEI=
 github.com/zclconf/go-cty-debug v0.0.0-20191215020915-b22d67c1ba0b/go.mod h1:ZRKQfBXbGkpdV6QMzT3rU1kSTAnfu1dO8dPKjYprgj8=
 github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=

--- a/internal/langserver/handlers/references.go
+++ b/internal/langserver/handlers/references.go
@@ -47,7 +47,7 @@ func (h *logHandler) References(ctx context.Context, params lsp.ReferenceParams)
 		return list, err
 	}
 
-	refTarget, err := d.OutermostReferenceTargetAtPos(fPos.Filename(), fPos.Position())
+	refTarget, err := d.InnermostReferenceTargetAtPos(fPos.Filename(), fPos.Position())
 	if err != nil {
 		return list, err
 	}
@@ -57,7 +57,7 @@ func (h *logHandler) References(ctx context.Context, params lsp.ReferenceParams)
 		return list, nil
 	}
 
-	h.logger.Printf("finding origins for target: %#v", refTarget)
+	h.logger.Printf("finding origins for inner-most target: %#v", refTarget)
 
 	origins, err := d.ReferenceOriginsTargeting(*refTarget)
 	if err != nil {


### PR DESCRIPTION
This (seemingly minor) change allows the user to use more fine-grained approach when looking for references.

Namely if they request references to a nested attribute/block, they receive references to that and _not_ to the parent (outermost) block:
![2021-07-07 12 41 02](https://user-images.githubusercontent.com/287584/124753219-9d8ad100-df20-11eb-8364-e24edcbd2159.gif)

They can still request all references to the block itself and any nested references for targets within the block if they click on the block header:

![2021-07-07 12 41 46](https://user-images.githubusercontent.com/287584/124753311-bb583600-df20-11eb-8e96-62a30ad7f9d8.gif)
