### PR TITLE
refactor: decouple diagnostics from handlers into a hook

### DIFF
--- a/internal/langserver/handlers/did_change.go
+++ b/internal/langserver/handlers/did_change.go
@@ -5,10 +5,8 @@ import (
 	"fmt"
 
 	lsctx "github.com/hashicorp/terraform-ls/internal/context"
-	"github.com/hashicorp/terraform-ls/internal/langserver/diagnostics"
 	ilsp "github.com/hashicorp/terraform-ls/internal/lsp"
 	lsp "github.com/hashicorp/terraform-ls/internal/protocol"
-	"github.com/hashicorp/terraform-ls/internal/terraform/ast"
 	op "github.com/hashicorp/terraform-ls/internal/terraform/module/operation"
 )
 
@@ -81,21 +79,6 @@ func TextDocumentDidChange(ctx context.Context, params lsp.DidChangeTextDocument
 	if err != nil {
 		return err
 	}
-
-	// TODO
-	notifier, err := lsctx.DiagnosticsNotifier(ctx)
-	if err != nil {
-		return err
-	}
-
-	diags := diagnostics.NewDiagnostics()
-	diags.EmptyRootDiagnostic()
-	diags.Append("HCL", mod.ModuleDiagnostics.AsMap())
-	diags.Append("HCL", mod.VarsDiagnostics.AutoloadedOnly().AsMap())
-	if vf, ok := ast.NewVarsFilename(f.Filename()); ok && !vf.IsAutoloaded() {
-		diags.Append("HCL", mod.VarsDiagnostics.ForFile(vf).AsMap())
-	}
-	notifier.PublishHCLDiags(ctx, mod.Path, diags)
 
 	return nil
 }

--- a/internal/langserver/handlers/did_change.go
+++ b/internal/langserver/handlers/did_change.go
@@ -61,35 +61,29 @@ func TextDocumentDidChange(ctx context.Context, params lsp.DidChangeTextDocument
 		return err
 	}
 
-	err = modMgr.EnqueueModuleOpWait(mod.Path, op.OpTypeParseModuleConfiguration)
+	err = modMgr.EnqueueModuleOp(mod.Path, op.OpTypeParseModuleConfiguration, nil)
 	if err != nil {
 		return err
 	}
-	err = modMgr.EnqueueModuleOpWait(mod.Path, op.OpTypeParseVariables)
+	err = modMgr.EnqueueModuleOp(mod.Path, op.OpTypeParseVariables, nil)
 	if err != nil {
 		return err
 	}
-	// TODO: parallelise the operations below in a workgroup
-	err = modMgr.EnqueueModuleOpWait(mod.Path, op.OpTypeLoadModuleMetadata)
+	err = modMgr.EnqueueModuleOp(mod.Path, op.OpTypeLoadModuleMetadata, nil)
 	if err != nil {
 		return err
 	}
-	err = modMgr.EnqueueModuleOpWait(mod.Path, op.OpTypeDecodeReferenceTargets)
+	err = modMgr.EnqueueModuleOp(mod.Path, op.OpTypeDecodeReferenceTargets, nil)
 	if err != nil {
 		return err
 	}
-	err = modMgr.EnqueueModuleOpWait(mod.Path, op.OpTypeDecodeReferenceOrigins)
+	err = modMgr.EnqueueModuleOp(mod.Path, op.OpTypeDecodeReferenceOrigins, nil)
 	if err != nil {
 		return err
 	}
 
+	// TODO
 	notifier, err := lsctx.DiagnosticsNotifier(ctx)
-	if err != nil {
-		return err
-	}
-
-	// obtain fresh module state after the above operations finished
-	mod, err = modMgr.ModuleByPath(fh.Dir())
 	if err != nil {
 		return err
 	}

--- a/internal/langserver/handlers/did_close.go
+++ b/internal/langserver/handlers/did_close.go
@@ -3,12 +3,9 @@ package handlers
 import (
 	"context"
 
-	"github.com/hashicorp/hcl/v2"
 	lsctx "github.com/hashicorp/terraform-ls/internal/context"
-	"github.com/hashicorp/terraform-ls/internal/langserver/diagnostics"
 	ilsp "github.com/hashicorp/terraform-ls/internal/lsp"
 	lsp "github.com/hashicorp/terraform-ls/internal/protocol"
-	"github.com/hashicorp/terraform-ls/internal/terraform/ast"
 )
 
 func TextDocumentDidClose(ctx context.Context, params lsp.DidCloseTextDocumentParams) error {
@@ -21,20 +18,6 @@ func TextDocumentDidClose(ctx context.Context, params lsp.DidCloseTextDocumentPa
 	err = fs.CloseAndRemoveDocument(fh)
 	if err != nil {
 		return err
-	}
-
-	if vf, ok := ast.NewVarsFilename(fh.Filename()); ok && !vf.IsAutoloaded() {
-		notifier, err := lsctx.DiagnosticsNotifier(ctx)
-		if err != nil {
-			return err
-		}
-
-		diags := diagnostics.NewDiagnostics()
-		diags.EmptyRootDiagnostic()
-		diags.Append("HCL", map[string]hcl.Diagnostics{
-			fh.Filename(): {},
-		})
-		notifier.PublishHCLDiags(ctx, fh.Dir(), diags)
 	}
 
 	return nil

--- a/internal/langserver/handlers/did_open.go
+++ b/internal/langserver/handlers/did_open.go
@@ -4,10 +4,8 @@ import (
 	"context"
 
 	lsctx "github.com/hashicorp/terraform-ls/internal/context"
-	"github.com/hashicorp/terraform-ls/internal/langserver/diagnostics"
 	ilsp "github.com/hashicorp/terraform-ls/internal/lsp"
 	lsp "github.com/hashicorp/terraform-ls/internal/protocol"
-	"github.com/hashicorp/terraform-ls/internal/terraform/ast"
 	"github.com/hashicorp/terraform-ls/internal/terraform/module"
 	op "github.com/hashicorp/terraform-ls/internal/terraform/module/operation"
 )
@@ -69,22 +67,6 @@ func (lh *logHandler) TextDocumentDidOpen(ctx context.Context, params lsp.DidOpe
 			return err
 		}
 	}
-
-	// TODO: move
-	notifier, err := lsctx.DiagnosticsNotifier(ctx)
-	if err != nil {
-		return err
-	}
-
-	diags := diagnostics.NewDiagnostics()
-	diags.EmptyRootDiagnostic()
-	diags.Append("HCL", mod.ModuleDiagnostics.AsMap())
-	diags.Append("HCL", mod.VarsDiagnostics.AutoloadedOnly().AsMap())
-	if vf, ok := ast.NewVarsFilename(f.Filename()); ok && !vf.IsAutoloaded() {
-		diags.Append("HCL", mod.VarsDiagnostics.ForFile(vf).AsMap())
-	}
-
-	notifier.PublishHCLDiags(ctx, mod.Path, diags)
 
 	return nil
 }

--- a/internal/langserver/handlers/did_open.go
+++ b/internal/langserver/handlers/did_open.go
@@ -48,11 +48,11 @@ func (lh *logHandler) TextDocumentDidOpen(ctx context.Context, params lsp.DidOpe
 	// We reparse because the file being opened may not match
 	// (originally parsed) content on the disk
 	// TODO: Do this only if we can verify the file differs?
-	modMgr.EnqueueModuleOpWait(mod.Path, op.OpTypeParseModuleConfiguration)
-	modMgr.EnqueueModuleOpWait(mod.Path, op.OpTypeParseVariables)
-	modMgr.EnqueueModuleOpWait(mod.Path, op.OpTypeLoadModuleMetadata)
-	modMgr.EnqueueModuleOpWait(mod.Path, op.OpTypeDecodeReferenceTargets)
-	modMgr.EnqueueModuleOpWait(mod.Path, op.OpTypeDecodeReferenceOrigins)
+	modMgr.EnqueueModuleOp(mod.Path, op.OpTypeParseModuleConfiguration, nil)
+	modMgr.EnqueueModuleOp(mod.Path, op.OpTypeParseVariables, nil)
+	modMgr.EnqueueModuleOp(mod.Path, op.OpTypeLoadModuleMetadata, nil)
+	modMgr.EnqueueModuleOp(mod.Path, op.OpTypeDecodeReferenceTargets, nil)
+	modMgr.EnqueueModuleOp(mod.Path, op.OpTypeDecodeReferenceOrigins, nil)
 
 	if mod.TerraformVersionState == op.OpStateUnknown {
 		modMgr.EnqueueModuleOp(mod.Path, op.OpTypeGetTerraformVersion, nil)
@@ -70,6 +70,7 @@ func (lh *logHandler) TextDocumentDidOpen(ctx context.Context, params lsp.DidOpe
 		}
 	}
 
+	// TODO: move
 	notifier, err := lsctx.DiagnosticsNotifier(ctx)
 	if err != nil {
 		return err

--- a/internal/langserver/handlers/initialize.go
+++ b/internal/langserver/handlers/initialize.go
@@ -70,9 +70,11 @@ func (svc *service) Initialize(ctx context.Context, params lsp.InitializeParams)
 
 	expClientCaps := lsp.ExperimentalClientCapabilities(clientCaps.Experimental)
 
+	svc.server = jrpc2.ServerFromContext(ctx)
+
 	if tv, ok := expClientCaps.TelemetryVersion(); ok {
 		svc.logger.Printf("enabling telemetry (version: %d)", tv)
-		err := svc.setupTelemetry(tv, jrpc2.ServerFromContext(ctx))
+		err := svc.setupTelemetry(tv, svc.server)
 		if err != nil {
 			svc.logger.Printf("failed to setup telemetry: %s", err)
 		}

--- a/internal/langserver/session/types.go
+++ b/internal/langserver/session/types.go
@@ -18,3 +18,12 @@ type ClientNotifier interface {
 }
 
 type SessionFactory func(context.Context) Session
+
+type ClientCaller interface {
+	Callback(ctx context.Context, method string, params interface{}) (*jrpc2.Response, error)
+}
+
+type Server interface {
+	ClientNotifier
+	ClientCaller
+}

--- a/internal/terraform/module/module_loader_test.go
+++ b/internal/terraform/module/module_loader_test.go
@@ -46,7 +46,7 @@ func TestModuleLoader_referenceCollection(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	<-modOp.doneCh
+	<-modOp.done()
 
 	manifestOp := NewModuleOperation(modPath, op.OpTypeLoadModuleMetadata)
 	err = ml.EnqueueModuleOp(manifestOp)
@@ -66,17 +66,12 @@ func TestModuleLoader_referenceCollection(t *testing.T) {
 	}
 
 	t.Log("waiting for all operations to finish")
-	for i := 0; i <= 2; i++ {
-		select {
-		case <-manifestOp.doneCh:
-			t.Log("manifest parsed")
-		case <-originsOp.doneCh:
-			t.Log("origins collected")
-		case <-targetsOp.doneCh:
-			t.Log("targets collected")
-		case <-ctx.Done():
-		}
-	}
+	<-manifestOp.done()
+	t.Log("manifest parsed")
+	<-originsOp.done()
+	t.Log("origins collected")
+	<-targetsOp.done()
+	t.Log("targets collected")
 
 	mod, err := ss.Modules.ModuleByPath(modPath)
 	if err != nil {

--- a/internal/terraform/module/module_manager.go
+++ b/internal/terraform/module/module_manager.go
@@ -86,7 +86,7 @@ func (mm *moduleManager) EnqueueModuleOp(modPath string, opType op.OpType, defer
 	modOp.Defer = deferFunc
 	mm.loader.EnqueueModuleOp(modOp)
 	if mm.syncLoading {
-		<-modOp.Done()
+		<-modOp.done()
 	}
 	return nil
 }

--- a/internal/terraform/module/module_manager.go
+++ b/internal/terraform/module/module_manager.go
@@ -81,15 +81,6 @@ func (mm *moduleManager) RemoveModule(modPath string) error {
 	return mm.moduleStore.Remove(modPath)
 }
 
-func (mm *moduleManager) EnqueueModuleOpWait(modPath string, opType op.OpType) error {
-	modOp := NewModuleOperation(modPath, opType)
-	mm.loader.EnqueueModuleOp(modOp)
-
-	<-modOp.Done()
-
-	return nil
-}
-
 func (mm *moduleManager) EnqueueModuleOp(modPath string, opType op.OpType, deferFunc DeferFunc) error {
 	modOp := NewModuleOperation(modPath, opType)
 	modOp.Defer = deferFunc

--- a/internal/terraform/module/module_ops.go
+++ b/internal/terraform/module/module_ops.go
@@ -39,9 +39,10 @@ func NewModuleOperation(modPath string, typ op.OpType) ModuleOperation {
 
 func (mo ModuleOperation) markAsDone() {
 	mo.doneCh <- struct{}{}
+	close(mo.doneCh)
 }
 
-func (mo ModuleOperation) Done() <-chan struct{} {
+func (mo ModuleOperation) done() <-chan struct{} {
 	return mo.doneCh
 }
 

--- a/internal/terraform/module/types.go
+++ b/internal/terraform/module/types.go
@@ -36,7 +36,6 @@ type ModuleManager interface {
 	AddModule(modPath string) (Module, error)
 	RemoveModule(modPath string) error
 	EnqueueModuleOp(modPath string, opType op.OpType, deferFunc DeferFunc) error
-	EnqueueModuleOpWait(modPath string, opType op.OpType) error
 	CancelLoading()
 }
 

--- a/internal/terraform/module/walker.go
+++ b/internal/terraform/module/walker.go
@@ -260,6 +260,11 @@ func (w *Walker) walk(ctx context.Context, rootPath string) error {
 				}
 			}
 
+			err = w.modMgr.EnqueueModuleOp(dir, op.OpTypeParseModuleConfiguration, nil)
+			if err != nil {
+				return err
+			}
+
 			err = w.modMgr.EnqueueModuleOp(dir, op.OpTypeGetTerraformVersion, nil)
 			if err != nil {
 				return err

--- a/internal/terraform/module/watcher.go
+++ b/internal/terraform/module/watcher.go
@@ -245,8 +245,7 @@ func decodeCalledModulesFunc(modMgr ModuleManager, w Watcher, modPath string) De
 			}
 			modMgr.AddModule(mc.Path)
 
-			modMgr.EnqueueModuleOpWait(mc.Path, op.OpTypeParseModuleConfiguration)
-
+			modMgr.EnqueueModuleOp(mc.Path, op.OpTypeParseModuleConfiguration, nil)
 			modMgr.EnqueueModuleOp(mc.Path, op.OpTypeParseVariables, nil)
 			modMgr.EnqueueModuleOp(mc.Path, op.OpTypeLoadModuleMetadata, nil)
 			modMgr.EnqueueModuleOp(mc.Path, op.OpTypeDecodeReferenceTargets, nil)


### PR DESCRIPTION
## Background

Originally we would only publish diagnostics directly from the relevant (RPC request) handlers, such as from `textDocument/didOpen`, `textDocument/didChange` or `textDocument/didClose`.

This in principle introduced the requirement on the task scheduler to support blocking/synchronous execution as we didn't want to be publishing stale diagnostics before the parsing and decoding is actually finished. However, this execution combined with the amount of operations we need to run in different contexts makes this a complex implementation hard to reason about and harder to maintain. Consequently there is at least one bug 🐛  where duplicate operations are attempted to be scheduled and one of them will remain blocking forever, effectively causing a deadlock 🙀 . This bug was first discovered in https://github.com/hashicorp/terraform-ls/pull/700 which adds more operations to ensure cross-module references are discovered and therefore makes the deadlock situation more likely to occur.

This PR therefore aims to remove the whole concept of blocking/sync execution and assume that all operations will be executed asynchronously.

## UX Implications

This comes with a (subtle?) UX difference where we would publish diagnostics for _all_ files as they are indexed (and changed), not just the ones which are open on the client. We could still provide the existing UX if we wanted to, but there's no clear benefit we'd gain by the additional complexity.

Also we now avoid publishing any diagnostics for non-autoloaded tfvars files, which more or less aligns the behaviour with gopls ' treatment of Go build tags. I will create a separate issue to track this problem.

See https://github.com/hashicorp/terraform-ls/issues/715

### LSP

There is currently no _clear_ guidance in LSP spec around whether servers should publish diagnostics for unopened files. The only [related part of the spec](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_publishDiagnostics) talks about clearing of diagnostics on close:

> Diagnostics are “owned” by the server so it is the server’s responsibility to clear them if necessary. The following rule is used for VS Code servers that generate diagnostics:
> 
>  - if a language is single file only (for example HTML) then diagnostics are cleared by the server when the file is closed. Please note that open / close events don’t necessarily reflect what the user sees in the user interface. These events are ownership events. So with the current version of the specification it is possible that problems are not cleared although the file is not visible in the user interface since the client has not closed the file yet.
>  - if a language has a project system (for example C#) diagnostics are not cleared when a file closes. When a project is opened all diagnostics for all files are recomputed (or read from a cache).
>  
> When a file changes it is the server’s responsibility to re-compute diagnostics and push them to the client. If the computed set is empty it has to push the empty array to clear former diagnostics. Newly pushed diagnostics always replace previously pushed diagnostics. There is no merging that happens on the client side.

### Language Clients & gopls

Although LSP doesn't provide clear guidance, it is clear that sending diagnostics for unopened files is a common practice in gopls. Clients account for this possibility differently, probably catering different user bases with different expectations:

 - Sublime Text LSP will hide any diagnostics which are not for unopened files
 - VS Code will display all diagnostics

## Future TODOs

### Versioned diagnostics

LSP allows us to send diagnostics with document versions, which presumably aids the client as it can just drop the ones which are associated with an old version of the document and effectively prevent ever publishing a stale diagnostic.

Attaching the document version at this point would not be trivial as we'd probably need to start tracking document versions in memdb alongside diagnostics. This PR therefore does increase the likelihood of us publishing outdated diagnostics, but they would always get updated/cleared as part of another module change hook execution anyway, so it's rather a "temporary blip".

See https://github.com/hashicorp/terraform-ls/issues/716

### Only publishing changed diagnostics

In an ideal scenario we would only publish diagnostics when there are _different_ ones to publish and avoid publishing the same ones multiple times. In order to achieve this however we would need to check whether all diagnostics are equal. Currently we use the upstream [`hcl.Diagnostic`](https://pkg.go.dev/github.com/hashicorp/hcl/v2@v2.10.1#Diagnostic) to represent a diagnostic and the upstream implementation does not have an equality function itself. We could implement all this relatively easily downstream, but we can't actually take advantage of it until we figure out a better way of publishing and clearing `validate` diagnostics, which currently get just cleared whenever other diagnostics are published, to avoid stale diagnostics.

See https://github.com/hashicorp/terraform-ls/issues/717