### PR TITLE
github: Keep running tests on other platforms upon failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     strategy:
+      fail-fast: false
       matrix:
         os:
           - ubuntu-latest


### PR DESCRIPTION
Prior to this patch we would stop running any steps in a matrix job immediately when one of them fails.

For example if a single test fails on Linux, that would cause the Windows and macOS steps to stop. While this is a sensible strategy for cost saving it's sometimes helpful to know whether tests actually fail on other platforms or whether it's platform-dependent failure.

We have already applied conservative timeout to each step and our tests generally don't take very long to finish so the cost saving argument is not as strong here anyway.

Docs: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast