### PR TITLE
internal: Avoid logging when capacity is reached

### DIFF
--- a/internal/terraform/module/module_loader.go
+++ b/internal/terraform/module/module_loader.go
@@ -115,7 +115,6 @@ func (ml *moduleLoader) run(ctx context.Context) {
 				// This may happen when op was received from the channel
 				// and dispatcher checked capacity before loading counters
 				// were decremented.
-				ml.logger.Println("no available capacity, retrying dispatch")
 				time.Sleep(100 * time.Millisecond)
 				ml.queue.PushOp(nextOp)
 				go ml.tryDispatchingModuleOp()


### PR DESCRIPTION
When a deep hierarchy is being indexed, there is a high chance that we reach the max. number of operations that can run at the same time and effectively hit a point where operations are repeatedly rescheduled for some time.

Logging this fact results in the message being all over the log and very spammy, so I'm proposing to remove it.
