### PR TITLE
github: Reduce jobs timeout from high default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-18.04
+    timeout-minutes: 15
     steps:
       -
         name: Checkout
@@ -51,6 +52,7 @@ jobs:
 
   test:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
     strategy:
       matrix:
         os:


### PR DESCRIPTION
Default timeouts are actually 6 hours and our jobs should typically finish within minutes, so there's no point in waiting any longer.