### PR TITLE
Plumb a context in to the server.Loop call.

### DIFF
--- a/internal/langserver/langserver.go
+++ b/internal/langserver/langserver.go
@@ -125,7 +125,7 @@ func (ls *langServer) StartTCP(address string) error {
 
 	go func() {
 		ls.logger.Println("Starting loop server ...")
-		err = server.Loop(accepter, ls.newService, &server.LoopOptions{
+		err = server.Loop(context.TODO(), accepter, ls.newService, &server.LoopOptions{
 			ServerOptions: ls.srvOptions,
 		})
 		if err != nil {


### PR DESCRIPTION
A simple fix for the breaking change in the v0.34 release.