### PR TITLE
schemas: Ignore zededa/zedcloud

### DIFF
--- a/internal/schemas/gen/gen.go
+++ b/internal/schemas/gen/gen.go
@@ -250,6 +250,7 @@ var ignore = map[string]bool{
 	"HewlettPackard/hpegl":    true,
 	"ThalesGroup/ciphertrust": true,
 	"nullstone-io/ns":         true,
+	"zededa/zedcloud":         true,
 }
 
 func filter(providers []provider) (filtered []provider) {


### PR DESCRIPTION
This is to address the fact that the provider doesn't have any release other than pre-release, which makes it impossible to install without explicit version (which is how we install it internally).