### PR TITLE
fix: avoid publishing stale 'validate' diagnostics

### DIFF
--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -33,7 +33,7 @@ var (
 	ctxModuleWalker         = &contextKey{"module walker"}
 	ctxRootDir              = &contextKey{"root directory"}
 	ctxCommandPrefix        = &contextKey{"command prefix"}
-	ctxDiags                = &contextKey{"diagnostics"}
+	ctxDiagsNotifier        = &contextKey{"diagnostics notifier"}
 	ctxLsVersion            = &contextKey{"language server version"}
 	ctxProgressToken        = &contextKey{"progress token"}
 	ctxExperimentalFeatures = &contextKey{"experimental features"}
@@ -224,14 +224,14 @@ func ModuleWalker(ctx context.Context) (*module.Walker, error) {
 	return w, nil
 }
 
-func WithDiagnostics(ctx context.Context, diags *diagnostics.Notifier) context.Context {
-	return context.WithValue(ctx, ctxDiags, diags)
+func WithDiagnosticsNotifier(ctx context.Context, diags *diagnostics.Notifier) context.Context {
+	return context.WithValue(ctx, ctxDiagsNotifier, diags)
 }
 
-func Diagnostics(ctx context.Context) (*diagnostics.Notifier, error) {
-	diags, ok := ctx.Value(ctxDiags).(*diagnostics.Notifier)
+func DiagnosticsNotifier(ctx context.Context) (*diagnostics.Notifier, error) {
+	diags, ok := ctx.Value(ctxDiagsNotifier).(*diagnostics.Notifier)
 	if !ok {
-		return nil, missingContextErr(ctxDiags)
+		return nil, missingContextErr(ctxDiagsNotifier)
 	}
 
 	return diags, nil


### PR DESCRIPTION
Fixes #524 

### Before

![2021-08-03 08 32 46](https://user-images.githubusercontent.com/287584/127976153-ccd6f57d-c26d-4426-9da7-c466de9fb31b.gif)

### After

![2021-08-03 08 37 19](https://user-images.githubusercontent.com/287584/127976748-d59d409b-197e-4b9a-bf2b-ff5a3646dc7d.gif)

--- 

The "silent delay" is an effect of VS Code not supporting progress reporting during command execution https://github.com/microsoft/vscode-languageserver-node/issues/528#issuecomment-541600565