### PR TITLE
fix: avoid sending empty diagnostics

### DIFF
--- a/internal/langserver/handlers/hooks_module.go
+++ b/internal/langserver/handlers/hooks_module.go
@@ -96,23 +96,22 @@ func sendModuleTelemetry(ctx context.Context, store *state.StateStore, telemetry
 
 func updateDiagnostics(ctx context.Context, notifier *diagnostics.Notifier) state.ModuleChangeHook {
 	return func(oldMod, newMod *state.Module) {
-		// TODO: check if diagnostics have actually changed
 		oldDiags, newDiags := 0, 0
 		if oldMod != nil {
-			oldDiags = len(oldMod.ModuleDiagnostics) + len(oldMod.VarsDiagnostics)
+			oldDiags = oldMod.ModuleDiagnostics.Count() + oldMod.VarsDiagnostics.Count()
 		}
 		if newMod != nil {
-			newDiags = len(newMod.ModuleDiagnostics) + len(newMod.VarsDiagnostics)
+			newDiags = newMod.ModuleDiagnostics.Count() + newMod.VarsDiagnostics.Count()
+		}
+
+		if oldDiags == 0 && newDiags == 0 {
+			return
 		}
 
 		diags := diagnostics.NewDiagnostics()
 		diags.EmptyRootDiagnostic()
 
 		defer notifier.PublishHCLDiags(ctx, newMod.Path, diags)
-
-		if oldDiags == 0 && newDiags == 0 {
-			return
-		}
 
 		if newMod != nil {
 			diags.Append("HCL", newMod.ModuleDiagnostics.AsMap())

--- a/internal/terraform/ast/module.go
+++ b/internal/terraform/ast/module.go
@@ -57,3 +57,11 @@ func (md ModDiags) AsMap() map[string]hcl.Diagnostics {
 	}
 	return m
 }
+
+func (md ModDiags) Count() int {
+	count := 0
+	for _, diags := range md {
+		count += len(diags)
+	}
+	return count
+}

--- a/internal/terraform/ast/variables.go
+++ b/internal/terraform/ast/variables.go
@@ -84,3 +84,11 @@ func (vd VarsDiags) AsMap() map[string]hcl.Diagnostics {
 	}
 	return m
 }
+
+func (vd VarsDiags) Count() int {
+	count := 0
+	for _, diags := range vd {
+		count += len(diags)
+	}
+	return count
+}


### PR DESCRIPTION
Previously we were checking length of a map where the key is a filename, which means we'd more often send `[]` (empty array) diagnostics when nothing has changed.

This removes the unnecessary diagnostics notifications.
