### PR TITLE
internal/lsp: fix encoding of unknown semantic token types

### DIFF
--- a/internal/lsp/token_encoder.go
+++ b/internal/lsp/token_encoder.go
@@ -12,6 +12,10 @@ type TokenEncoder struct {
 	Lines      source.Lines
 	Tokens     []lang.SemanticToken
 	ClientCaps lsp.SemanticTokensClientCapabilities
+
+	// lastEncodedTokenIdx tracks index of the last encoded token
+	// so we can account for any skipped tokens in calculating diff
+	lastEncodedTokenIdx int
 }
 
 func (te *TokenEncoder) Encode() []uint32 {
@@ -92,10 +96,10 @@ func (te *TokenEncoder) encodeTokenOfIndex(i int) []uint32 {
 	previousLine := 0
 	previousStartChar := 0
 	if i > 0 {
-		previousLine = te.Tokens[i-1].Range.End.Line - 1
+		previousLine = te.Tokens[te.lastEncodedTokenIdx].Range.End.Line - 1
 		currentLine := te.Tokens[i].Range.End.Line - 1
 		if currentLine == previousLine {
-			previousStartChar = te.Tokens[i-1].Range.Start.Column - 1
+			previousStartChar = te.Tokens[te.lastEncodedTokenIdx].Range.Start.Column - 1
 		}
 	}
 
@@ -139,6 +143,8 @@ func (te *TokenEncoder) encodeTokenOfIndex(i int) []uint32 {
 			previousLine = tokenLine
 		}
 	}
+
+	te.lastEncodedTokenIdx = i
 
 	return data
 }

--- a/internal/lsp/token_encoder_test.go
+++ b/internal/lsp/token_encoder_test.go
@@ -82,6 +82,7 @@ func TestTokenEncoder_singleLineTokens(t *testing.T) {
 
 func TestTokenEncoder_unknownTokenType(t *testing.T) {
 	bytes := []byte(`variable "test" {
+  type = string
   default = "foo"
 }
 `)
@@ -89,7 +90,7 @@ func TestTokenEncoder_unknownTokenType(t *testing.T) {
 		Lines: source.MakeSourceLines("test.tf", bytes),
 		Tokens: []lang.SemanticToken{
 			{
-				Type:      lang.TokenBlockType,
+				Type:      lang.SemanticTokenType(999),
 				Modifiers: []lang.SemanticTokenModifier{},
 				Range: hcl.Range{
 					Filename: "main.tf",
@@ -98,12 +99,12 @@ func TestTokenEncoder_unknownTokenType(t *testing.T) {
 				},
 			},
 			{
-				Type:      lang.SemanticTokenType(999),
+				Type:      lang.SemanticTokenType(1000),
 				Modifiers: []lang.SemanticTokenModifier{},
 				Range: hcl.Range{
 					Filename: "main.tf",
-					Start:    hcl.Pos{Line: 1, Column: 10, Byte: 9},
-					End:      hcl.Pos{Line: 1, Column: 16, Byte: 15},
+					Start:    hcl.Pos{Line: 2, Column: 3, Byte: 20},
+					End:      hcl.Pos{Line: 2, Column: 7, Byte: 24},
 				},
 			},
 			{
@@ -111,8 +112,8 @@ func TestTokenEncoder_unknownTokenType(t *testing.T) {
 				Modifiers: []lang.SemanticTokenModifier{},
 				Range: hcl.Range{
 					Filename: "main.tf",
-					Start:    hcl.Pos{Line: 2, Column: 3, Byte: 20},
-					End:      hcl.Pos{Line: 2, Column: 10, Byte: 27},
+					Start:    hcl.Pos{Line: 3, Column: 3, Byte: 36},
+					End:      hcl.Pos{Line: 3, Column: 10, Byte: 43},
 				},
 			},
 		},
@@ -123,8 +124,7 @@ func TestTokenEncoder_unknownTokenType(t *testing.T) {
 	}
 	data := te.Encode()
 	expectedData := []uint32{
-		0, 0, 8, 0, 0,
-		1, 2, 7, 2, 0,
+		2, 2, 7, 2, 0,
 	}
 
 	if diff := cmp.Diff(expectedData, data); diff != "" {

--- a/internal/lsp/token_encoder_test.go
+++ b/internal/lsp/token_encoder_test.go
@@ -80,6 +80,59 @@ func TestTokenEncoder_singleLineTokens(t *testing.T) {
 	}
 }
 
+func TestTokenEncoder_unknownTokenType(t *testing.T) {
+	bytes := []byte(`variable "test" {
+  default = "foo"
+}
+`)
+	te := &TokenEncoder{
+		Lines: source.MakeSourceLines("test.tf", bytes),
+		Tokens: []lang.SemanticToken{
+			{
+				Type:      lang.TokenBlockType,
+				Modifiers: []lang.SemanticTokenModifier{},
+				Range: hcl.Range{
+					Filename: "main.tf",
+					Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+					End:      hcl.Pos{Line: 1, Column: 9, Byte: 8},
+				},
+			},
+			{
+				Type:      lang.SemanticTokenType(999),
+				Modifiers: []lang.SemanticTokenModifier{},
+				Range: hcl.Range{
+					Filename: "main.tf",
+					Start:    hcl.Pos{Line: 1, Column: 10, Byte: 9},
+					End:      hcl.Pos{Line: 1, Column: 16, Byte: 15},
+				},
+			},
+			{
+				Type:      lang.TokenAttrName,
+				Modifiers: []lang.SemanticTokenModifier{},
+				Range: hcl.Range{
+					Filename: "main.tf",
+					Start:    hcl.Pos{Line: 2, Column: 3, Byte: 20},
+					End:      hcl.Pos{Line: 2, Column: 10, Byte: 27},
+				},
+			},
+		},
+		ClientCaps: protocol.SemanticTokensClientCapabilities{
+			TokenTypes:     serverTokenTypes.AsStrings(),
+			TokenModifiers: serverTokenModifiers.AsStrings(),
+		},
+	}
+	data := te.Encode()
+	expectedData := []uint32{
+		0, 0, 8, 0, 0,
+		1, 2, 7, 2, 0,
+	}
+
+	if diff := cmp.Diff(expectedData, data); diff != "" {
+		t.Fatalf("unexpected encoded data.\nexpected: %#v\ngiven:    %#v",
+			expectedData, data)
+	}
+}
+
 func TestTokenEncoder_multiLineTokens(t *testing.T) {
 	bytes := []byte(`myblock "mytype" {
   str_attr = "something"


### PR DESCRIPTION
Fixes #763

## Before

<img width="253" alt="156248451-7809c3e5-98ae-4b0c-a907-dc4a2817f631" src="https://user-images.githubusercontent.com/287584/156329742-b63b380e-5d9f-4ae2-b438-7b7fbf0bded3.png">

## After

![Screenshot 2022-03-02 at 09 05 12](https://user-images.githubusercontent.com/287584/156329935-48605bd3-2728-4019-a7d1-2aa61e1916ee.png)

## Follow up issues

 - https://github.com/hashicorp/vscode-terraform/issues/955
 - https://github.com/hashicorp/terraform-ls/issues/816