### PR TITLE
deps: Update hashicorp/terraform-schema to latest rev

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/hashicorp/terraform-exec v0.15.0
 	github.com/hashicorp/terraform-json v0.13.0
 	github.com/hashicorp/terraform-registry-address v0.0.0-20210816115301-cb2034eba045
-	github.com/hashicorp/terraform-schema v0.0.0-20211118125251-a89436f69539
+	github.com/hashicorp/terraform-schema v0.0.0-20220111104703-762daa2d811e
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mh-cbon/go-fmt-fail v0.0.0-20160815164508-67765b3fbcb5
 	github.com/mitchellh/cli v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -284,8 +284,8 @@ github.com/hashicorp/terraform-json v0.13.0/go.mod h1:y5OdLBCT+rxbwnpxZs9kGL7R9E
 github.com/hashicorp/terraform-registry-address v0.0.0-20210412075316-9b2996cce896/go.mod h1:bzBPnUIkI0RxauU8Dqo+2KrZZ28Cf48s8V6IHt3p4co=
 github.com/hashicorp/terraform-registry-address v0.0.0-20210816115301-cb2034eba045 h1:R/I8ofvXuPcTNoc//N4ruvaHGZcShI/VuU2iXo875Lo=
 github.com/hashicorp/terraform-registry-address v0.0.0-20210816115301-cb2034eba045/go.mod h1:anRyJbe12BZscpFgaeGu9gH12qfdBP094LYFtuAFzd4=
-github.com/hashicorp/terraform-schema v0.0.0-20211118125251-a89436f69539 h1:cKcbX33DsyhYo6niqnNuJxU/rj+U3ix/g+T6HevO3C8=
-github.com/hashicorp/terraform-schema v0.0.0-20211118125251-a89436f69539/go.mod h1:8AxXLNebdxejfusRC5/sYkL7bx4ZpY1ZUjLOXMix3TM=
+github.com/hashicorp/terraform-schema v0.0.0-20220111104703-762daa2d811e h1:QhxYlrs7MR0bpJmOG7FVLb76RqDk9Pk5EdfoQHvEP8E=
+github.com/hashicorp/terraform-schema v0.0.0-20220111104703-762daa2d811e/go.mod h1:Dzo2jIy24WA3uSGHcp13kPxy3mF5yZEgIjDK43pq5QM=
 github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734 h1:HKLsbzeOsfXmKNpr3GiT18XAblV0BjCbzL8KQAMZGa0=
 github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734/go.mod h1:kNDNcF7sN4DocDLBkQYz73HGKwN1ANB1blq4lIYLYvg=
 github.com/huandu/xstrings v1.3.2 h1:L18LIDzqlW6xN2rEkpdV8+oL/IXWJ1APd+vsdYy4Wdw=

--- a/internal/decoder/decoder.go
+++ b/internal/decoder/decoder.go
@@ -54,7 +54,7 @@ func modulePathContext(mod *state.Module, schemaReader state.SchemaReader, modRe
 }
 
 func varsPathContext(mod *state.Module) (*decoder.PathContext, error) {
-	schema, err := tfschema.SchemaForVariables(mod.Meta.Variables)
+	schema, err := tfschema.SchemaForVariables(mod.Meta.Variables, mod.Path)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This is mainly to unblock https://github.com/hashicorp/terraform-ls/pull/758 without having to merge https://github.com/hashicorp/terraform-ls/pull/727 yet.

Upstream changes were introduced in https://github.com/hashicorp/terraform-schema/pull/84