### PR TITLE
telemetry: Disable logging when telemetry is disabled

### DIFF
--- a/internal/telemetry/noop.go
+++ b/internal/telemetry/noop.go
@@ -17,6 +17,4 @@ func (t *NoopSender) log() *log.Logger {
 	return log.New(ioutil.Discard, "", 0)
 }
 
-func (t *NoopSender) SendEvent(ctx context.Context, name string, properties map[string]interface{}) {
-	t.log().Printf("telemetry disabled %q: %#v", name, properties)
-}
+func (t *NoopSender) SendEvent(ctx context.Context, name string, properties map[string]interface{}) {}


### PR DESCRIPTION
This was useful when implementing the telemetry features, but now it can make the log output unnecessarily verbose, which doesn't help especially when debugging other things, as usually that happens in a dev environment where telemetry is disabled.