### PR TITLE
schemas: Ignore jradtilbrook/buildkite

### DIFF
--- a/internal/schemas/gen/gen.go
+++ b/internal/schemas/gen/gen.go
@@ -248,6 +248,7 @@ var ignore = map[string]bool{
 	"a10networks/vthunder":    true,
 	"HewlettPackard/oneview":  true,
 	"HewlettPackard/hpegl":    true,
+	"jradtilbrook/buildkite":  true,
 	"ThalesGroup/ciphertrust": true,
 	"nullstone-io/ns":         true,
 	"zededa/zedcloud":         true,


### PR DESCRIPTION
This is to address

```
Error: Incompatible provider version

Provider registry.terraform.io/jradtilbrook/buildkite v0.6.0 does not have a
package available for your current platform, linux_amd64.

Provider releases are separate from Terraform CLI releases, so not all
providers are available for all platforms. Other versions of this provider
may have different platforms supported.
```

https://github.com/hashicorp/terraform-ls/runs/5122097433?check_suite_focus=true#step:6:68