### PR TITLE
Always validate URI schema

### DIFF
--- a/internal/langserver/handlers/command/init.go
+++ b/internal/langserver/handlers/command/init.go
@@ -12,12 +12,17 @@ import (
 	ilsp "github.com/hashicorp/terraform-ls/internal/lsp"
 	lsp "github.com/hashicorp/terraform-ls/internal/protocol"
 	"github.com/hashicorp/terraform-ls/internal/terraform/module"
+	"github.com/hashicorp/terraform-ls/internal/uri"
 )
 
 func TerraformInitHandler(ctx context.Context, args cmd.CommandArgs) (interface{}, error) {
 	dirUri, ok := args.GetString("uri")
 	if !ok || dirUri == "" {
 		return nil, fmt.Errorf("%w: expected module uri argument to be set", code.InvalidParams.Err())
+	}
+
+	if !uri.IsURIValid(dirUri) {
+		return nil, fmt.Errorf("URI %q is not valid", dirUri)
 	}
 
 	dh := ilsp.FileHandlerFromDirURI(lsp.DocumentURI(dirUri))

--- a/internal/langserver/handlers/command/module_callers.go
+++ b/internal/langserver/handlers/command/module_callers.go
@@ -28,6 +28,10 @@ func ModuleCallersHandler(ctx context.Context, args cmd.CommandArgs) (interface{
 		return nil, fmt.Errorf("%w: expected module uri argument to be set", code.InvalidParams.Err())
 	}
 
+	if !uri.IsURIValid(modUri) {
+		return nil, fmt.Errorf("URI %q is not valid", modUri)
+	}
+
 	modPath, err := uri.PathFromURI(modUri)
 	if err != nil {
 		return nil, err

--- a/internal/langserver/handlers/command/validate.go
+++ b/internal/langserver/handlers/command/validate.go
@@ -13,12 +13,17 @@ import (
 	ilsp "github.com/hashicorp/terraform-ls/internal/lsp"
 	lsp "github.com/hashicorp/terraform-ls/internal/protocol"
 	"github.com/hashicorp/terraform-ls/internal/terraform/module"
+	"github.com/hashicorp/terraform-ls/internal/uri"
 )
 
 func TerraformValidateHandler(ctx context.Context, args cmd.CommandArgs) (interface{}, error) {
 	dirUri, ok := args.GetString("uri")
 	if !ok || dirUri == "" {
 		return nil, fmt.Errorf("%w: expected module uri argument to be set", code.InvalidParams.Err())
+	}
+
+	if !uri.IsURIValid(dirUri) {
+		return nil, fmt.Errorf("URI %q is not valid", dirUri)
 	}
 
 	dh := ilsp.FileHandlerFromDirURI(lsp.DocumentURI(dirUri))

--- a/internal/lsp/file_handler_unix_test.go
+++ b/internal/lsp/file_handler_unix_test.go
@@ -39,9 +39,10 @@ func TestFileHandler_valid_unix(t *testing.T) {
 }
 
 func TestFileHandler_valid_unixDir(t *testing.T) {
-	fh := FileHandlerFromDirURI(lsp.DocumentURI("/valid/path/to"))
+	uri := "file:///valid/path/to"
+	fh := FileHandlerFromDirURI(lsp.DocumentURI(uri))
 	if !fh.Valid() {
-		t.Fatalf("Expected %q to be valid", "/valid/path/to")
+		t.Fatalf("Expected %q to be valid", uri)
 	}
 
 	expectedDir := "/valid/path/to"

--- a/internal/uri/uri.go
+++ b/internal/uri/uri.go
@@ -40,5 +40,10 @@ func parseUri(uri string) (string, error) {
 		return "", err
 	}
 
+	if u.Scheme != "file" {
+		return "", fmt.Errorf("unexpected scheme %q in URI %q",
+			u.Scheme, uri)
+	}
+
 	return url.PathUnescape(u.Path)
 }

--- a/internal/uri/uri_test.go
+++ b/internal/uri/uri_test.go
@@ -1,0 +1,12 @@
+package uri
+
+import (
+	"testing"
+)
+
+func TestIsURIValid_invalid(t *testing.T) {
+	uri := "output:extension-output-%232"
+	if IsURIValid(uri) {
+		t.Fatalf("Expected %q to be invalid", uri)
+	}
+}


### PR DESCRIPTION
I ran into a weird situation where the Terraform VS Code extension would call the validate command with `uri=output:extension-output-%232` which was somehow silently accepted.

I can no longer reproduce that client-side bug to understand why this happened, but at least this patch will make that problem more visible next time it happens.