### PR TITLE
Implement ignorelist for module indexing

### DIFF
--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -68,6 +68,18 @@ Or if left empty
 This setting should be deprecated once the language server supports multiple workspaces,
 as this arises in VS code because a server instance is started per VS Code workspace.
 
+## `ignoreDirectoryNames` (`[]string`)
+
+This allows excluding directories from being checked by the walker by passing a static list of directory names.
+
+The following list of directories will always be ignored:
+
+- `.git`
+- `.idea`
+- `.vscode`
+- `terraform.tfstate.d`
+- `.terragrunt-cache`
+
 ## `experimentalFeatures` (object)
 
 This object contains inner settings used to opt into experimental features not yet ready to be on by default.

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -70,7 +70,7 @@ as this arises in VS code because a server instance is started per VS Code works
 
 ## `ignoreDirectoryNames` (`[]string`)
 
-This allows excluding directories from being checked by the walker by passing a static list of directory names.
+This allows excluding directories from being indexed upon initialization by passing a list of directory names.
 
 The following list of directories will always be ignored:
 

--- a/internal/langserver/handlers/initialize.go
+++ b/internal/langserver/handlers/initialize.go
@@ -59,6 +59,7 @@ func (svc *service) Initialize(ctx context.Context, params lsp.InitializeParams)
 		"options.rootModulePaths":                         false,
 		"options.excludeModulePaths":                      false,
 		"options.commandPrefix":                           false,
+		"options.ignoreDirectoryNames":                    false,
 		"options.experimentalFeatures.validateOnSave":     false,
 		"options.terraformExecPath":                       false,
 		"options.terraformExecTimeout":                    "",
@@ -123,6 +124,7 @@ func (svc *service) Initialize(ctx context.Context, params lsp.InitializeParams)
 	properties["options.rootModulePaths"] = len(out.Options.ModulePaths) > 0
 	properties["options.excludeModulePaths"] = len(out.Options.ExcludeModulePaths) > 0
 	properties["options.commandPrefix"] = len(out.Options.CommandPrefix) > 0
+	properties["options.ignoreDirectoryNames"] = len(out.Options.IgnoreDirectoryNames) > 0
 	properties["options.experimentalFeatures.prefillRequiredFields"] = out.Options.ExperimentalFeatures.PrefillRequiredFields
 	properties["options.experimentalFeatures.validateOnSave"] = out.Options.ExperimentalFeatures.ValidateOnSave
 	properties["options.terraformExecPath"] = len(out.Options.TerraformExecPath) > 0
@@ -192,6 +194,8 @@ func (svc *service) Initialize(ctx context.Context, params lsp.InitializeParams)
 		excludeModulePaths = append(excludeModulePaths, modPath)
 	}
 
+	// TODO? do we need to validate the input here?
+	svc.walker.SetIgnoreDirectoryNames(cfgOpts.IgnoreDirectoryNames)
 	svc.walker.SetExcludeModulePaths(excludeModulePaths)
 	svc.walker.EnqueuePath(fh.Dir())
 

--- a/internal/langserver/handlers/initialize.go
+++ b/internal/langserver/handlers/initialize.go
@@ -194,7 +194,6 @@ func (svc *service) Initialize(ctx context.Context, params lsp.InitializeParams)
 		excludeModulePaths = append(excludeModulePaths, modPath)
 	}
 
-	// TODO? do we need to validate the input here?
 	svc.walker.SetIgnoreDirectoryNames(cfgOpts.IgnoreDirectoryNames)
 	svc.walker.SetExcludeModulePaths(excludeModulePaths)
 	svc.walker.EnqueuePath(fh.Dir())

--- a/internal/langserver/handlers/initialize_test.go
+++ b/internal/langserver/handlers/initialize_test.go
@@ -134,7 +134,7 @@ func TestInitialize_ignoreDirectoryNames(t *testing.T) {
 			PerWorkDir: map[string][]*mock.Call{
 				pluginDir: validTfMockCalls(),
 				emptyDir: {
-					// TODO? can this be empty?
+					// TODO! improve mock and remove entry for `emptyDir` here afterwards
 					{
 						Method:        "GetExecPath",
 						Repeatability: 1,

--- a/internal/langserver/handlers/initialize_test.go
+++ b/internal/langserver/handlers/initialize_test.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"fmt"
+	"path/filepath"
 	"testing"
 
 	"github.com/creachadair/jrpc2/code"
@@ -118,4 +119,43 @@ func TestInitialize_multipleFolders(t *testing.T) {
 	    	}
 	    ]
 	}`, rootDir.URI(), rootDir.URI())})
+}
+
+func TestInitialize_ignoreDirectoryNames(t *testing.T) {
+	tmpDir := TempDir(t, "plugin", "ignore")
+	pluginDir := filepath.Join(tmpDir.Dir(), "plugin")
+	emptyDir := filepath.Join(tmpDir.Dir(), "ignore")
+
+	InitPluginCache(t, pluginDir)
+	InitPluginCache(t, emptyDir)
+
+	ls := langserver.NewLangServerMock(t, NewMockSession(&MockSessionInput{
+		TerraformCalls: &exec.TerraformMockCalls{
+			PerWorkDir: map[string][]*mock.Call{
+				pluginDir: validTfMockCalls(),
+				emptyDir: {
+					// TODO? can this be empty?
+					{
+						Method:        "GetExecPath",
+						Repeatability: 1,
+						ReturnArguments: []interface{}{
+							"",
+						},
+					},
+				},
+			},
+		}}))
+	stop := ls.Start(t)
+	defer stop()
+
+	ls.Call(t, &langserver.CallRequest{
+		Method: "initialize",
+		ReqParams: fmt.Sprintf(`{
+			"capabilities": {},
+			"rootUri": %q,
+			"processId": 12345,
+			"initializationOptions": {
+				"ignoreDirectoryNames": [%q]
+			}
+	}`, tmpDir.URI(), "ignore")})
 }

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
+	"github.com/hashicorp/terraform-ls/internal/terraform/datadir"
 	"github.com/mitchellh/mapstructure"
 )
 
@@ -44,6 +46,18 @@ func (o *Options) Validate() error {
 		}
 		if stat.IsDir() {
 			return fmt.Errorf("Expected a Terraform binary, got a directory: %q", path)
+		}
+	}
+
+	if len(o.IgnoreDirectoryNames) > 0 {
+		for _, directory := range o.IgnoreDirectoryNames {
+			if directory == datadir.DataDirName {
+				return fmt.Errorf("cannot ignore data directory %q", datadir.DataDirName)
+			}
+
+			if strings.Contains(directory, string(filepath.Separator)) {
+				return fmt.Errorf("expected directory name, got a path: %q", directory)
+			}
 		}
 	}
 

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -52,7 +52,7 @@ func (o *Options) Validate() error {
 	if len(o.IgnoreDirectoryNames) > 0 {
 		for _, directory := range o.IgnoreDirectoryNames {
 			if directory == datadir.DataDirName {
-				return fmt.Errorf("cannot ignore data directory %q", datadir.DataDirName)
+				return fmt.Errorf("cannot ignore directory %q", datadir.DataDirName)
 			}
 
 			if strings.Contains(directory, string(filepath.Separator)) {

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -15,9 +15,10 @@ type ExperimentalFeatures struct {
 
 type Options struct {
 	// ModulePaths describes a list of absolute paths to modules to load
-	ModulePaths        []string `mapstructure:"rootModulePaths"`
-	ExcludeModulePaths []string `mapstructure:"excludeModulePaths"`
-	CommandPrefix      string   `mapstructure:"commandPrefix"`
+	ModulePaths          []string `mapstructure:"rootModulePaths"`
+	ExcludeModulePaths   []string `mapstructure:"excludeModulePaths"`
+	CommandPrefix        string   `mapstructure:"commandPrefix"`
+	IgnoreDirectoryNames []string `mapstructure:"ignoreDirectoryNames"`
 
 	// ExperimentalFeatures encapsulates experimental features users can opt into.
 	ExperimentalFeatures ExperimentalFeatures `mapstructure:"experimentalFeatures"`

--- a/internal/settings/settings_test.go
+++ b/internal/settings/settings_test.go
@@ -1,6 +1,8 @@
 package settings
 
 import (
+	"fmt"
+	"path/filepath"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -48,7 +50,7 @@ func TestValidate_IgnoreDirectoryNames_error(t *testing.T) {
 		result string
 	}{
 		{datadir.DataDirName, `cannot ignore data directory ".terraform"`},
-		{"path/path", `expected directory name, got a path: "path/path"`},
+		{filepath.Join("path", "path"), fmt.Sprintf(`expected directory name, got a path: "path%spath"`, string(filepath.Separator))},
 	}
 
 	for _, table := range tables {

--- a/internal/settings/settings_test.go
+++ b/internal/settings/settings_test.go
@@ -49,7 +49,7 @@ func TestValidate_IgnoreDirectoryNames_error(t *testing.T) {
 		input  string
 		result string
 	}{
-		{datadir.DataDirName, `cannot ignore data directory ".terraform"`},
+		{datadir.DataDirName, `cannot ignore directory ".terraform"`},
 		{filepath.Join("path", "path"), fmt.Sprintf(`expected directory name, got a path: %q`, filepath.Join("path", "path"))},
 	}
 

--- a/internal/settings/settings_test.go
+++ b/internal/settings/settings_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-ls/internal/terraform/datadir"
 )
 
 func TestDecodeOptions_nil(t *testing.T) {
@@ -38,5 +39,42 @@ func TestDecodeOptions_success(t *testing.T) {
 	expectedPaths := []string{"/random/path"}
 	if diff := cmp.Diff(expectedPaths, opts.ModulePaths); diff != "" {
 		t.Fatalf("options mismatch: %s", diff)
+	}
+}
+
+func TestValidate_IgnoreDirectoryNames_error(t *testing.T) {
+	tables := []struct {
+		input  string
+		result string
+	}{
+		{datadir.DataDirName, `cannot ignore data directory ".terraform"`},
+		{"path/path", `expected directory name, got a path: "path/path"`},
+	}
+
+	for _, table := range tables {
+		out, err := DecodeOptions(map[string]interface{}{
+			"IgnoreDirectoryNames": []string{table.input},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		result := out.Options.Validate()
+		if result.Error() != table.result {
+			t.Fatalf("expected error: %s, got: %s", table.result, result)
+		}
+	}
+}
+func TestValidate_IgnoreDirectoryNames_success(t *testing.T) {
+	out, err := DecodeOptions(map[string]interface{}{
+		"IgnoreDirectoryNames": []string{"directory"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result := out.Options.Validate()
+	if result != nil {
+		t.Fatalf("did not expect error: %s", result)
 	}
 }

--- a/internal/settings/settings_test.go
+++ b/internal/settings/settings_test.go
@@ -55,7 +55,7 @@ func TestValidate_IgnoreDirectoryNames_error(t *testing.T) {
 
 	for _, table := range tables {
 		out, err := DecodeOptions(map[string]interface{}{
-			"IgnoreDirectoryNames": []string{table.input},
+			"ignoreDirectoryNames": []string{table.input},
 		})
 		if err != nil {
 			t.Fatal(err)
@@ -69,7 +69,7 @@ func TestValidate_IgnoreDirectoryNames_error(t *testing.T) {
 }
 func TestValidate_IgnoreDirectoryNames_success(t *testing.T) {
 	out, err := DecodeOptions(map[string]interface{}{
-		"IgnoreDirectoryNames": []string{"directory"},
+		"ignoreDirectoryNames": []string{"directory"},
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/settings/settings_test.go
+++ b/internal/settings/settings_test.go
@@ -50,7 +50,7 @@ func TestValidate_IgnoreDirectoryNames_error(t *testing.T) {
 		result string
 	}{
 		{datadir.DataDirName, `cannot ignore data directory ".terraform"`},
-		{filepath.Join("path", "path"), fmt.Sprintf(`expected directory name, got a path: "path%spath"`, string(filepath.Separator))},
+		{filepath.Join("path", "path"), fmt.Sprintf(`expected directory name, got a path: %q`, filepath.Join("path", "path"))},
 	}
 
 	for _, table := range tables {

--- a/internal/terraform/module/walker.go
+++ b/internal/terraform/module/walker.go
@@ -21,6 +21,8 @@ var (
 
 	// skipDirNames represent directory names which would never contain
 	// plugin/module cache, so it's safe to skip them during the walk
+	//
+	// please keep the list in `SETTINGS.md` in sync
 	skipDirNames = map[string]bool{
 		".git":                true,
 		".idea":               true,


### PR DESCRIPTION
This PR adds a new setting called `ignoreDirectoryNames` to the language server. It's now possible to send a list of directories on `initialize`, which should be ignored by the walker and never be indexed.

Closes #670 