### PR TITLE
goreleaser: Enable pre-release publishing

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -94,6 +94,7 @@ brews:
       owner: hashicorp
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    skip_upload: auto
     url_template: "https://releases.hashicorp.com/terraform-ls/{{ .Version }}/{{ .ArtifactName }}"
     commit_author:
       name: hc-espd-packager
@@ -123,6 +124,9 @@ publishers:
 milestones:
   - name_template: "{{ .Tag }}"
     close: true
+
+release:
+  prerelease: auto
 
 changelog:
   skip: true


### PR DESCRIPTION
TODO:
 - [x] Verify impact on https://github.com/hashicorp/vscode-terraform (earlier versions which do not bundle LS)
 - [ ] Docs to cover expectations of pre-releases and how to obtain them
 - [x] Linux packages - do other product publish them for pre-releases? Do we need to do anything extra?

--- 

Closes #456

See relevant docs at https://goreleaser.com/customization/release/#github

```yaml
  # If set to auto, will mark the release as not ready for production
  # in case there is an indicator for this in the tag e.g. v1.0.0-rc1
  # If set to true, will mark the release as not ready for production.
  # Default is false.
  prerelease: auto
```

and https://goreleaser.com/customization/homebrew/

```yaml
    # If set to auto, the release will not be uploaded to the homebrew tap
    # in case there is an indicator for prerelease in the tag e.g. v1.0.0-rc1
    # Default is false.
    skip_upload: true
```