### PR TITLE
internal/state: avoid deadlock caused by mid-flight job change

### DIFF
--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -15,7 +16,7 @@ import (
 	"github.com/hashicorp/terraform-ls/internal/state"
 )
 
-func TestScheduler_basic(t *testing.T) {
+func TestScheduler_closedOnly(t *testing.T) {
 	ss, err := state.NewStateStore()
 	if err != nil {
 		t.Fatal(err)
@@ -65,7 +66,129 @@ func TestScheduler_basic(t *testing.T) {
 	}
 }
 
-func BenchmarkScheduler_EnqueueAndWaitForJob(b *testing.B) {
+func TestScheduler_closedAndOpen(t *testing.T) {
+	ss, err := state.NewStateStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ss.SetLogger(testLogger())
+
+	tmpDir := t.TempDir()
+
+	var wg sync.WaitGroup
+
+	var closedJobsExecuted int64 = 0
+	closedJobsToExecute := 50
+	closedIds := make([]job.ID, 0)
+	wg.Add(1)
+	go func(t *testing.T) {
+		defer wg.Done()
+		for i := 0; i < closedJobsToExecute; i++ {
+			i := i
+			dirPath := filepath.Join(tmpDir, fmt.Sprintf("folder-x-%d", i))
+
+			newId, err := ss.JobStore.EnqueueJob(job.Job{
+				Func: func(c context.Context) error {
+					atomic.AddInt64(&closedJobsExecuted, 1)
+					return nil
+				},
+				Dir:  document.DirHandleFromPath(dirPath),
+				Type: "test-type",
+			})
+			if err != nil {
+				t.Error(err)
+			}
+			closedIds = append(closedIds, newId)
+		}
+	}(t)
+
+	openJobsToExecute := 50
+	var openJobsExecuted int64 = 0
+	openIds := make([]job.ID, 0)
+	wg.Add(1)
+	go func(t *testing.T) {
+		defer wg.Done()
+		for i := 0; i < openJobsToExecute; i++ {
+			i := i
+			dirPath := filepath.Join(tmpDir, fmt.Sprintf("folder-y-%d", i))
+
+			newId, err := ss.JobStore.EnqueueJob(job.Job{
+				Func: func(c context.Context) error {
+					atomic.AddInt64(&openJobsExecuted, 1)
+					return nil
+				},
+				Dir:  document.DirHandleFromPath(dirPath),
+				Type: "test-type",
+			})
+			if err != nil {
+				t.Error(err)
+			}
+
+			openIds = append(openIds, newId)
+		}
+	}(t)
+
+	wg.Add(1)
+	// we intentionally open the documents in a separate routine,
+	// possibly after some of the relevant jobs have been queued (as closed)
+	// to better reflect what may happen in reality
+	go func(t *testing.T) {
+		defer wg.Done()
+		for i := 0; i < openJobsToExecute; i++ {
+			dirPath := filepath.Join(tmpDir, fmt.Sprintf("folder-y-%d", i))
+			dh := document.HandleFromPath(filepath.Join(dirPath, "test.tf"))
+			err := ss.DocumentStore.OpenDocument(dh, "", 0, []byte{})
+			if err != nil {
+				t.Error(err)
+			}
+		}
+	}(t)
+
+	ctx := context.Background()
+	if deadline, ok := t.Deadline(); ok {
+		var cancelFunc context.CancelFunc
+		ctx, cancelFunc = context.WithDeadline(ctx, deadline)
+		t.Cleanup(cancelFunc)
+	}
+
+	cs := NewScheduler(&closedDirJobs{js: ss.JobStore}, 1)
+	cs.SetLogger(testLogger())
+	cs.Start(ctx)
+	t.Cleanup(func() {
+		cs.Stop()
+	})
+
+	os := NewScheduler(&openDirJobs{js: ss.JobStore}, 1)
+	os.SetLogger(testLogger())
+	os.Start(ctx)
+	t.Cleanup(func() {
+		os.Stop()
+	})
+
+	// wait for all scheduling and document opening to finish
+	wg.Wait()
+	t.Log("finished all scheduling and doc opening")
+
+	allIds := make([]job.ID, 0)
+	allIds = append(allIds, closedIds...)
+	allIds = append(allIds, openIds...)
+
+	t.Logf("waiting for %d jobs", len(allIds))
+	err = ss.JobStore.WaitForJobs(ctx, allIds...)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if closedJobsExecuted != int64(closedJobsToExecute) {
+		t.Fatalf("expected %d closed jobs to execute, got: %d", closedJobsToExecute, closedJobsExecuted)
+	}
+
+	if openJobsExecuted != int64(openJobsToExecute) {
+		t.Fatalf("expected %d open jobs to execute, got: %d", openJobsToExecute, openJobsExecuted)
+	}
+}
+
+func BenchmarkScheduler_EnqueueAndWaitForJob_closedOnly(b *testing.B) {
 	ss, err := state.NewStateStore()
 	if err != nil {
 		b.Fatal(err)
@@ -221,5 +344,25 @@ func (js *closedDirJobs) FinishJob(id job.ID, jobErr error, deferredJobIds ...jo
 }
 
 func (js *closedDirJobs) WaitForJobs(ctx context.Context, jobIds ...job.ID) error {
+	return js.js.WaitForJobs(ctx, jobIds...)
+}
+
+type openDirJobs struct {
+	js *state.JobStore
+}
+
+func (js *openDirJobs) EnqueueJob(newJob job.Job) (job.ID, error) {
+	return js.js.EnqueueJob(newJob)
+}
+
+func (js *openDirJobs) AwaitNextJob(ctx context.Context) (job.ID, job.Job, error) {
+	return js.js.AwaitNextJob(ctx, true)
+}
+
+func (js *openDirJobs) FinishJob(id job.ID, jobErr error, deferredJobIds ...job.ID) error {
+	return js.js.FinishJob(id, jobErr, deferredJobIds...)
+}
+
+func (js *openDirJobs) WaitForJobs(ctx context.Context, jobIds ...job.ID) error {
 	return js.js.WaitForJobs(ctx, jobIds...)
 }

--- a/internal/state/errors.go
+++ b/internal/state/errors.go
@@ -1,6 +1,10 @@
 package state
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-ls/internal/job"
+)
 
 type AlreadyExistsError struct {
 	Idx string
@@ -38,4 +42,26 @@ func IsModuleNotFound(err error) bool {
 	}
 	_, ok := err.(*ModuleNotFoundError)
 	return ok
+}
+
+type jobAlreadyRunning struct {
+	ID job.ID
+}
+
+func (e jobAlreadyRunning) Error() string {
+	if e.ID != "" {
+		return fmt.Sprintf("job %q is already running", e.ID)
+	}
+	return "job is already running"
+}
+
+type jobNotFound struct {
+	ID job.ID
+}
+
+func (e jobNotFound) Error() string {
+	if e.ID != "" {
+		return fmt.Sprintf("job %q not found", e.ID)
+	}
+	return "job not found"
 }


### PR DESCRIPTION
There is a relatively rare case of when we may end up processing the same job twice here:

https://github.com/hashicorp/terraform-ls/blob/bff4e90811f3375c029cf099142adbf869c56f5c/internal/state/jobs.go#L188-L211

1. a job e.g. ID 42 is found by e.g. "closed scheduler" (`*`)
2. in the split second between finding this job and marking it as running (which itself _is_ correctly guarded by an internal memdb mutex), the involved directory is open.
3. the same job ID 42 is then also found by "open scheduler" (`**`)
4. whichever scheduler obtains the memdb mutex first marks that job as running
5. the other scheduler then waits for the mutex and attempts to do the same
6. because that fails, we return error, making the scheduler to effectively shut down, practically causing a deadlock in places which wait for jobs to finish - as they'd never finish

(`*`) - the scheduler responsible for processing jobs involving directories which are _not_ open
(`**`) - the scheduler responsible for processing jobs involving directories which _are_ open

While this may be rare, I ran into that bug myself this morning, as can be seen from this log snippet:
https://gist.github.com/radeksimko/7ce4e9a7d0c8bbc65bd65e277dc3bd92