### PR TITLE
github: declare permissions for all GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,6 @@ on:
     branches:
       - main
 
-permissions:
-  contents: read
-
 env:
   GOPROXY: https://proxy.golang.org/
 

--- a/.github/workflows/issue-comment-created.yml
+++ b/.github/workflows/issue-comment-created.yml
@@ -1,5 +1,9 @@
 name: Issue Comment Created Triage
 
+permissions:
+  issues: write
+  pull-requests: write
+
 on:
   issue_comment:
     types: [created]

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -1,5 +1,9 @@
 name: 'Lock Threads'
 
+permissions:
+  issues: write
+  pull-requests: write
+
 on:
   schedule:
     - cron: '0 3 * * *'
@@ -10,7 +14,6 @@ jobs:
     steps:
       - uses: dessant/lock-threads@v2
         with:
-          github-token: ${{ github.token }}
           issue-lock-comment: >
             I'm going to lock this issue because it has been closed for _30 days_ ⏳. This helps our maintainers find and focus on the active issues.
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
 
 permissions:
-  contents: write
+  contents: write # for uploading release artifacts
   issues: write # for closing milestone via goreleaser
   packages: read # for downloading signore docker image
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,7 +14,6 @@ jobs:
     steps:
     - uses: actions/stale@v3
       with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
         days-before-stale: '-1'
         days-before-close: '90'
         only-labels: 'waiting-response'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,4 +1,9 @@
 name: "Stale issues and pull requests"
+
+permissions:
+  issues: write
+  pull-requests: write
+
 on:
   schedule:
   - cron: "10 3 * * *"


### PR DESCRIPTION
This allows us to be a little bit more defensive by not giving any workflows more permissions than they really need and use this safer default settings for the repo

![Screenshot 2022-03-04 at 09 16 36](https://user-images.githubusercontent.com/287584/156734951-5eb92433-87d9-4de0-a9d0-d6a3f0c10200.png)

I also removed the explicit token for lock-threads as this is now default since 2.1.0 https://github.com/dessant/lock-threads/blob/master/CHANGELOG.md#210-2021-07-09 and did the same for the stale action: https://github.com/actions/stale#repo-token

More about GitHub token permissions: https://docs.github.com/en/actions/security-guides/automatic-token-authentication