### PR TITLE
schemas/gen: exclude harness-io/harness

### DIFF
--- a/internal/schemas/gen/gen.go
+++ b/internal/schemas/gen/gen.go
@@ -246,6 +246,7 @@ func listProviders(tier string) ([]provider, error) {
 
 var ignore = map[string]bool{
 	"a10networks/vthunder":    true,
+	"harness-io/harness":      true,
 	"HewlettPackard/oneview":  true,
 	"HewlettPackard/hpegl":    true,
 	"jradtilbrook/buildkite":  true,


### PR DESCRIPTION
This is in reaction to the following
https://github.com/hashicorp/terraform-ls/runs/5419512936?check_suite_focus=true#step:6:47

```
Error: Incompatible provider version

Provider registry.terraform.io/harness-io/harness v0.1.15 does not have a
package available for your current platform, linux_amd64.

Provider releases are separate from Terraform CLI releases, so not all
providers are available for all platforms. Other versions of this provider
may have different platforms supported.
```