### PR TITLE
Fix validate on save

### DIFF
--- a/internal/langserver/handlers/service.go
+++ b/internal/langserver/handlers/service.go
@@ -270,6 +270,7 @@ func (svc *service) Assigner() (jrpc2.Assigner, error) {
 			ctx = lsctx.WithDiagnosticsNotifier(ctx, svc.diagsNotifier)
 			ctx = lsctx.WithExperimentalFeatures(ctx, &expFeatures)
 			ctx = exec.WithExecutorOpts(ctx, svc.tfExecOpts)
+			ctx = exec.WithExecutorFactory(ctx, svc.tfExecFactory)
 
 			return handle(ctx, req, svc.TextDocumentDidSave)
 		},


### PR DESCRIPTION
The `/didSave` handler was missing WithModuleManager and WithExecutorFactory, which the validate command handler needs to find terraform to execute validate.

Closes #792 