### PR TITLE
ci: Use latest versions of (Windows/macOS/Ubuntu)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       -
@@ -56,9 +56,9 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-18.04
-          - windows-2019
-          - macos-10.15
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
     steps:
       -
         name: Checkout


### PR DESCRIPTION
There is no reason to be pinning to a particular OS version at this point. We expect LS to follow compatibility promises of the underlying Go version at build time for the most part.
