### PR TITLE
Support standalone (not autoloaded) `*.tfvars` files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.go text eol=lf
+*.tf text eol=lf

--- a/internal/decoder/decoder.go
+++ b/internal/decoder/decoder.go
@@ -2,12 +2,11 @@ package decoder
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/hashicorp/hcl-lang/decoder"
 	"github.com/hashicorp/hcl-lang/lang"
-	"github.com/hashicorp/hcl/v2"
 	lsctx "github.com/hashicorp/terraform-ls/internal/context"
+	"github.com/hashicorp/terraform-ls/internal/terraform/ast"
 	"github.com/hashicorp/terraform-ls/internal/terraform/module"
 )
 
@@ -30,36 +29,27 @@ func DecoderForModule(ctx context.Context, mod module.Module) (*decoder.Decoder,
 		d.SetUtmMedium(clientName)
 	}
 
-	err := loadFiles(d, mod.ParsedModuleFiles)
-	if err != nil {
-		return nil, err
-	}
-
-	return d, nil
-}
-
-func DecoderForVariables(mod module.Module) (*decoder.Decoder, error) {
-	d := decoder.NewDecoder()
-
-	err := loadFiles(d, mod.ParsedModuleFiles)
-	if err != nil {
-		return nil, err
-	}
-
-	err = loadFiles(d, mod.ParsedVarsFiles)
-	if err != nil {
-		return nil, err
-	}
-
-	return d, nil
-}
-
-func loadFiles(d *decoder.Decoder, files map[string]*hcl.File) error {
-	for name, f := range files {
-		err := d.LoadFile(name, f)
+	for name, f := range mod.ParsedModuleFiles {
+		err := d.LoadFile(name.String(), f)
 		if err != nil {
-			return fmt.Errorf("failed to load a file: %w", err)
+			// skip unreadable files
+			continue
 		}
 	}
-	return nil
+
+	return d, nil
+}
+
+func DecoderForVariables(varsFiles ast.VarsFiles) (*decoder.Decoder, error) {
+	d := decoder.NewDecoder()
+
+	for name, f := range varsFiles {
+		err := d.LoadFile(name.String(), f)
+		if err != nil {
+			// skip unreadable files
+			continue
+		}
+	}
+
+	return d, nil
 }

--- a/internal/filesystem/filesystem_test.go
+++ b/internal/filesystem/filesystem_test.go
@@ -1,6 +1,7 @@
 package filesystem
 
 import (
+	"io/fs"
 	"io/ioutil"
 	"log"
 	"os"
@@ -317,10 +318,10 @@ func TestFilesystem_ReadDir_memFsOnly(t *testing.T) {
 	}
 }
 
-func namesFromFileInfos(fis []os.FileInfo) []string {
-	names := make([]string, len(fis), len(fis))
-	for i, fi := range fis {
-		names[i] = fi.Name()
+func namesFromFileInfos(entries []fs.DirEntry) []string {
+	names := make([]string, len(entries), len(entries))
+	for i, entry := range entries {
+		names[i] = entry.Name()
 	}
 	return names
 }

--- a/internal/filesystem/types.go
+++ b/internal/filesystem/types.go
@@ -1,6 +1,7 @@
 package filesystem
 
 import (
+	"io/fs"
 	"log"
 	"os"
 
@@ -51,15 +52,7 @@ type Filesystem interface {
 
 	// direct FS methods
 	ReadFile(name string) ([]byte, error)
-	ReadDir(name string) ([]os.FileInfo, error)
-	Open(name string) (File, error)
+	ReadDir(name string) ([]fs.DirEntry, error)
+	Open(name string) (fs.File, error)
 	Stat(name string) (os.FileInfo, error)
-}
-
-// File represents an open file in FS
-// See io/fs.File in http://golang.org/s/draft-iofs-design
-type File interface {
-	Stat() (os.FileInfo, error)
-	Read([]byte) (int, error)
-	Close() error
 }

--- a/internal/langserver/handlers/command/validate.go
+++ b/internal/langserver/handlers/command/validate.go
@@ -69,8 +69,8 @@ func TerraformValidateHandler(ctx context.Context, args cmd.CommandArgs) (interf
 	validateDiags := diagnostics.HCLDiagsFromJSON(jsonDiags)
 	diags.EmptyRootDiagnostic()
 	diags.Append("terraform validate", validateDiags)
-	diags.Append("HCL", mod.ModuleDiagnostics)
-	diags.Append("HCL", mod.VarsDiagnostics)
+	diags.Append("HCL", mod.ModuleDiagnostics.AsMap())
+	diags.Append("HCL", mod.VarsDiagnostics.AutoloadedOnly().AsMap())
 
 	notifier.PublishHCLDiags(ctx, mod.Path, diags)
 

--- a/internal/langserver/handlers/did_close.go
+++ b/internal/langserver/handlers/did_close.go
@@ -3,9 +3,12 @@ package handlers
 import (
 	"context"
 
+	"github.com/hashicorp/hcl/v2"
 	lsctx "github.com/hashicorp/terraform-ls/internal/context"
+	"github.com/hashicorp/terraform-ls/internal/langserver/diagnostics"
 	ilsp "github.com/hashicorp/terraform-ls/internal/lsp"
 	lsp "github.com/hashicorp/terraform-ls/internal/protocol"
+	"github.com/hashicorp/terraform-ls/internal/terraform/ast"
 )
 
 func TextDocumentDidClose(ctx context.Context, params lsp.DidCloseTextDocumentParams) error {
@@ -15,5 +18,24 @@ func TextDocumentDidClose(ctx context.Context, params lsp.DidCloseTextDocumentPa
 	}
 
 	fh := ilsp.FileHandlerFromDocumentURI(params.TextDocument.URI)
-	return fs.CloseAndRemoveDocument(fh)
+	err = fs.CloseAndRemoveDocument(fh)
+	if err != nil {
+		return err
+	}
+
+	if vf, ok := ast.NewVarsFilename(fh.Filename()); ok && !vf.IsAutoloaded() {
+		notifier, err := lsctx.DiagnosticsNotifier(ctx)
+		if err != nil {
+			return err
+		}
+
+		diags := diagnostics.NewDiagnostics()
+		diags.EmptyRootDiagnostic()
+		diags.Append("HCL", map[string]hcl.Diagnostics{
+			fh.Filename(): {},
+		})
+		notifier.PublishHCLDiags(ctx, fh.Dir(), diags)
+	}
+
+	return nil
 }

--- a/internal/langserver/handlers/service.go
+++ b/internal/langserver/handlers/service.go
@@ -155,6 +155,7 @@ func (svc *service) Assigner() (jrpc2.Assigner, error) {
 			if err != nil {
 				return nil, err
 			}
+			ctx = lsctx.WithDiagnosticsNotifier(ctx, notifier)
 			ctx = lsctx.WithDocumentStorage(ctx, svc.fs)
 			return handle(ctx, req, TextDocumentDidClose)
 		},
@@ -533,7 +534,7 @@ func schemaForDocument(mf module.ModuleFinder, doc filesystem.Document) (*schema
 
 func decoderForDocument(ctx context.Context, mod module.Module, languageID string) (*decoder.Decoder, error) {
 	if languageID == ilsp.Tfvars.String() {
-		return idecoder.DecoderForVariables(mod)
+		return idecoder.DecoderForVariables(mod.ParsedVarsFiles)
 	}
 	return idecoder.DecoderForModule(ctx, mod)
 }

--- a/internal/terraform/ast/ast.go
+++ b/internal/terraform/ast/ast.go
@@ -1,0 +1,13 @@
+package ast
+
+import (
+	"strings"
+)
+
+// isIgnoredFile returns true if the given filename (which must not have a
+// directory path ahead of it) should be ignored as e.g. an editor swap file.
+func isIgnoredFile(name string) bool {
+	return strings.HasPrefix(name, ".") || // Unix-like hidden files
+		strings.HasSuffix(name, "~") || // vim
+		strings.HasPrefix(name, "#") && strings.HasSuffix(name, "#") // emacs
+}

--- a/internal/terraform/ast/ast_test.go
+++ b/internal/terraform/ast/ast_test.go
@@ -1,0 +1,39 @@
+package ast
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/zclconf/go-cty-debug/ctydebug"
+)
+
+func TestVarsDiags_autoloadedOnly(t *testing.T) {
+	vd := VarsDiagsFromMap(map[string]hcl.Diagnostics{
+		"alpha.tfvars": {},
+		"terraform.tfvars": {
+			{
+				Severity: hcl.DiagError,
+				Summary:  "Test error",
+				Detail:   "Test description",
+			},
+		},
+		"beta.tfvars":      {},
+		"gama.auto.tfvars": {},
+	})
+	diags := vd.AutoloadedOnly().AsMap()
+	expectedDiags := map[string]hcl.Diagnostics{
+		"terraform.tfvars": {
+			{
+				Severity: hcl.DiagError,
+				Summary:  "Test error",
+				Detail:   "Test description",
+			},
+		},
+		"gama.auto.tfvars": {},
+	}
+
+	if diff := cmp.Diff(expectedDiags, diags, ctydebug.CmpOptions); diff != "" {
+		t.Fatalf("unexpected diagnostics: %s", diff)
+	}
+}

--- a/internal/terraform/ast/module.go
+++ b/internal/terraform/ast/module.go
@@ -1,0 +1,53 @@
+package ast
+
+import (
+	"strings"
+
+	"github.com/hashicorp/hcl/v2"
+)
+
+type ModFilename string
+
+func (mf ModFilename) String() string {
+	return string(mf)
+}
+
+func IsModuleFilename(name string) bool {
+	return strings.HasSuffix(name, ".tf") && !isIgnoredFile(name)
+}
+
+type ModFiles map[ModFilename]*hcl.File
+
+func ModFilesFromMap(m map[string]*hcl.File) ModFiles {
+	mf := make(ModFiles, len(m))
+	for name, file := range m {
+		mf[ModFilename(name)] = file
+	}
+	return mf
+}
+
+func (mf ModFiles) AsMap() map[string]*hcl.File {
+	m := make(map[string]*hcl.File, len(mf))
+	for name, file := range mf {
+		m[string(name)] = file
+	}
+	return m
+}
+
+type ModDiags map[ModFilename]hcl.Diagnostics
+
+func ModDiagsFromMap(m map[string]hcl.Diagnostics) ModDiags {
+	mf := make(ModDiags, len(m))
+	for name, file := range m {
+		mf[ModFilename(name)] = file
+	}
+	return mf
+}
+
+func (md ModDiags) AsMap() map[string]hcl.Diagnostics {
+	m := make(map[string]hcl.Diagnostics, len(md))
+	for name, diags := range md {
+		m[string(name)] = diags
+	}
+	return m
+}

--- a/internal/terraform/ast/variables.go
+++ b/internal/terraform/ast/variables.go
@@ -1,0 +1,77 @@
+package ast
+
+import (
+	"strings"
+
+	"github.com/hashicorp/hcl/v2"
+)
+
+type VarsFilename string
+
+func NewVarsFilename(name string) (VarsFilename, bool) {
+	if IsVarsFilename(name) {
+		return VarsFilename(name), true
+	}
+	return "", false
+}
+
+func IsVarsFilename(name string) bool {
+	return strings.HasSuffix(name, ".tfvars") && !isIgnoredFile(name)
+}
+
+func (vf VarsFilename) String() string {
+	return string(vf)
+}
+
+func (vf VarsFilename) IsAutoloaded() bool {
+	name := string(vf)
+	return strings.HasSuffix(name, ".auto.tfvars") || name == "terraform.tfvars"
+}
+
+type VarsFiles map[VarsFilename]*hcl.File
+
+func VarsFilesFromMap(m map[string]*hcl.File) VarsFiles {
+	mf := make(VarsFiles, len(m))
+	for name, file := range m {
+		mf[VarsFilename(name)] = file
+	}
+	return mf
+}
+
+type VarsDiags map[VarsFilename]hcl.Diagnostics
+
+func VarsDiagsFromMap(m map[string]hcl.Diagnostics) VarsDiags {
+	mf := make(VarsDiags, len(m))
+	for name, file := range m {
+		mf[VarsFilename(name)] = file
+	}
+	return mf
+}
+
+func (vd VarsDiags) AutoloadedOnly() VarsDiags {
+	diags := make(VarsDiags)
+	for name, f := range vd {
+		if name.IsAutoloaded() {
+			diags[name] = f
+		}
+	}
+	return diags
+}
+
+func (vd VarsDiags) ForFile(name VarsFilename) VarsDiags {
+	diags := make(VarsDiags)
+	for fName, f := range vd {
+		if fName == name {
+			diags[fName] = f
+		}
+	}
+	return diags
+}
+
+func (vd VarsDiags) AsMap() map[string]hcl.Diagnostics {
+	m := make(map[string]hcl.Diagnostics, len(vd))
+	for name, diags := range vd {
+		m[string(name)] = diags
+	}
+	return m
+}

--- a/internal/terraform/parser/module.go
+++ b/internal/terraform/parser/module.go
@@ -1,0 +1,49 @@
+package parser
+
+import (
+	"path/filepath"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/hashicorp/terraform-ls/internal/terraform/ast"
+)
+
+func ParseModuleFiles(fs FS, modPath string) (ast.ModFiles, ast.ModDiags, error) {
+	files := make(ast.ModFiles, 0)
+	diags := make(ast.ModDiags, 0)
+
+	infos, err := fs.ReadDir(modPath)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	for _, info := range infos {
+		if info.IsDir() {
+			// We only care about files
+			continue
+		}
+
+		name := info.Name()
+		if !ast.IsModuleFilename(name) {
+			continue
+		}
+
+		// TODO: overrides
+
+		fullPath := filepath.Join(modPath, name)
+
+		src, err := fs.ReadFile(fullPath)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		f, pDiags := hclsyntax.ParseConfig(src, name, hcl.InitialPos)
+		filename := ast.ModFilename(name)
+		diags[filename] = pDiags
+		if f != nil {
+			files[filename] = f
+		}
+	}
+
+	return files, diags, nil
+}

--- a/internal/terraform/parser/module_test.go
+++ b/internal/terraform/parser/module_test.go
@@ -1,0 +1,114 @@
+package parser
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/terraform-ls/internal/terraform/ast"
+	"github.com/spf13/afero"
+)
+
+func TestParseModuleFiles(t *testing.T) {
+	testCases := []struct {
+		dirName           string
+		expectedFileNames map[string]struct{}
+		expectedDiags     map[string]hcl.Diagnostics
+	}{
+		{
+			"empty-dir",
+			map[string]struct{}{},
+			map[string]hcl.Diagnostics{},
+		},
+		{
+			"valid-mod-files",
+			map[string]struct{}{
+				"empty.tf":     {},
+				"resources.tf": {},
+			},
+			map[string]hcl.Diagnostics{
+				"empty.tf":     nil,
+				"resources.tf": nil,
+			},
+		},
+		{
+			"valid-mod-files-with-extra-items",
+			map[string]struct{}{
+				"main.tf": {},
+			},
+			map[string]hcl.Diagnostics{
+				"main.tf": nil,
+			},
+		},
+		{
+			"invalid-mod-files",
+			map[string]struct{}{
+				"incomplete-block.tf": {},
+				"missing-brace.tf":    {},
+			},
+			map[string]hcl.Diagnostics{
+				"incomplete-block.tf": {
+					{
+						Severity: hcl.DiagError,
+						Summary:  "Invalid block definition",
+						Detail:   `A block definition must have block content delimited by "{" and "}", starting on the same line as the block header.`,
+						Subject: &hcl.Range{
+							Filename: "incomplete-block.tf",
+							Start:    hcl.Pos{Line: 1, Column: 30, Byte: 29},
+							End:      hcl.Pos{Line: 2, Column: 1, Byte: 30},
+						},
+						Context: &hcl.Range{
+							Filename: "incomplete-block.tf",
+							Start:    hcl.InitialPos,
+							End:      hcl.Pos{Line: 2, Column: 1, Byte: 30},
+						},
+					},
+				},
+				"missing-brace.tf": {
+					{
+						Severity: hcl.DiagError,
+						Summary:  "Argument or block definition required",
+						Detail:   "An argument or block definition is required here.",
+						Subject: &hcl.Range{
+							Filename: "missing-brace.tf",
+							Start:    hcl.Pos{Line: 10, Column: 1, Byte: 207},
+							End:      hcl.Pos{Line: 10, Column: 1, Byte: 207},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	fs := afero.NewIOFS(afero.NewOsFs())
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d-%s", i, tc.dirName), func(t *testing.T) {
+			modPath := filepath.Join("testdata", tc.dirName)
+
+			files, diags, err := ParseModuleFiles(fs, modPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			fileNames := mapKeys(files)
+			if diff := cmp.Diff(tc.expectedFileNames, fileNames); diff != "" {
+				t.Fatalf("unexpected file names: %s", diff)
+			}
+
+			if diff := cmp.Diff(tc.expectedDiags, diags.AsMap()); diff != "" {
+				t.Fatalf("unexpected diagnostics: %s", diff)
+			}
+		})
+	}
+}
+
+func mapKeys(mf ast.ModFiles) map[string]struct{} {
+	m := make(map[string]struct{}, len(mf))
+	for name := range mf {
+		m[name.String()] = struct{}{}
+	}
+	return m
+}

--- a/internal/terraform/parser/parser.go
+++ b/internal/terraform/parser/parser.go
@@ -1,0 +1,11 @@
+package parser
+
+import (
+	"io/fs"
+)
+
+type FS interface {
+	fs.FS
+	ReadDir(name string) ([]fs.DirEntry, error)
+	ReadFile(name string) ([]byte, error)
+}

--- a/internal/terraform/parser/testdata/invalid-mod-files/incomplete-block.tf
+++ b/internal/terraform/parser/testdata/invalid-mod-files/incomplete-block.tf
@@ -1,0 +1,1 @@
+resource "aws_security_group"

--- a/internal/terraform/parser/testdata/invalid-mod-files/missing-brace.tf
+++ b/internal/terraform/parser/testdata/invalid-mod-files/missing-brace.tf
@@ -1,0 +1,9 @@
+resource "aws_security_group" "web-sg" {
+  name = "${random_pet.name.id}-sg"
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+# missing brace

--- a/internal/terraform/parser/testdata/valid-mod-files-with-extra-items/.hidden.tf
+++ b/internal/terraform/parser/testdata/valid-mod-files-with-extra-items/.hidden.tf
@@ -1,0 +1,16 @@
+resource "aws_security_group" "web-sg" {
+  name = "${random_pet.name.id}-sg"
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}

--- a/internal/terraform/parser/testdata/valid-mod-files-with-extra-items/main.tf
+++ b/internal/terraform/parser/testdata/valid-mod-files-with-extra-items/main.tf
@@ -1,0 +1,16 @@
+resource "aws_security_group" "web-sg" {
+  name = "${random_pet.name.id}-sg"
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}

--- a/internal/terraform/parser/testdata/valid-mod-files-with-extra-items/main.tf~
+++ b/internal/terraform/parser/testdata/valid-mod-files-with-extra-items/main.tf~
@@ -1,0 +1,16 @@
+resource "aws_security_group" "web-sg" {
+  name = "${random_pet.name.id}-sg"
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}

--- a/internal/terraform/parser/testdata/valid-mod-files/resources.tf
+++ b/internal/terraform/parser/testdata/valid-mod-files/resources.tf
@@ -1,0 +1,9 @@
+resource "aws_instance" "web" {
+  ami                    = "ami-a0cfeed8"
+  instance_type          = "t2.micro"
+  user_data              = file("init-script.sh")
+
+  tags = {
+    Name = random_pet.name.id
+  }
+}

--- a/internal/terraform/parser/variables.go
+++ b/internal/terraform/parser/variables.go
@@ -1,0 +1,47 @@
+package parser
+
+import (
+	"path/filepath"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/hashicorp/terraform-ls/internal/terraform/ast"
+)
+
+func ParseVariableFiles(fs FS, modPath string) (ast.VarsFiles, ast.VarsDiags, error) {
+	files := make(ast.VarsFiles, 0)
+	diags := make(ast.VarsDiags, 0)
+
+	dirEntries, err := fs.ReadDir(modPath)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	for _, entry := range dirEntries {
+		if entry.IsDir() {
+			// We only care about files
+			continue
+		}
+
+		name := entry.Name()
+		if !ast.IsVarsFilename(name) {
+			continue
+		}
+
+		fullPath := filepath.Join(modPath, name)
+
+		src, err := fs.ReadFile(fullPath)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		f, pDiags := hclsyntax.ParseConfig(src, name, hcl.InitialPos)
+		filename := ast.VarsFilename(name)
+		diags[filename] = pDiags
+		if f != nil {
+			files[filename] = f
+		}
+	}
+
+	return files, diags, nil
+}


### PR DESCRIPTION
Closes #562

This PR decouples some logic of the overgrown `module` package into `ast` and `parser`:
 - `parser` is responsible for parsing `*.tf` and `*.tfvars` files - and potentially other future files we will support
 - `ast` is responsible for representing the files and diagnostics so that they can be filtered accordingly (e.g. we can distinguish between autoloaded and not-autoloaded tfvars files)
