### PR TITLE
Sign releases using signore

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,9 @@ jobs:
           role-skip-session-tagging: true
           role-duration-seconds: 3600
       -
+        name: Install signore
+        uses: hashicorp/setup-signore-package@v1
+      -
         name: Release
         uses: goreleaser/goreleaser-action@v2
         with:
@@ -78,6 +81,9 @@ jobs:
           ARTIFACTORY_TOKEN: ${{ secrets.ARTIFACTORY_TOKEN }}
           ARTIFACTORY_USER: ${{ secrets.ARTIFACTORY_USER }}
           CIRCLE_TOKEN: ${{ secrets.CIRCLE_TOKEN }}
+          SIGNORE_CLIENT_ID: ${{ secrets.SIGNORE_CLIENT_ID }}
+          SIGNORE_CLIENT_SECRET: ${{ secrets.SIGNORE_CLIENT_SECRET }}
+          SIGNORE_SIGNER: ${{ secrets.SIGNORE_SIGNER }}
       -
         name: Publish released artifacts
         run: hc-releases publish -product=terraform-ls

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,9 +52,6 @@ jobs:
         with:
           github-token: ${{ secrets.CODESIGN_GITHUB_TOKEN }}
       -
-        name: Import key for archive signing
-        run: echo -e "${{ secrets.GPG_PRIVATE_KEY_DECRYPTED }}" | gpg --import --batch --no-tty
-      - 
         name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,9 @@ jobs:
         env:
           VERSION: v0
       -
+        name: Install signore
+        uses: hashicorp/setup-signore-package@v1
+      -
         uses: hashicorp/setup-hc-releases@v1
         with:
           github-token: ${{ secrets.CODESIGN_GITHUB_TOKEN }}
@@ -61,9 +64,6 @@ jobs:
           role-to-assume: ${{ secrets.TERRAFORM_PROD_AWS_ROLE_TO_ASSUME }}
           role-skip-session-tagging: true
           role-duration-seconds: 3600
-      -
-        name: Install signore
-        uses: hashicorp/setup-signore-package@v1
       -
         name: Release
         uses: goreleaser/goreleaser-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,6 @@ jobs:
           version: latest
           args: release
         env:
-          GPG_KEY_ID: ${{ secrets.GPG_PUBLIC_KEY_ID }}
           CODESIGN_IMAGE: ${{ steps.codesign.outputs.image }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -76,7 +76,8 @@ checksum:
 signs:
   -
     id: with_key_id
-    signature: "${artifact}.{{ .Env.GPG_KEY_ID }}.sig"
+    # TODO: Replace with variable once signore provides the primary_key_id
+    signature: "${artifact}.72D7468F.sig"
     cmd: signore
     args: ["sign", "--dearmor", "--file", "${artifact}", "--out", "${signature}"]
     artifacts: checksum

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -76,8 +76,7 @@ checksum:
 signs:
   -
     id: with_key_id
-    # TODO: Replace with variable once goreleaser supports variables here
-    signature: "${artifact}.72D7468F.sig"
+    signature: "${artifact}.{{ .Env.GPG_KEY_ID }}.sig"
     cmd: signore
     args: ["sign", "--dearmor", "--file", "${artifact}", "--out", "${signature}"]
     artifacts: checksum

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -78,12 +78,14 @@ signs:
     id: with_key_id
     # TODO: Replace with variable once goreleaser supports variables here
     signature: "${artifact}.72D7468F.sig"
-    args: ["--batch", "--no-tty", "-u", "{{ .Env.GPG_KEY_ID }}", "--output", "${artifact}.{{ .Env.GPG_KEY_ID }}.sig", "--detach-sign", "${artifact}"]
+    cmd: signore
+    args: ["sign", "--dearmor", "--file", "${artifact}", "--out", "${signature}"]
     artifacts: checksum
   -
     id: default
     signature: "${artifact}.sig"
-    args: ["--batch", "--no-tty", "-u", "{{ .Env.GPG_KEY_ID }}", "--output", "${artifact}.sig", "--detach-sign", "${artifact}"]
+    cmd: signore
+    args: ["sign", "--dearmor", "--file", "${artifact}", "--out", "${signature}"]
     artifacts: checksum
 
 brews:


### PR DESCRIPTION
This PR updates the release signing to use the internal HashiCorp signing service (signore).

Closes #688.

Update secrets before merging:
- [x] add `SIGNORE_CLIENT_ID`
- [x] add `SIGNORE_CLIENT_SECRET`
- [x] add `SIGNORE_SIGNER`