### PR TITLE
Avoid duplicate state entries (by avoiding symlink evaluation)

### DIFF
--- a/internal/langserver/handlers/initialize.go
+++ b/internal/langserver/handlers/initialize.go
@@ -266,7 +266,7 @@ func resolvePath(rootDir, rawPath string) (string, error) {
 }
 
 func cleanupPath(path string) (string, error) {
-	absPath, err := filepath.EvalSymlinks(path)
+	absPath, err := filepath.Abs(path)
 	return toLowerVolumePath(absPath), err
 }
 

--- a/internal/terraform/module/module_manager.go
+++ b/internal/terraform/module/module_manager.go
@@ -68,7 +68,9 @@ func (mm *moduleManager) AddModule(modPath string) (Module, error) {
 
 	err := mm.moduleStore.Add(modPath)
 	if err != nil {
-		return nil, err
+		if _, ok := err.(*state.AlreadyExistsError); !ok {
+			return nil, err
+		}
 	}
 
 	// TODO: Avoid returning new module, just the error from adding


### PR DESCRIPTION
We use module paths in many different places and we this ensure we will compare the same paths consistently and avoid duplicate entries in memdb.

There is unfortunately no easy way to test this as the potential problem would arise as part of a module operation which is executed asynchronously, and/or when publishing diagnostics, which is in itself hard to test currently.

This bug is more visible in https://github.com/hashicorp/terraform-ls/pull/714 and https://github.com/hashicorp/terraform-ls/pull/700 when you open a folder that has symlink somewhere in the path.

--- 

We will likely re-evaluate this decision more holistically (in the context of the whole codebase) in https://github.com/hashicorp/terraform-ls/issues/241