### PR TITLE
schemas: Ignore HewlettPackard/hpegl

### DIFF
--- a/internal/schemas/gen/gen.go
+++ b/internal/schemas/gen/gen.go
@@ -232,6 +232,7 @@ func listProviders(tier string) ([]provider, error) {
 var ignore = map[string]bool{
 	"a10networks/vthunder":    true,
 	"HewlettPackard/oneview":  true,
+	"HewlettPackard/hpegl":    true,
 	"ThalesGroup/ciphertrust": true,
 	"nullstone-io/ns":         true,
 }


### PR DESCRIPTION
This is to address the fact that the provider doesn't have any release other than pre-release, which makes it impossible to install without explicit version (which is how we install it internally).

```
Error: Failed to query available provider packages

Could not retrieve the list of available versions for provider
hewlettpackard/hpegl: no available releases match the given constraints 
```

Related: https://github.com/hashicorp/terraform/issues/30337