### PR TITLE
Switch to hc-install from tfinstall

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.2
 	github.com/hashicorp/go-version v1.4.0
+	github.com/hashicorp/hc-install v0.3.1
 	github.com/hashicorp/hcl-lang v0.0.0-20211123142056-191cd51dec5b
 	github.com/hashicorp/hcl/v2 v2.11.1
 	github.com/hashicorp/terraform-exec v0.15.0

--- a/go.sum
+++ b/go.sum
@@ -265,6 +265,8 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
+github.com/hashicorp/hc-install v0.3.1 h1:VIjllE6KyAI1A244G8kTaHXy+TL5/XYzvrtFi8po/Yk=
+github.com/hashicorp/hc-install v0.3.1/go.mod h1:3LCdWcCDS1gaHC9mhHCGbkYfoY6vdsKohGjugbZdZak=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/hcl-lang v0.0.0-20211118124824-da3a292c5d7a/go.mod h1:0W3+VP07azoS+fCX5hWk1KxwHnqf1s9J7oBg2cFXm1c=
@@ -498,6 +500,7 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
+golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20211108221036-ceb1ce70b4fa h1:idItI2DDfCokpg0N51B2VtiLdJ4vAuXC9fnCb2gACo4=
 golang.org/x/crypto v0.0.0-20211108221036-ceb1ce70b4fa/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=

--- a/internal/langserver/handlers/complete_test.go
+++ b/internal/langserver/handlers/complete_test.go
@@ -851,7 +851,9 @@ output "test" {
 func tfExecutor(t *testing.T, workdir, tfVersion string) exec.TerraformExecutor {
 	ctx := context.Background()
 	installDir := filepath.Join(workdir, "hcinstall")
-	err := os.MkdirAll(installDir, 0o755)
+	if err := os.MkdirAll(installDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
 
 	i := hcinstall.NewInstaller()
 	v := version.Must(version.NewVersion(tfVersion))

--- a/internal/langserver/handlers/complete_test.go
+++ b/internal/langserver/handlers/complete_test.go
@@ -10,7 +10,11 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-exec/tfinstall"
+	hcinstall "github.com/hashicorp/hc-install"
+	"github.com/hashicorp/hc-install/fs"
+	"github.com/hashicorp/hc-install/product"
+	"github.com/hashicorp/hc-install/releases"
+	"github.com/hashicorp/hc-install/src"
 	tfjson "github.com/hashicorp/terraform-json"
 	"github.com/hashicorp/terraform-ls/internal/langserver"
 	"github.com/hashicorp/terraform-ls/internal/langserver/session"
@@ -603,7 +607,7 @@ func TestVarsCompletion_withValidData(t *testing.T) {
 						"detail": "required, string",
 						"insertTextFormat":1,
 						"textEdit": {
-							"range": {"start":{"line":0,"character":0}, "end":{"line":0,"character":0}}, 
+							"range": {"start":{"line":0,"character":0}, "end":{"line":0,"character":0}},
 							"newText":"test"
 						}
 					}
@@ -844,14 +848,25 @@ output "test" {
 		}`)
 }
 
-func tfExecutor(t *testing.T, workdir, version string) exec.TerraformExecutor {
+func tfExecutor(t *testing.T, workdir, tfVersion string) exec.TerraformExecutor {
 	ctx := context.Background()
-	installPath := filepath.Join(t.TempDir(), "tfinstall")
-	err := os.MkdirAll(installPath, 0o755)
-	if err != nil {
-		t.Fatal(err)
-	}
-	execPath, err := tfinstall.Find(ctx, tfinstall.ExactVersion(version, installPath))
+	installDir := filepath.Join(workdir, "hcinstall")
+	err := os.MkdirAll(installDir, 0o755)
+
+	i := hcinstall.NewInstaller()
+	v := version.Must(version.NewVersion(tfVersion))
+
+	execPath, err := i.Ensure(ctx, []src.Source{
+		&fs.ExactVersion{
+			Product: product.Terraform,
+			Version: v,
+		},
+		&releases.ExactVersion{
+			Product:    product.Terraform,
+			Version:    v,
+			InstallDir: installDir,
+		},
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/langserver/handlers/complete_test.go
+++ b/internal/langserver/handlers/complete_test.go
@@ -854,6 +854,11 @@ func tfExecutor(t *testing.T, workdir, tfVersion string) exec.TerraformExecutor 
 	if err := os.MkdirAll(installDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
+	t.Cleanup(func() {
+		if err := os.Remove(installDir); err != nil {
+			t.Fatal(err)
+		}
+	})
 
 	i := hcinstall.NewInstaller()
 	v := version.Must(version.NewVersion(tfVersion))
@@ -872,6 +877,12 @@ func tfExecutor(t *testing.T, workdir, tfVersion string) exec.TerraformExecutor 
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	t.Cleanup(func() {
+		if err := i.Remove(ctx); err != nil {
+			t.Fatal(err)
+		}
+	})
 
 	tfExec, err := exec.NewExecutor(workdir, execPath)
 	if err != nil {

--- a/internal/langserver/handlers/complete_test.go
+++ b/internal/langserver/handlers/complete_test.go
@@ -850,7 +850,7 @@ output "test" {
 
 func tfExecutor(t *testing.T, workdir, tfVersion string) exec.TerraformExecutor {
 	ctx := context.Background()
-	installDir := filepath.Join(workdir, "hcinstall")
+	installDir := filepath.Join(t.TempDir(), "hcinstall")
 	if err := os.MkdirAll(installDir, 0o755); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/schemas/gen/gen.go
+++ b/internal/schemas/gen/gen.go
@@ -15,8 +15,12 @@ import (
 	"path/filepath"
 
 	"github.com/hashicorp/go-version"
+	hcinstall "github.com/hashicorp/hc-install"
+	"github.com/hashicorp/hc-install/fs"
+	"github.com/hashicorp/hc-install/product"
+	"github.com/hashicorp/hc-install/releases"
+	"github.com/hashicorp/hc-install/src"
 	"github.com/hashicorp/terraform-exec/tfexec"
-	"github.com/hashicorp/terraform-exec/tfinstall"
 	"github.com/hashicorp/terraform-ls/internal/schemas"
 	"github.com/shurcooL/vfsgen"
 )
@@ -82,13 +86,22 @@ func gen() error {
 
 	log.Println("ensuring terraform is installed")
 
-	tmpDir, err := ioutil.TempDir("", "tfinstall")
+	installDir, err := ioutil.TempDir("", "hcinstall")
 	if err != nil {
 		return err
 	}
-	defer os.RemoveAll(tmpDir)
+	defer os.RemoveAll(installDir)
 
-	execPath, err := tfinstall.Find(ctx, tfinstall.LookPath(), tfinstall.LatestVersion(tmpDir, false))
+	i := hcinstall.NewInstaller()
+	execPath, err := i.Ensure(ctx, []src.Source{
+		&fs.AnyVersion{
+			Product: &product.Terraform,
+		},
+		&releases.LatestVersion{
+			Product:    product.Terraform,
+			InstallDir: installDir,
+		},
+	})
 	if err != nil {
 		return err
 	}

--- a/internal/schemas/gen/gen.go
+++ b/internal/schemas/gen/gen.go
@@ -106,6 +106,8 @@ func gen() error {
 		return err
 	}
 
+	defer i.Remove(ctx)
+
 	log.Println("running terraform init")
 
 	cwd, err := os.Getwd()

--- a/internal/terraform/exec/exec_test.go
+++ b/internal/terraform/exec/exec_test.go
@@ -8,9 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/go-version"
 	hcinstall "github.com/hashicorp/hc-install"
-	"github.com/hashicorp/hc-install/fs"
 	"github.com/hashicorp/hc-install/product"
 	"github.com/hashicorp/hc-install/releases"
 	"github.com/hashicorp/hc-install/src"
@@ -22,7 +20,7 @@ func TestExec_timeout(t *testing.T) {
 	// See https://github.com/hashicorp/terraform-exec/issues/129
 	t.Skip("upstream implementation prone to race conditions")
 
-	e := newExecutor(t, "1.1.0")
+	e := newExecutor(t)
 	timeout := 1 * time.Millisecond
 	e.SetTimeout(timeout)
 
@@ -42,7 +40,7 @@ func TestExec_timeout(t *testing.T) {
 }
 
 func TestExec_cancel(t *testing.T) {
-	e := newExecutor(t, "1.1.0")
+	e := newExecutor(t)
 
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	cancelFunc()
@@ -62,7 +60,7 @@ func TestExec_cancel(t *testing.T) {
 	t.Fatalf("expected cancel error: %#v, given: %#v", expectedErr, err)
 }
 
-func newExecutor(t *testing.T, tfVersion string) TerraformExecutor {
+func newExecutor(t *testing.T) TerraformExecutor {
 	ctx := context.Background()
 	workDir := TempDir(t)
 	installDir := filepath.Join(workDir, "hcinstall")
@@ -72,16 +70,10 @@ func newExecutor(t *testing.T, tfVersion string) TerraformExecutor {
 	}
 
 	i := hcinstall.NewInstaller()
-	v := version.Must(version.NewVersion(tfVersion))
 
 	execPath, err := i.Ensure(ctx, []src.Source{
-		&fs.ExactVersion{
-			Product: product.Terraform,
-			Version: v,
-		},
-		&releases.ExactVersion{
+		&releases.LatestVersion{
 			Product:    product.Terraform,
-			Version:    v,
 			InstallDir: installDir,
 		},
 	})

--- a/internal/terraform/exec/exec_test.go
+++ b/internal/terraform/exec/exec_test.go
@@ -64,10 +64,14 @@ func newExecutor(t *testing.T) TerraformExecutor {
 	ctx := context.Background()
 	workDir := TempDir(t)
 	installDir := filepath.Join(workDir, "hcinstall")
-	err := os.MkdirAll(installDir, 0755)
-	if err != nil {
+	if err := os.MkdirAll(installDir, 0755); err != nil {
 		t.Fatal(err)
 	}
+	t.Cleanup(func() {
+		if err := os.Remove(installDir); err != nil {
+			t.Fatal(err)
+		}
+	})
 
 	i := hcinstall.NewInstaller()
 
@@ -80,6 +84,12 @@ func newExecutor(t *testing.T) TerraformExecutor {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	t.Cleanup(func() {
+		if err := i.Remove(ctx); err != nil {
+			t.Fatal(err)
+		}
+	})
 
 	e, err := NewExecutor(workDir, execPath)
 	if err != nil {


### PR DESCRIPTION
Closes #711

---

- replaced all `tfinstall` usage with `hc-install` which first looks for tf in filesystem and if didn't find, installs specified/latest version
- in `exec` moved tf version into function arguments