### PR TITLE
fix: Catch OS agnostic interrupt signal

### DIFF
--- a/internal/cmd/inspect_module_command.go
+++ b/internal/cmd/inspect_module_command.go
@@ -98,7 +98,7 @@ func (c *InspectModuleCommand) inspect(rootPath string) error {
 	walker.SetLogger(c.logger)
 
 	ctx, cancel := ictx.WithSignalCancel(context.Background(),
-		c.logger, syscall.SIGINT, syscall.SIGTERM)
+		c.logger, os.Interrupt, syscall.SIGTERM)
 	defer cancel()
 
 	walker.EnqueuePath(rootPath)

--- a/internal/cmd/serve_command.go
+++ b/internal/cmd/serve_command.go
@@ -96,7 +96,7 @@ func (c *ServeCommand) Run(args []string) int {
 	}
 
 	ctx, cancelFunc := lsctx.WithSignalCancel(context.Background(), logger,
-		syscall.SIGINT, syscall.SIGTERM)
+		os.Interrupt, syscall.SIGTERM)
 	defer cancelFunc()
 
 	// Setting this option as a CLI flag is deprecated


### PR DESCRIPTION
While debugging https://github.com/hashicorp/terraform-ls/issues/733 Windows users have reported that CPU profile never gets written in their environment.

This is because CPU profile only gets written upon (graceful) shutdown which we perform by catching particular interrupt/termination signals. Prior to this patch however we were only catching Unix-native signals, which Windows never sends, resulting in dirty shutdowns and never giving the opportunity for a CPU profile to be written to disk.

See also: https://pkg.go.dev/os/signal#hdr-Windows and https://stackoverflow.com/a/35683558