### PR TITLE
Implement support for JSON variable files

### DIFF
--- a/internal/terraform/ast/variables.go
+++ b/internal/terraform/ast/variables.go
@@ -31,7 +31,10 @@ func (vf VarsFilename) IsJSON() bool {
 
 func (vf VarsFilename) IsAutoloaded() bool {
 	name := string(vf)
-	return strings.HasSuffix(name, ".auto.tfvars") || name == "terraform.tfvars"
+	return strings.HasSuffix(name, ".auto.tfvars") ||
+		strings.HasSuffix(name, ".auto.tfvars.json") ||
+		name == "terraform.tfvars" ||
+		name == "terraform.tfvars.json"
 }
 
 type VarsFiles map[VarsFilename]*hcl.File

--- a/internal/terraform/ast/variables.go
+++ b/internal/terraform/ast/variables.go
@@ -16,11 +16,17 @@ func NewVarsFilename(name string) (VarsFilename, bool) {
 }
 
 func IsVarsFilename(name string) bool {
-	return strings.HasSuffix(name, ".tfvars") && !isIgnoredFile(name)
+	return (strings.HasSuffix(name, ".tfvars") ||
+		strings.HasSuffix(name, ".tfvars.json")) &&
+		!isIgnoredFile(name)
 }
 
 func (vf VarsFilename) String() string {
 	return string(vf)
+}
+
+func (vf VarsFilename) IsJSON() bool {
+	return strings.HasSuffix(string(vf), ".json")
 }
 
 func (vf VarsFilename) IsAutoloaded() bool {

--- a/internal/terraform/parser/variables.go
+++ b/internal/terraform/parser/variables.go
@@ -3,8 +3,6 @@ package parser
 import (
 	"path/filepath"
 
-	"github.com/hashicorp/hcl/v2"
-	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/terraform-ls/internal/terraform/ast"
 )
 
@@ -35,8 +33,10 @@ func ParseVariableFiles(fs FS, modPath string) (ast.VarsFiles, ast.VarsDiags, er
 			return nil, nil, err
 		}
 
-		f, pDiags := hclsyntax.ParseConfig(src, name, hcl.InitialPos)
 		filename := ast.VarsFilename(name)
+
+		f, pDiags := parseFile(src, filename)
+
 		diags[filename] = pDiags
 		if f != nil {
 			files[filename] = f


### PR DESCRIPTION
This PR adds support for collecting variables from `*.tfvars.json` and `*.auto.tfvars.json` files in addition to `*.tfvars`.

Closes #519.

--- 

## UX Impact

### Symbols

Users can find variables declared in JSON files when seeking symbols across the workspace.

<img width="507" alt="CleanShot 2021-11-08 at 15 18 29@2x" src="https://user-images.githubusercontent.com/45985/140758040-7630ccbe-d76a-4ea1-80a2-18dbb4f46684.png">

### Problems

Users can find a list of issues for JSON files in the problems tab.

<img width="734" alt="CleanShot 2021-11-09 at 10 38 40@2x" src="https://user-images.githubusercontent.com/45985/140901032-9dc6545d-e748-4d37-9707-b6dbb91daae7.png">


