### PR TITLE
Update semantic token block label type

### DIFF
--- a/internal/langserver/handlers/semantic_tokens_test.go
+++ b/internal/langserver/handlers/semantic_tokens_test.go
@@ -71,7 +71,8 @@ func TestSemanticTokensFull(t *testing.T) {
 					"tokenTypes": [
 						"type",
 						"property",
-						"string"
+						"string",
+						"enumMember"
 					],
 					"tokenModifiers": [
 						"deprecated",
@@ -113,7 +114,7 @@ func TestSemanticTokensFull(t *testing.T) {
 			"result": {
 				"data": [
 					0,0,8,0,0,
-					0,9,6,1,2
+					0,9,6,3,2
 				]
 			}
 		}`)
@@ -178,7 +179,8 @@ func TestSemanticTokensFull_clientSupportsDelta(t *testing.T) {
 					"tokenTypes": [
 						"type",
 						"property",
-						"string"
+						"string",
+						"enumMember"
 					],
 					"tokenModifiers": [
 						"deprecated",
@@ -222,7 +224,7 @@ func TestSemanticTokensFull_clientSupportsDelta(t *testing.T) {
 			"result": {
 				"data": [
 					0,0,8,0,0,
-					0,9,6,1,2
+					0,9,6,3,2
 				]
 			}
 		}`)

--- a/internal/lsp/token_encoder.go
+++ b/internal/lsp/token_encoder.go
@@ -34,7 +34,7 @@ func (te *TokenEncoder) encodeTokenOfIndex(i int) []uint32 {
 	case lang.TokenBlockType:
 		tokenType = TokenTypeType
 	case lang.TokenBlockLabel:
-		tokenType = TokenTypeString
+		tokenType = TokenTypeEnumMember
 	case lang.TokenAttrName:
 		tokenType = TokenTypeProperty
 	case lang.TokenBool:

--- a/internal/lsp/token_encoder_test.go
+++ b/internal/lsp/token_encoder_test.go
@@ -68,7 +68,7 @@ func TestTokenEncoder_singleLineTokens(t *testing.T) {
 	data := te.Encode()
 	expectedData := []uint32{
 		0, 0, 7, 0, 0,
-		0, 8, 8, 1, 0,
+		0, 8, 8, 7, 0,
 		1, 2, 8, 2, 0,
 		1, 2, 8, 2, 0,
 		1, 2, 9, 2, 0,
@@ -162,8 +162,8 @@ func TestTokenEncoder_deltaStartCharBug(t *testing.T) {
 	data := te.Encode()
 	expectedData := []uint32{
 		0, 0, 8, 0, 0,
-		0, 9, 21, 1, 2,
-		0, 22, 20, 1, 0,
+		0, 9, 21, 7, 2,
+		0, 22, 20, 7, 0,
 	}
 
 	if diff := cmp.Diff(expectedData, data); diff != "" {
@@ -243,7 +243,7 @@ func TestTokenEncoder_tokenModifiers(t *testing.T) {
 	data := te.Encode()
 	expectedData := []uint32{
 		0, 0, 7, 0, 0,
-		0, 8, 8, 1, 1,
+		0, 8, 8, 7, 1,
 		1, 2, 8, 2, 1,
 		1, 2, 8, 2, 2,
 		1, 2, 9, 2, 3,

--- a/internal/lsp/token_types.go
+++ b/internal/lsp/token_types.go
@@ -109,6 +109,7 @@ var (
 		TokenTypeNumber,
 		TokenTypeParameter,
 		TokenTypeVariable,
+		TokenTypeEnumMember,
 	}
 	serverTokenModifiers = TokenModifiers{
 		TokenModifierDeprecated,


### PR DESCRIPTION
This PR updates the type for block labels from string to enum member.

It's the first step in providing more contextual information on block labels. With a schema update, it will be possible to differentiate between multiple block labels. This will allow us to report two different tokens for block labels where the first one stays enum member and the second one becomes a string.

We've tried different token types, like `class`, `macro`, `method`, and `enumMember` and settled on the latter. `enumMember` makes the most sense from a semantic perspective and has good highlighting in the default themes.

Having semantic tokens for block labels enables better highlighting for nested blocks.

Before (no LS)
![CleanShot 2022-02-23 at 15 23 06](https://user-images.githubusercontent.com/45985/155338730-44bde059-8352-433a-8431-afaf5dbf7331.png)

After (with LS)
![CleanShot 2022-02-23 at 15 26 55](https://user-images.githubusercontent.com/45985/155338810-fa0c6b91-f107-4eb2-acb8-4e8e446c29c5.png)

For a smoother user experience, we propose to update the static grammar for block labels from `entity.name.tag.terraform` to `variable.other.enummember`. This change would update the raw grammar version (no LS) to this:
![CleanShot 2022-02-23 at 15 28 43](https://user-images.githubusercontent.com/45985/155339423-8b043553-e737-4b10-951a-5006926817df.png)


Closes #777 