### PR TITLE
Make references scope & type aware

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/go-memdb v1.3.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-version v1.3.0
-	github.com/hashicorp/hcl-lang v0.0.0-20210707112750-2f1f1d6a3355
+	github.com/hashicorp/hcl-lang v0.0.0-20210708095602-d4a0c548d7c9
 	github.com/hashicorp/hcl/v2 v2.10.0
 	github.com/hashicorp/terraform-exec v0.14.0
 	github.com/hashicorp/terraform-json v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -191,8 +191,8 @@ github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uG
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/hcl-lang v0.0.0-20210616121206-bd34ebcc883b/go.mod h1:uMsq6wV8ZXEH8qndov4tncXlHDYnZ8aHsGmS4T74e2o=
-github.com/hashicorp/hcl-lang v0.0.0-20210707112750-2f1f1d6a3355 h1:DF+5etYGgdAWMxbs2U8nwim7Rp49Wge8859f7SdGBk0=
-github.com/hashicorp/hcl-lang v0.0.0-20210707112750-2f1f1d6a3355/go.mod h1:A1Pj/o2k+ADlN0onToNuOJWNuWywxV7towLQmzU8dfU=
+github.com/hashicorp/hcl-lang v0.0.0-20210708095602-d4a0c548d7c9 h1:ijDta0b/7G9ghwUuxE7KvWMtj9+ohg8ngbHR49VRVEU=
+github.com/hashicorp/hcl-lang v0.0.0-20210708095602-d4a0c548d7c9/go.mod h1:A1Pj/o2k+ADlN0onToNuOJWNuWywxV7towLQmzU8dfU=
 github.com/hashicorp/hcl/v2 v2.10.0 h1:1S1UnuhDGlv3gRFV4+0EdwB+znNP5HmcGbIqwnSCByg=
 github.com/hashicorp/hcl/v2 v2.10.0/go.mod h1:FwWsfWEjyV/CMj8s/gqAuiviY72rJ1/oayI9WftqcKg=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=


### PR DESCRIPTION
Previously reference origins/addresses (such as `var.foo`) would be matched against addressable targets (attributes or blocks) in a strict fashion where addresses have to match exactly.

This patch makes origins scope & type aware as per https://github.com/hashicorp/hcl-lang/pull/68 which in turn helps us "optimistically" recognize references to targets of unknown type.

### Before

References to `var.test` are not recognized (no data provided on hover, reference not semantically highlighted, no go-to-definition etc.) due to the variable not having explicit type.

![Screenshot 2021-07-08 at 10 48 29](https://user-images.githubusercontent.com/287584/124902199-a213c000-dfda-11eb-8166-f69a00baf894.png)

### After

![Screenshot 2021-07-08 at 10 49 01](https://user-images.githubusercontent.com/287584/124902143-9627fe00-dfda-11eb-81c2-df65c8c2f95a.png)

On hover we display the closest known target (for clarity).

![Screenshot 2021-07-08 at 10 49 34](https://user-images.githubusercontent.com/287584/124902347-bf488e80-dfda-11eb-8fae-2ced49fb3a16.png)

![2021-07-08 10 49 50](https://user-images.githubusercontent.com/287584/124902372-c40d4280-dfda-11eb-9145-2e7a4a2ba492.gif)
