### PR TITLE
ci: Automate milestone closing & commenting

### DIFF
--- a/.github/workflows/milestone-closed.yml
+++ b/.github/workflows/milestone-closed.yml
@@ -1,0 +1,22 @@
+name: Closed Milestones
+
+on:
+  milestone:
+    types: [closed]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  Comment:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: bflad/action-milestone-comment@v1
+        with:
+          body: |
+            This functionality has been released in [${{ github.event.milestone.title }} of the language server](https://github.com/${{ github.repository }}/blob/${{ github.event.milestone.title }}/CHANGELOG.md).
+            If you use the official Terraform VS Code extension, it will prompt you to upgrade to this version automatically upon next launch or within the next 24 hours.
+
+            For further feature requests or bug reports with this functionality, please create a [new GitHub issue](https://github.com/${{ github.repository }}/issues/new/choose) following the template. Thank you!

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  issues: write
 
 env:
   GOPROXY: https://proxy.golang.org/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -118,5 +118,9 @@ publishers:
       - AWS_SESSION_TOKEN={{ .Env.AWS_SESSION_TOKEN }}
     cmd: hc-releases upload-file {{ abs .ArtifactPath }}
 
+milestones:
+  - name_template: "{{ .Tag }}"
+    close: true
+
 changelog:
   skip: true


### PR DESCRIPTION
Assuming that we assign all issues and PRs queued up for a release to the relevant milestone, we can automate closing of that milestone and publish comments to inform subscribes users that the feature or bug fix was released upon the release.

This follows what the AWS provider does; for example https://github.com/hashicorp/terraform-provider-aws/issues/20047#issuecomment-876773674
