### PR TITLE
fix: avoid crash on highlighting unknown tuple element

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/go-memdb v1.3.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-version v1.3.0
-	github.com/hashicorp/hcl-lang v0.0.0-20210730145509-f403a86a1605
+	github.com/hashicorp/hcl-lang v0.0.0-20210803102942-476b73b115cf
 	github.com/hashicorp/hcl/v2 v2.10.1
 	github.com/hashicorp/terraform-exec v0.14.0
 	github.com/hashicorp/terraform-json v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -190,8 +190,9 @@ github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+l
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/hashicorp/hcl-lang v0.0.0-20210730145509-f403a86a1605 h1:558O3NRU7baTVlQNgui1NeHDORRFEgTsICpHmI+ubA0=
 github.com/hashicorp/hcl-lang v0.0.0-20210730145509-f403a86a1605/go.mod h1:xzXU6Fn+TWVaZUFxV8CyAsObi2oMgSEFAmLvCx2ArzM=
+github.com/hashicorp/hcl-lang v0.0.0-20210803102942-476b73b115cf h1:4BD/Um2c4AReaem7FX2wAs+9kwFoRuZwNUES0rmzDCQ=
+github.com/hashicorp/hcl-lang v0.0.0-20210803102942-476b73b115cf/go.mod h1:xzXU6Fn+TWVaZUFxV8CyAsObi2oMgSEFAmLvCx2ArzM=
 github.com/hashicorp/hcl/v2 v2.10.1 h1:h4Xx4fsrRE26ohAk/1iGF/JBqRQbyUqu5Lvj60U54ys=
 github.com/hashicorp/hcl/v2 v2.10.1/go.mod h1:FwWsfWEjyV/CMj8s/gqAuiviY72rJ1/oayI9WftqcKg=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=


### PR DESCRIPTION
This addresses one of two bugs reported in https://github.com/hashicorp/vscode-terraform/issues/707 , specifically in https://github.com/hashicorp/vscode-terraform/issues/707#issuecomment-891008775

The other bug is to be fixed on the client / extension side.

This brings in the following upstream patch https://github.com/hashicorp/hcl-lang/pull/77