### PR TITLE
schemas: exclude ciphertrust

### DIFF
--- a/internal/schemas/gen/gen.go
+++ b/internal/schemas/gen/gen.go
@@ -245,15 +245,16 @@ func listProviders(tier string) ([]provider, error) {
 // registry for registry.terraform.io/jfrog/artifactory: failed to retrieve
 // authentication checksums for provider: 404 Not Found
 var ignore = map[string]bool{
-	"Icinga/icinga2":         true,
-	"a10networks/vthunder":   true,
-	"jradtilbrook/buildkite": true,
-	"HewlettPackard/oneview": true,
-	"zerotier/zerotier":      true,
-	"nirmata/nirmata":        true,
-	"datastax/astra":         true,
-	"oktadeveloper/okta":     true,
-	"jfrog/artifactory":      true,
+	"Icinga/icinga2":          true,
+	"a10networks/vthunder":    true,
+	"jradtilbrook/buildkite":  true,
+	"HewlettPackard/oneview":  true,
+	"zerotier/zerotier":       true,
+	"nirmata/nirmata":         true,
+	"datastax/astra":          true,
+	"oktadeveloper/okta":      true,
+	"jfrog/artifactory":       true,
+	"ThalesGroup/ciphertrust": true,
 }
 
 func filter(providers []provider) (filtered []provider) {


### PR DESCRIPTION
This is to address the failing CI build which is caused by the fact that the provider only has a single release, which is a pre-release (beta1) and since we don't provide any version constraints in our generated configs it implicitly excludes prereleases.

https://github.com/hashicorp/terraform-ls/runs/4065743149?check_suite_focus=true#step:6:65