### PR TITLE
Enable Semantic Token Refresh

### DIFF
--- a/internal/langserver/handlers/hooks_module.go
+++ b/internal/langserver/handlers/hooks_module.go
@@ -174,8 +174,6 @@ func refreshCodeLens(ctx context.Context, clientRequester session.ClientCaller) 
 
 func refreshSemanticTokens(ctx context.Context, svrCtx context.Context, logger *log.Logger) state.ModuleChangeHook {
 	return func(_, newMod *state.Module) {
-		logger.Printf("Request semantic token refresh for %s", newMod.Path)
-
 		jrpcsvc := jrpc2.ServerFromContext(ctx)
 		_, err := jrpcsvc.Callback(svrCtx, "workspace/semanticTokens/refresh", nil)
 		if err != nil {

--- a/internal/langserver/handlers/hooks_module.go
+++ b/internal/langserver/handlers/hooks_module.go
@@ -3,7 +3,9 @@ package handlers
 import (
 	"context"
 	"fmt"
+	"log"
 
+	"github.com/creachadair/jrpc2"
 	"github.com/hashicorp/terraform-ls/internal/langserver/diagnostics"
 	"github.com/hashicorp/terraform-ls/internal/langserver/session"
 	"github.com/hashicorp/terraform-ls/internal/state"
@@ -166,6 +168,18 @@ func refreshCodeLens(ctx context.Context, clientRequester session.ClientCaller) 
 
 		if oldOrigins != newOrigins || oldTargets != newTargets {
 			clientRequester.Callback(ctx, "workspace/codeLens/refresh", nil)
+		}
+	}
+}
+
+func refreshSemanticTokens(ctx context.Context, svrCtx context.Context, logger *log.Logger) state.ModuleChangeHook {
+	return func(_, newMod *state.Module) {
+		logger.Printf("Request semantic token refresh for %s", newMod.Path)
+
+		jrpcsvc := jrpc2.ServerFromContext(ctx)
+		_, err := jrpcsvc.Callback(svrCtx, "workspace/semanticTokens/refresh", nil)
+		if err != nil {
+			logger.Printf("Error refreshing %s: %s", newMod.Path, err)
 		}
 	}
 }

--- a/internal/langserver/handlers/service.go
+++ b/internal/langserver/handlers/service.go
@@ -446,6 +446,7 @@ func (svc *service) configureSessionDependencies(ctx context.Context, cfgOpts *s
 	svc.stateStore.Modules.ChangeHooks = state.ModuleChangeHooks{
 		updateDiagnostics(svc.sessCtx, svc.diagsNotifier),
 		sendModuleTelemetry(svc.sessCtx, svc.stateStore, svc.telemetry),
+		refreshSemanticTokens(ctx, svc.srvCtx, svc.logger),
 	}
 
 	cc, err := ilsp.ClientCapabilities(ctx)

--- a/internal/state/module.go
+++ b/internal/state/module.go
@@ -456,6 +456,11 @@ func (s *ModuleStore) UpdateModManifest(path string, manifest *datadir.ModuleMan
 		return err
 	}
 
+	txn.Defer(func() {
+		s.logger.Printf("Queuing refresh for %s", path)
+		go s.ChangeHooks.notifyModuleChange(nil, mod)
+	})
+
 	txn.Commit()
 	return nil
 }
@@ -474,6 +479,10 @@ func (s *ModuleStore) SetTerraformVersionState(path string, state op.OpState) er
 	if err != nil {
 		return err
 	}
+
+	txn.Defer(func() {
+		go s.ChangeHooks.notifyModuleChange(nil, mod)
+	})
 
 	txn.Commit()
 	return nil
@@ -555,6 +564,10 @@ func (s *ModuleStore) UpdateTerraformVersion(modPath string, tfVer *version.Vers
 	if err != nil {
 		return err
 	}
+
+	txn.Defer(func() {
+		go s.ChangeHooks.notifyModuleChange(nil, mod)
+	})
 
 	txn.Commit()
 	return nil


### PR DESCRIPTION
Add change hooks to the Module state store to trigger token refresh after specified parts of the schema are discovered after initialization.

Fixes #344