### PR TITLE
schemas: exclude kvrhdn/honeycombio

### DIFF
--- a/internal/schemas/gen/gen.go
+++ b/internal/schemas/gen/gen.go
@@ -249,6 +249,7 @@ var ignore = map[string]bool{
 	"HewlettPackard/oneview":  true,
 	"HewlettPackard/hpegl":    true,
 	"jradtilbrook/buildkite":  true,
+	"kvrhdn/honeycombio":      true,
 	"ThalesGroup/ciphertrust": true,
 	"nullstone-io/ns":         true,
 	"zededa/zedcloud":         true,


### PR DESCRIPTION
This is to address the following

```
Error: Incompatible provider version

Provider registry.terraform.io/kvrhdn/honeycombio v0.3.0 does not have a
package available for your current platform, linux_amd64.

Provider releases are separate from Terraform CLI releases, so not all
providers are available for all platforms. Other versions of this provider
may have different platforms supported.
```

https://github.com/hashicorp/terraform-ls/runs/5245400640?check_suite_focus=true#step:6:67