### PR TITLE
Add packages `read` permission for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   issues: write
+  packages: read
 
 env:
   GOPROXY: https://proxy.golang.org/


### PR DESCRIPTION
This PR adds the `read` permission for packages for the release job. This is required to install the signore package.