### PR TITLE
internal/lsp: report dependent modifiers as `defaultLibrary`

### DIFF
--- a/internal/langserver/handlers/semantic_tokens_test.go
+++ b/internal/langserver/handlers/semantic_tokens_test.go
@@ -76,7 +76,7 @@ func TestSemanticTokensFull(t *testing.T) {
 					],
 					"tokenModifiers": [
 						"deprecated",
-						"modification"
+						"defaultLibrary"
 					],
 					"requests": {
 						"full": true
@@ -184,7 +184,7 @@ func TestSemanticTokensFull_clientSupportsDelta(t *testing.T) {
 					],
 					"tokenModifiers": [
 						"deprecated",
-						"modification"
+						"defaultLibrary"
 					],
 					"requests": {
 						"full": {
@@ -293,7 +293,7 @@ func TestVarsSemanticTokensFull(t *testing.T) {
 					],
 					"tokenModifiers": [
 						"deprecated",
-						"modification"
+						"defaultLibrary"
 					],
 					"requests": {
 						"full": true

--- a/internal/lsp/token_encoder.go
+++ b/internal/lsp/token_encoder.go
@@ -69,10 +69,10 @@ func (te *TokenEncoder) encodeTokenOfIndex(i int) []uint32 {
 	for _, m := range token.Modifiers {
 		switch m {
 		case lang.TokenModifierDependent:
-			if !te.tokenModifierSupported(TokenModifierModification) {
+			if !te.tokenModifierSupported(TokenModifierDefaultLibrary) {
 				continue
 			}
-			modifiers = append(modifiers, TokenModifierModification)
+			modifiers = append(modifiers, TokenModifierDefaultLibrary)
 		case lang.TokenModifierDeprecated:
 			if !te.tokenModifierSupported(TokenModifierDeprecated) {
 				continue

--- a/internal/lsp/token_types.go
+++ b/internal/lsp/token_types.go
@@ -113,7 +113,7 @@ var (
 	}
 	serverTokenModifiers = TokenModifiers{
 		TokenModifierDeprecated,
-		TokenModifierModification,
+		TokenModifierDefaultLibrary,
 	}
 )
 


### PR DESCRIPTION
Closes #710


The (LSP) modifier `defaultLibrary` better represents the meaning of dependent labels or attributes, as opposed to `modification` which was chosen mostly arbitrarily as part of the initial implementation in https://github.com/hashicorp/terraform-ls/pull/331

Highlighting dependent labels was already possible prior to this patch but the change of the modifier here reflects the commitment to support custom themes in a more sensible (and hopefully stable) way.

Default VSCode themes [do not assign meaning to any modifiers](https://github.com/microsoft/vscode/blob/main/src/vs/platform/theme/common/tokenClassificationRegistry.ts#L572-L594) but it is possible to take advantage of this in a custom theme or simply by modifying the VSCode settings such as

```json
    "editor.semanticTokenColorCustomizations": {
        "rules": {
            "enumMember.defaultLibrary": {
                "bold": true
            }
        }
    },
```

## Before

(assuming customized settings as above & default theme)

![Screenshot 2022-03-02 at 12 20 41](https://user-images.githubusercontent.com/287584/156360632-003a727e-255a-4e31-96f8-d00ecee55d51.png) ![Screenshot 2022-03-02 at 12 20 31](https://user-images.githubusercontent.com/287584/156360629-8f617341-fc5c-4fe0-8f94-026b5b54e0e3.png)

## After

(assuming customized settings as above & default theme)

![Screenshot 2022-03-02 at 12 16 20](https://user-images.githubusercontent.com/287584/156360469-5de34aef-a069-4c43-85b9-ad158b0bf888.png) ![Screenshot 2022-03-02 at 12 16 37](https://user-images.githubusercontent.com/287584/156360471-32b9d2ac-976a-45c3-8fad-ec957e86f767.png)

cc @tringuyen-yw

--- 

`variable` name getting also reported as dependent is not intended, but I opened a separate issue for that problem: https://github.com/hashicorp/terraform-schema/issues/96