### PR TITLE
fix: recognize references in lists and other complex types

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/go-memdb v1.3.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-version v1.3.0
-	github.com/hashicorp/hcl-lang v0.0.0-20210720185741-4775fe675507
+	github.com/hashicorp/hcl-lang v0.0.0-20210727133229-454bfd2596ce
 	github.com/hashicorp/hcl/v2 v2.10.1
 	github.com/hashicorp/terraform-exec v0.14.0
 	github.com/hashicorp/terraform-json v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -191,8 +191,8 @@ github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uG
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/hcl-lang v0.0.0-20210616121206-bd34ebcc883b/go.mod h1:uMsq6wV8ZXEH8qndov4tncXlHDYnZ8aHsGmS4T74e2o=
-github.com/hashicorp/hcl-lang v0.0.0-20210720185741-4775fe675507 h1:oJvWrjpJ631eWE/WLeNfVX7JXgEEIbavD17B70JA5bU=
-github.com/hashicorp/hcl-lang v0.0.0-20210720185741-4775fe675507/go.mod h1:A1Pj/o2k+ADlN0onToNuOJWNuWywxV7towLQmzU8dfU=
+github.com/hashicorp/hcl-lang v0.0.0-20210727133229-454bfd2596ce h1:XekCZzsJL95UGIMEWHBdPjGSPpi8uxU91zRghDbRgTc=
+github.com/hashicorp/hcl-lang v0.0.0-20210727133229-454bfd2596ce/go.mod h1:xzXU6Fn+TWVaZUFxV8CyAsObi2oMgSEFAmLvCx2ArzM=
 github.com/hashicorp/hcl/v2 v2.10.0/go.mod h1:FwWsfWEjyV/CMj8s/gqAuiviY72rJ1/oayI9WftqcKg=
 github.com/hashicorp/hcl/v2 v2.10.1 h1:h4Xx4fsrRE26ohAk/1iGF/JBqRQbyUqu5Lvj60U54ys=
 github.com/hashicorp/hcl/v2 v2.10.1/go.mod h1:FwWsfWEjyV/CMj8s/gqAuiviY72rJ1/oayI9WftqcKg=

--- a/internal/langserver/handlers/go_to_ref_target.go
+++ b/internal/langserver/handlers/go_to_ref_target.go
@@ -58,6 +58,7 @@ func (h *logHandler) GoToReferenceTarget(ctx context.Context, params lsp.TextDoc
 	if origin == nil {
 		return nil, nil
 	}
+	h.logger.Printf("found origin: %#v", origin)
 
 	target, err := d.ReferenceTargetForOrigin(*origin)
 	if err != nil {


### PR DESCRIPTION
This still doesn't mean we can recognize references in arbitrarily deeply nested expressions - that will be addressed in https://github.com/hashicorp/terraform-ls/issues/496, but this PR at least addresses the lowest-hanging fruits.

Brings in the following upstream PRs:
 - https://github.com/hashicorp/hcl-lang/pull/73
 - https://github.com/hashicorp/hcl-lang/pull/74

### Before

![Screenshot 2021-07-27 at 14 48 01](https://user-images.githubusercontent.com/287584/127165491-4bca319a-4a0c-4874-9151-cb843cd868ef.png)

### After

![Screenshot 2021-07-27 at 14 48 58](https://user-images.githubusercontent.com/287584/127165496-91df5a17-edf6-42f8-838c-dfe7e83393ab.png)
