### PR TITLE
telemetry: Only send requests if data has changed

### DIFF
--- a/internal/state/installed_providers.go
+++ b/internal/state/installed_providers.go
@@ -1,0 +1,26 @@
+package state
+
+import (
+	"github.com/hashicorp/go-version"
+	tfaddr "github.com/hashicorp/terraform-registry-address"
+)
+
+type InstalledProviders map[tfaddr.Provider]*version.Version
+
+func (ip InstalledProviders) Equals(p InstalledProviders) bool {
+	if len(ip) != len(p) {
+		return false
+	}
+
+	for pAddr, ver := range ip {
+		c, ok := p[pAddr]
+		if !ok {
+			return false
+		}
+		if !ver.Equal(c) {
+			return false
+		}
+	}
+
+	return true
+}

--- a/internal/state/installed_providers_test.go
+++ b/internal/state/installed_providers_test.go
@@ -1,0 +1,80 @@
+package state
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-version"
+	tfaddr "github.com/hashicorp/terraform-registry-address"
+)
+
+func TestInstalledProviders(t *testing.T) {
+	testCases := []struct {
+		first, second InstalledProviders
+		expectEqual   bool
+	}{
+		{
+			InstalledProviders{},
+			InstalledProviders{},
+			true,
+		},
+		{
+			InstalledProviders{
+				tfaddr.NewBuiltInProvider("terraform"): version.Must(version.NewVersion("1.0")),
+			},
+			InstalledProviders{
+				tfaddr.NewBuiltInProvider("terraform"): version.Must(version.NewVersion("1.0")),
+			},
+			true,
+		},
+		{
+			InstalledProviders{
+				tfaddr.NewDefaultProvider("foo"): version.Must(version.NewVersion("1.0")),
+			},
+			InstalledProviders{
+				tfaddr.NewDefaultProvider("bar"): version.Must(version.NewVersion("1.0")),
+			},
+			false,
+		},
+		{
+			InstalledProviders{
+				tfaddr.NewDefaultProvider("foo"): version.Must(version.NewVersion("1.0")),
+			},
+			InstalledProviders{
+				tfaddr.NewDefaultProvider("foo"): version.Must(version.NewVersion("1.1")),
+			},
+			false,
+		},
+		{
+			InstalledProviders{
+				tfaddr.NewDefaultProvider("foo"): version.Must(version.NewVersion("1.0")),
+				tfaddr.NewDefaultProvider("bar"): version.Must(version.NewVersion("1.0")),
+			},
+			InstalledProviders{
+				tfaddr.NewDefaultProvider("foo"): version.Must(version.NewVersion("1.0")),
+			},
+			false,
+		},
+		{
+			InstalledProviders{
+				tfaddr.NewDefaultProvider("foo"): version.Must(version.NewVersion("1.0")),
+			},
+			InstalledProviders{
+				tfaddr.NewDefaultProvider("foo"): version.Must(version.NewVersion("1.0")),
+				tfaddr.NewDefaultProvider("bar"): version.Must(version.NewVersion("1.0")),
+			},
+			false,
+		},
+	}
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			equals := tc.first.Equals(tc.second)
+			if tc.expectEqual != equals {
+				if tc.expectEqual {
+					t.Fatalf("expected requirements to be equal\nfirst: %#v\nsecond: %#v", tc.first, tc.second)
+				}
+				t.Fatalf("expected requirements to mismatch\nfirst: %#v\nsecond: %#v", tc.first, tc.second)
+			}
+		})
+	}
+}

--- a/internal/state/module.go
+++ b/internal/state/module.go
@@ -19,7 +19,7 @@ type ModuleMetadata struct {
 	CoreRequirements     version.Constraints
 	Backend              *tfmod.Backend
 	ProviderReferences   map[tfmod.ProviderRef]tfaddr.Provider
-	ProviderRequirements map[tfaddr.Provider]version.Constraints
+	ProviderRequirements tfmod.ProviderRequirements
 	Variables            map[string]tfmod.Variable
 	Outputs              map[string]tfmod.Output
 }
@@ -45,7 +45,7 @@ func (mm ModuleMetadata) Copy() ModuleMetadata {
 	}
 
 	if mm.ProviderRequirements != nil {
-		newMm.ProviderRequirements = make(map[tfaddr.Provider]version.Constraints, len(mm.ProviderRequirements))
+		newMm.ProviderRequirements = make(tfmod.ProviderRequirements, len(mm.ProviderRequirements))
 		for provider, vc := range mm.ProviderRequirements {
 			// version.Constraints is never mutated in this context
 			newMm.ProviderRequirements[provider] = vc
@@ -80,7 +80,7 @@ type Module struct {
 	TerraformVersionErr   error
 	TerraformVersionState op.OpState
 
-	InstalledProviders map[tfaddr.Provider]*version.Version
+	InstalledProviders InstalledProviders
 
 	ProviderSchemaErr   error
 	ProviderSchemaState op.OpState
@@ -146,7 +146,7 @@ func (m *Module) Copy() *Module {
 	}
 
 	if m.InstalledProviders != nil {
-		newMod.InstalledProviders = make(map[tfaddr.Provider]*version.Version, 0)
+		newMod.InstalledProviders = make(InstalledProviders, 0)
 		for addr, pv := range m.InstalledProviders {
 			// version.Version is practically immutable once parsed
 			newMod.InstalledProviders[addr] = pv


### PR DESCRIPTION
Depends on https://github.com/hashicorp/terraform-schema/pull/89
Depends on https://github.com/hashicorp/terraform-ls/pull/761

According to manual testing with a single installed module from https://registry.terraform.io/modules/terraform-aws-modules/eks/aws/latest this can reduce the amount of telemetry requests to about half (from 32 to 14).

There's probably more we can do here - e.g. avoid sending telemetry for unsaved data. This is not only extra overhead, but also pollutes the data with "unfinished" provider or backend names. However this would require more effort - probably queueing the telemetry data somewhere and then adding a hook which gets triggered by `textDocument/didSave`. Either way not something I wanted to tackle in this PR.