### PR TITLE
fix: recognize references in common nested expressions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,12 +12,12 @@ require (
 	github.com/hashicorp/go-memdb v1.3.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-version v1.3.0
-	github.com/hashicorp/hcl-lang v0.0.0-20210728150846-565e9ca96f5a
+	github.com/hashicorp/hcl-lang v0.0.0-20210730145509-f403a86a1605
 	github.com/hashicorp/hcl/v2 v2.10.1
 	github.com/hashicorp/terraform-exec v0.14.0
 	github.com/hashicorp/terraform-json v0.12.0
 	github.com/hashicorp/terraform-registry-address v0.0.0-20210412075316-9b2996cce896
-	github.com/hashicorp/terraform-schema v0.0.0-20210728151552-ade5695c845a
+	github.com/hashicorp/terraform-schema v0.0.0-20210730150127-e9a4cde5d2a6
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mh-cbon/go-fmt-fail v0.0.0-20160815164508-67765b3fbcb5
 	github.com/mitchellh/cli v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -190,8 +190,8 @@ github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+l
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/hashicorp/hcl-lang v0.0.0-20210728150846-565e9ca96f5a h1:/4iJtfKKXrHCi99FQgUeHvF6OBNUzJeVO7Tsmfj8F1s=
-github.com/hashicorp/hcl-lang v0.0.0-20210728150846-565e9ca96f5a/go.mod h1:xzXU6Fn+TWVaZUFxV8CyAsObi2oMgSEFAmLvCx2ArzM=
+github.com/hashicorp/hcl-lang v0.0.0-20210730145509-f403a86a1605 h1:558O3NRU7baTVlQNgui1NeHDORRFEgTsICpHmI+ubA0=
+github.com/hashicorp/hcl-lang v0.0.0-20210730145509-f403a86a1605/go.mod h1:xzXU6Fn+TWVaZUFxV8CyAsObi2oMgSEFAmLvCx2ArzM=
 github.com/hashicorp/hcl/v2 v2.10.1 h1:h4Xx4fsrRE26ohAk/1iGF/JBqRQbyUqu5Lvj60U54ys=
 github.com/hashicorp/hcl/v2 v2.10.1/go.mod h1:FwWsfWEjyV/CMj8s/gqAuiviY72rJ1/oayI9WftqcKg=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
@@ -204,8 +204,8 @@ github.com/hashicorp/terraform-json v0.12.0 h1:8czPgEEWWPROStjkWPUnTQDXmpmZPlkQA
 github.com/hashicorp/terraform-json v0.12.0/go.mod h1:pmbq9o4EuL43db5+0ogX10Yofv1nozM+wskr/bGFJpI=
 github.com/hashicorp/terraform-registry-address v0.0.0-20210412075316-9b2996cce896 h1:1FGtlkJw87UsTMg5s8jrekrHmUPUJaMcu6ELiVhQrNw=
 github.com/hashicorp/terraform-registry-address v0.0.0-20210412075316-9b2996cce896/go.mod h1:bzBPnUIkI0RxauU8Dqo+2KrZZ28Cf48s8V6IHt3p4co=
-github.com/hashicorp/terraform-schema v0.0.0-20210728151552-ade5695c845a h1:IZ1T0OvyLXM5+VYaMYhOrbCb8qS2ASoDlPfsbx8c64M=
-github.com/hashicorp/terraform-schema v0.0.0-20210728151552-ade5695c845a/go.mod h1:laZKK46fUcgutOVcEOx7lY0POxOEFxLZCD+eaUvGIc8=
+github.com/hashicorp/terraform-schema v0.0.0-20210730150127-e9a4cde5d2a6 h1:NGjNSbYdtgqvkwfD49PRrO/b8uKI8HOXNtqi0i0kolA=
+github.com/hashicorp/terraform-schema v0.0.0-20210730150127-e9a4cde5d2a6/go.mod h1:gkASkhoBSC/CHyqPW0Di8ZPEB9/OVGe7yGecFsOWYQc=
 github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734 h1:HKLsbzeOsfXmKNpr3GiT18XAblV0BjCbzL8KQAMZGa0=
 github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734/go.mod h1:kNDNcF7sN4DocDLBkQYz73HGKwN1ANB1blq4lIYLYvg=
 github.com/huandu/xstrings v1.3.2 h1:L18LIDzqlW6xN2rEkpdV8+oL/IXWJ1APd+vsdYy4Wdw=


### PR DESCRIPTION
Fixes #592 

This addresses the case of references nested within most common types of expressions (list, set, tuple, object or map). Remaining expression types are to be addressed as part of https://github.com/hashicorp/terraform-ls/issues/496

### Before

![Screenshot 2021-07-30 at 16 05 40](https://user-images.githubusercontent.com/287584/127673232-2ecf4f68-adad-4355-9d70-e9110c0b20da.png)

### After

![Screenshot 2021-07-30 at 16 06 25](https://user-images.githubusercontent.com/287584/127673235-dd0740ad-b12e-43cf-b46b-d8a3d48300bb.png)
