### PR TITLE
Parse `*.tf.json` for references and symbols

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/hashicorp/go-memdb v1.3.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-version v1.3.0
-	github.com/hashicorp/hcl-lang v0.0.0-20211007132635-f22d3c2adf6c
+	github.com/hashicorp/hcl-lang v0.0.0-20211014152429-0bfbdcca0902
 	github.com/hashicorp/hcl/v2 v2.10.1
 	github.com/hashicorp/terraform-exec v0.15.0
 	github.com/hashicorp/terraform-json v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -191,8 +191,8 @@ github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uG
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/hcl-lang v0.0.0-20210803155453-7c098e4940bc/go.mod h1:xzXU6Fn+TWVaZUFxV8CyAsObi2oMgSEFAmLvCx2ArzM=
-github.com/hashicorp/hcl-lang v0.0.0-20211007132635-f22d3c2adf6c h1:98h0kdFx2qqS8lMAbGxR+b/HO3d52NdJsIgzG6Ikucg=
-github.com/hashicorp/hcl-lang v0.0.0-20211007132635-f22d3c2adf6c/go.mod h1:D7lBT7dekCcgbxzIHHBFvaRm42u5jY0pDoiC2J6A2KM=
+github.com/hashicorp/hcl-lang v0.0.0-20211014152429-0bfbdcca0902 h1:FxmNMZrjISkvGoXdoySct4dnk40KwhspPj9LvAaPPJo=
+github.com/hashicorp/hcl-lang v0.0.0-20211014152429-0bfbdcca0902/go.mod h1:D7lBT7dekCcgbxzIHHBFvaRm42u5jY0pDoiC2J6A2KM=
 github.com/hashicorp/hcl/v2 v2.10.1 h1:h4Xx4fsrRE26ohAk/1iGF/JBqRQbyUqu5Lvj60U54ys=
 github.com/hashicorp/hcl/v2 v2.10.1/go.mod h1:FwWsfWEjyV/CMj8s/gqAuiviY72rJ1/oayI9WftqcKg=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=

--- a/internal/langserver/handlers/code_lens_test.go
+++ b/internal/langserver/handlers/code_lens_test.go
@@ -184,7 +184,7 @@ output "test" {
 							"arguments": [
 								{
 									"line": 0,
-									"character": 8
+									"character": 7
 								},
 								{
 									"includeDeclaration": false

--- a/internal/langserver/handlers/workspace_symbol.go
+++ b/internal/langserver/handlers/workspace_symbol.go
@@ -12,7 +12,7 @@ import (
 func (h *logHandler) WorkspaceSymbol(ctx context.Context, params lsp.WorkspaceSymbolParams) ([]lsp.SymbolInformation, error) {
 	var symbols []lsp.SymbolInformation
 
-	mm, err := lsctx.ModuleFinder(ctx)
+	mf, err := lsctx.ModuleFinder(ctx)
 	if err != nil {
 		return symbols, err
 	}
@@ -22,7 +22,7 @@ func (h *logHandler) WorkspaceSymbol(ctx context.Context, params lsp.WorkspaceSy
 		return nil, err
 	}
 
-	modules, err := mm.ListModules()
+	modules, err := mf.ListModules()
 	if err != nil {
 		return nil, err
 	}
@@ -32,6 +32,9 @@ func (h *logHandler) WorkspaceSymbol(ctx context.Context, params lsp.WorkspaceSy
 		if err != nil {
 			return symbols, err
 		}
+
+		schema, _ := mf.SchemaForModule(mod.Path)
+		d.SetSchema(schema)
 
 		modSymbols, err := d.Symbols(params.Query)
 		if err != nil {

--- a/internal/terraform/ast/module.go
+++ b/internal/terraform/ast/module.go
@@ -12,8 +12,14 @@ func (mf ModFilename) String() string {
 	return string(mf)
 }
 
+func (mf ModFilename) IsJSON() bool {
+	return strings.HasSuffix(string(mf), ".json")
+}
+
 func IsModuleFilename(name string) bool {
-	return strings.HasSuffix(name, ".tf") && !isIgnoredFile(name)
+	return (strings.HasSuffix(name, ".tf") ||
+		strings.HasSuffix(name, ".tf.json")) &&
+		!isIgnoredFile(name)
 }
 
 type ModFiles map[ModFilename]*hcl.File

--- a/internal/terraform/parser/module.go
+++ b/internal/terraform/parser/module.go
@@ -3,8 +3,6 @@ package parser
 import (
 	"path/filepath"
 
-	"github.com/hashicorp/hcl/v2"
-	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/terraform-ls/internal/terraform/ast"
 )
 
@@ -37,8 +35,10 @@ func ParseModuleFiles(fs FS, modPath string) (ast.ModFiles, ast.ModDiags, error)
 			return nil, nil, err
 		}
 
-		f, pDiags := hclsyntax.ParseConfig(src, name, hcl.InitialPos)
 		filename := ast.ModFilename(name)
+
+		f, pDiags := parseFile(src, filename)
+
 		diags[filename] = pDiags
 		if f != nil {
 			files[filename] = f

--- a/internal/terraform/parser/parser.go
+++ b/internal/terraform/parser/parser.go
@@ -2,10 +2,26 @@ package parser
 
 import (
 	"io/fs"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/hashicorp/hcl/v2/json"
 )
 
 type FS interface {
 	fs.FS
 	ReadDir(name string) ([]fs.DirEntry, error)
 	ReadFile(name string) ([]byte, error)
+}
+
+type filename interface {
+	IsJSON() bool
+	String() string
+}
+
+func parseFile(src []byte, filename filename) (*hcl.File, hcl.Diagnostics) {
+	if filename.IsJSON() {
+		return json.Parse(src, filename.String())
+	}
+	return hclsyntax.ParseConfig(src, filename.String(), hcl.InitialPos)
 }


### PR DESCRIPTION
Closes #498 

Depends on https://github.com/hashicorp/hcl-lang/pull/88

--- 

## UX Impact

### Completion

References to targetable blocks or attributes (such as variables) declared in JSON are provided to the user as completion candidates in HCL configs.
![image5](https://user-images.githubusercontent.com/287584/137317579-0b7ca6ab-2a1c-4652-a67b-33213f4b4cde.png)

### Hover

Hovering over a reference (such as `var.delta`) in HCL config provides user details about the reference, such as the type (e.g. `string`) when the target attribute or block itself is declared in JSON.

![image9](https://user-images.githubusercontent.com/287584/137317762-5e3963e3-c6db-48c0-a373-bae37ea63073.png)

### Semantic Highlighting

Valid references to targetable blocks or attributes declared in JSON are highlighted accordingly in HCL configs. Note that it may be hard to spot the difference below, but "`var.`" on the screenshot has black+dark-blue colours (highlighted only via static TextMate grammar) or whole dark-blue (semantically highlighted).

![image3](https://user-images.githubusercontent.com/287584/137317878-d7b9d7c3-1ffa-47bf-a04e-0d06a615e596.png)

### Go To References

Using the context menu option "**Go to References**", the user is able to go from an attribute or a block to any of its references declared in any JSON files.

![image8](https://user-images.githubusercontent.com/287584/137317947-19ee9422-5e06-4b72-adf2-edc399d2a1e6.png)
![image11](https://user-images.githubusercontent.com/287584/137317952-b976767d-d2b4-4313-b1a8-fede7558069f.png)

### Go To Definition

Using the context menu option "**Go to Definition**" or Ctrl/Cmd+click on a reference, the user is able to go from an HCL reference to the definition of a block or an attribute in JSON.

![image2](https://user-images.githubusercontent.com/287584/137317987-7e1d2421-835d-4f9b-b98e-6891e4b11311.png)
![image10](https://user-images.githubusercontent.com/287584/137317990-043b98dd-22da-47e4-8b58-c432371a061d.png)

### List References

Code lenses providing a number of references to top level blocks continue to be activated on HCL configuration, but will include results from JSON files and (naturally) provide "go-to-reference" pointing to these JSON files.

![image7](https://user-images.githubusercontent.com/287584/137318008-08fdae1f-6e54-4f89-9ba1-e9a8d92e8c62.png)

### Symbols
Users is able to find symbols declared in JSON files when seeking for symbols across the workspace.

![image6](https://user-images.githubusercontent.com/287584/137317686-035037f3-4910-4dc9-ab5a-dc950b1cf7ca.png)
![image4](https://user-images.githubusercontent.com/287584/137317680-c8cfffc3-b3d5-42a2-9f51-4408b45dcdb5.png)
