### PR TITLE
github: bump dessant/lock-threads to v3

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -1,5 +1,9 @@
 name: 'Lock Threads'
 
+permissions:
+  issues: write
+  pull-requests: write
+
 on:
   schedule:
     - cron: '0 3 * * *'
@@ -8,16 +12,15 @@ jobs:
   lock:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@v2
+      - uses: dessant/lock-threads@v3
         with:
-          github-token: ${{ github.token }}
-          issue-lock-comment: >
+          issue-comment: >
             I'm going to lock this issue because it has been closed for _30 days_ ⏳. This helps our maintainers find and focus on the active issues.
 
             If you have found a problem that seems similar to this, please open a new issue and complete the issue template so we can capture all the details necessary to investigate further.
-          issue-lock-inactive-days: '30'
-          pr-lock-comment: >
+          issue-inactive-days: '30'
+          pr-comment: >
             I'm going to lock this pull request because it has been closed for _30 days_ ⏳. This helps our maintainers find and focus on the active issues.
 
             If you have found a problem that seems related to this change, please open a new issue and complete the issue template so we can capture all the details necessary to investigate further.
-          pr-lock-inactive-days: '30'
+          pr-inactive-days: '30'


### PR DESCRIPTION
This is in reaction to v2 apparently not being available anymore:

https://github.com/hashicorp/terraform-ls/runs/5419688427?check_suite_focus=true

follows the upgrade guide in https://github.com/dessant/lock-threads/commit/08e671be8ac8944d0e132aa71d0ae8ccfb347675