### PR TITLE
fix: Avoid crash in telemetry on module removal

### DIFF
--- a/internal/langserver/handlers/did_change_workspace_folders_test.go
+++ b/internal/langserver/handlers/did_change_workspace_folders_test.go
@@ -1,0 +1,53 @@
+package handlers
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-ls/internal/langserver"
+	"github.com/hashicorp/terraform-ls/internal/terraform/exec"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestDidChangeWorkspaceFolders(t *testing.T) {
+	rootDir := TempDir(t)
+	ls := langserver.NewLangServerMock(t, NewMockSession(&MockSessionInput{
+		TerraformCalls: &exec.TerraformMockCalls{
+			PerWorkDir: map[string][]*mock.Call{
+				rootDir.Dir(): validTfMockCalls(),
+			},
+		},
+	}))
+	stop := ls.Start(t)
+	defer stop()
+
+	ls.Call(t, &langserver.CallRequest{
+		Method: "initialize",
+		ReqParams: fmt.Sprintf(`{
+		"capabilities": {},
+		"rootUri": %q,
+		"processId": 12345,
+		"workspaceFolders": [
+			{
+				"uri": %q,
+				"name": "first"
+			}
+		]
+	}`, rootDir.URI(), rootDir.URI())})
+	ls.Notify(t, &langserver.CallRequest{
+		Method:    "initialized",
+		ReqParams: "{}",
+	})
+	ls.Call(t, &langserver.CallRequest{
+		Method: "workspace/didChangeWorkspaceFolders",
+		ReqParams: fmt.Sprintf(`{
+		"event": {
+			"added": [
+				{"uri": %q, "name": "second"}
+			],
+			"removed": [
+				{"uri": %q, "name": "first"}
+			]
+		}
+	}`, rootDir.URI(), rootDir.URI())})
+}

--- a/internal/langserver/handlers/hooks_module.go
+++ b/internal/langserver/handlers/hooks_module.go
@@ -11,6 +11,12 @@ import (
 
 func sendModuleTelemetry(ctx context.Context, store *state.StateStore, telemetrySender telemetry.Sender) state.ModuleChangeHook {
 	return func(_, newMod *state.Module) {
+		if newMod == nil {
+			// module is being removed
+			// TODO: Track module removal as an event
+			return
+		}
+
 		modId, err := store.GetModuleID(newMod.Path)
 		if err != nil {
 			return

--- a/internal/langserver/handlers/service.go
+++ b/internal/langserver/handlers/service.go
@@ -300,6 +300,7 @@ func (svc *service) Assigner() (jrpc2.Assigner, error) {
 			}
 
 			ctx = lsctx.WithModuleWalker(ctx, svc.walker)
+			ctx = lsctx.WithModuleManager(ctx, svc.modMgr)
 			ctx = lsctx.WithWatcher(ctx, svc.watcher)
 
 			return handle(ctx, req, lh.DidChangeWorkspaceFolders)


### PR DESCRIPTION
I was able to reproduce this by removing a folder from a workspace, but I also noticed that the VS Code client in particular sends `shutdown` to the server instead of `didChangeWorkspaceFolder` with the removed folder, so we can't _really_ track module removals _yet_ until that client-side bug is addressed.

https://github.com/hashicorp/terraform-ls/blob/055cf0226f209e9b5cbfa95a9ec59d0fe1928c41/internal/state/module.go#L252-L255

I also noticed that the notifications for folder change would never work because we weren't passing the module manager down to the handler, so it would always error out 🙈  This was there since the beginning https://github.com/hashicorp/terraform-ls/pull/502
