### PR TITLE
Add String() for `OpTypeDecodeVarsReferences`

### DIFF
--- a/internal/terraform/module/operation/op_type_string.go
+++ b/internal/terraform/module/operation/op_type_string.go
@@ -17,11 +17,12 @@ func _() {
 	_ = x[OpTypeLoadModuleMetadata-6]
 	_ = x[OpTypeDecodeReferenceTargets-7]
 	_ = x[OpTypeDecodeReferenceOrigins-8]
+	_ = x[OpTypeDecodeVarsReferences-9]
 }
 
-const _OpType_name = "OpTypeUnknownOpTypeGetTerraformVersionOpTypeObtainSchemaOpTypeParseModuleConfigurationOpTypeParseVariablesOpTypeParseModuleManifestOpTypeLoadModuleMetadataOpTypeDecodeReferenceTargetsOpTypeDecodeReferenceOrigins"
+const _OpType_name = "OpTypeUnknownOpTypeGetTerraformVersionOpTypeObtainSchemaOpTypeParseModuleConfigurationOpTypeParseVariablesOpTypeParseModuleManifestOpTypeLoadModuleMetadataOpTypeDecodeReferenceTargetsOpTypeDecodeReferenceOriginsOpTypeDecodeVarsReferences"
 
-var _OpType_index = [...]uint8{0, 13, 38, 56, 86, 106, 131, 155, 183, 211}
+var _OpType_index = [...]uint8{0, 13, 38, 56, 86, 106, 131, 155, 183, 211, 237}
 
 func (i OpType) String() string {
 	if i >= OpType(len(_OpType_index)-1) {

--- a/internal/terraform/module/operation/operation.go
+++ b/internal/terraform/module/operation/operation.go
@@ -1,6 +1,6 @@
 package operation
 
-//go:generate stringer -type=OpState -output=op_state_string.go
+//go:generate go run golang.org/x/tools/cmd/stringer -type=OpState -output=op_state_string.go
 type OpState uint
 
 const (
@@ -10,7 +10,7 @@ const (
 	OpStateLoaded
 )
 
-//go:generate stringer -type=OpType -output=op_type_string.go
+//go:generate go run golang.org/x/tools/cmd/stringer -type=OpType -output=op_type_string.go
 type OpType uint
 
 const (


### PR DESCRIPTION
This is mostly for convenience in debug messages, which otherwise come through as not-very-descriptive `OpType(9)`.