### PR TITLE
internal/lsp: recognize type declarations as semantic tokens

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/hashicorp/go-uuid v1.0.2
 	github.com/hashicorp/go-version v1.4.0
 	github.com/hashicorp/hc-install v0.3.1
-	github.com/hashicorp/hcl-lang v0.0.0-20211123142056-191cd51dec5b
+	github.com/hashicorp/hcl-lang v0.0.0-20220304112739-b2b314ea7c44
 	github.com/hashicorp/hcl/v2 v2.11.1
 	github.com/hashicorp/terraform-exec v0.16.0
 	github.com/hashicorp/terraform-json v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -296,8 +296,8 @@ github.com/hashicorp/hc-install v0.3.1/go.mod h1:3LCdWcCDS1gaHC9mhHCGbkYfoY6vdsK
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/hcl-lang v0.0.0-20211118124824-da3a292c5d7a/go.mod h1:0W3+VP07azoS+fCX5hWk1KxwHnqf1s9J7oBg2cFXm1c=
-github.com/hashicorp/hcl-lang v0.0.0-20211123142056-191cd51dec5b h1:UircH3n8tUnq881dS1EV/m+ZcIKjZq9jzl0M65PAdWU=
-github.com/hashicorp/hcl-lang v0.0.0-20211123142056-191cd51dec5b/go.mod h1:0W3+VP07azoS+fCX5hWk1KxwHnqf1s9J7oBg2cFXm1c=
+github.com/hashicorp/hcl-lang v0.0.0-20220304112739-b2b314ea7c44 h1:R+ZKsdqgXle9KO2pLE6AwXg6IStjfM8wgQY4u0qPtx0=
+github.com/hashicorp/hcl-lang v0.0.0-20220304112739-b2b314ea7c44/go.mod h1:vyszbX6YNHCKIaVUhbh3LIZljxwYOtgWCIkhT5zKfjc=
 github.com/hashicorp/hcl/v2 v2.10.1/go.mod h1:FwWsfWEjyV/CMj8s/gqAuiviY72rJ1/oayI9WftqcKg=
 github.com/hashicorp/hcl/v2 v2.11.1 h1:yTyWcXcm9XB0TEkyU/JCRU6rYy4K+mgLtzn2wlrJbcc=
 github.com/hashicorp/hcl/v2 v2.11.1/go.mod h1:FwWsfWEjyV/CMj8s/gqAuiviY72rJ1/oayI9WftqcKg=

--- a/internal/langserver/handlers/semantic_tokens_test.go
+++ b/internal/langserver/handlers/semantic_tokens_test.go
@@ -69,14 +69,14 @@ func TestSemanticTokensFull(t *testing.T) {
 			"textDocument": {
 				"semanticTokens": {
 					"tokenTypes": [
-						"type",
+						"enumMember",
 						"property",
 						"string",
-						"enumMember"
+						"type"
 					],
 					"tokenModifiers": [
-						"deprecated",
-						"defaultLibrary"
+						"defaultLibrary",
+						"deprecated"
 					],
 					"requests": {
 						"full": true
@@ -113,8 +113,8 @@ func TestSemanticTokensFull(t *testing.T) {
 			"id": 3,
 			"result": {
 				"data": [
-					0,0,8,0,0,
-					0,9,6,3,2
+					0,0,8,3,0,
+					0,9,6,0,1
 				]
 			}
 		}`)
@@ -177,14 +177,14 @@ func TestSemanticTokensFull_clientSupportsDelta(t *testing.T) {
 			"textDocument": {
 				"semanticTokens": {
 					"tokenTypes": [
-						"type",
+						"enumMember",
 						"property",
 						"string",
-						"enumMember"
+						"type"
 					],
 					"tokenModifiers": [
-						"deprecated",
-						"defaultLibrary"
+						"defaultLibrary",
+						"deprecated"
 					],
 					"requests": {
 						"full": {
@@ -223,8 +223,8 @@ func TestSemanticTokensFull_clientSupportsDelta(t *testing.T) {
 			"id": 3,
 			"result": {
 				"data": [
-					0,0,8,0,0,
-					0,9,6,3,2
+					0,0,8,3,0,
+					0,9,6,0,1
 				]
 			}
 		}`)
@@ -292,8 +292,8 @@ func TestVarsSemanticTokensFull(t *testing.T) {
 						"string"
 					],
 					"tokenModifiers": [
-						"deprecated",
-						"defaultLibrary"
+						"defaultLibrary",
+						"deprecated"
 					],
 					"requests": {
 						"full": true
@@ -340,7 +340,7 @@ func TestVarsSemanticTokensFull(t *testing.T) {
 			"id": 4,
 			"result": {
 				"data": [
-					0,0,4,2,0,
+					0,0,4,0,0,
 					0,7,5,1,0
 				]
 			}

--- a/internal/lsp/token_encoder.go
+++ b/internal/lsp/token_encoder.go
@@ -55,6 +55,10 @@ func (te *TokenEncoder) encodeTokenOfIndex(i int) []uint32 {
 		tokenType = TokenTypeVariable
 	case lang.TokenTraversalStep:
 		tokenType = TokenTypeVariable
+	case lang.TokenTypeCapsule:
+		tokenType = TokenTypeFunction
+	case lang.TokenTypePrimitive:
+		tokenType = TokenTypeKeyword
 
 	default:
 		return []uint32{}

--- a/internal/lsp/token_encoder_test.go
+++ b/internal/lsp/token_encoder_test.go
@@ -67,11 +67,11 @@ func TestTokenEncoder_singleLineTokens(t *testing.T) {
 	}
 	data := te.Encode()
 	expectedData := []uint32{
-		0, 0, 7, 0, 0,
-		0, 8, 8, 7, 0,
-		1, 2, 8, 2, 0,
-		1, 2, 8, 2, 0,
-		1, 2, 9, 2, 0,
+		0, 0, 7, 7, 0,
+		0, 8, 8, 0, 0,
+		1, 2, 8, 5, 0,
+		1, 2, 8, 5, 0,
+		1, 2, 9, 5, 0,
 	}
 
 	if diff := cmp.Diff(expectedData, data); diff != "" {
@@ -124,7 +124,7 @@ func TestTokenEncoder_unknownTokenType(t *testing.T) {
 	}
 	data := te.Encode()
 	expectedData := []uint32{
-		2, 2, 7, 2, 0,
+		2, 2, 7, 5, 0,
 	}
 
 	if diff := cmp.Diff(expectedData, data); diff != "" {
@@ -161,9 +161,9 @@ func TestTokenEncoder_multiLineTokens(t *testing.T) {
 	}
 	data := te.Encode()
 	expectedData := []uint32{
-		1, 2, 24, 2, 0,
-		1, 0, 15, 2, 0,
-		1, 0, 11, 2, 0,
+		1, 2, 24, 5, 0,
+		1, 0, 15, 5, 0,
+		1, 0, 11, 5, 0,
 	}
 
 	if diff := cmp.Diff(expectedData, data); diff != "" {
@@ -214,9 +214,9 @@ func TestTokenEncoder_deltaStartCharBug(t *testing.T) {
 	}
 	data := te.Encode()
 	expectedData := []uint32{
-		0, 0, 8, 0, 0,
-		0, 9, 21, 7, 2,
-		0, 22, 20, 7, 0,
+		0, 0, 8, 7, 0,
+		0, 9, 21, 0, 1,
+		0, 22, 20, 0, 0,
 	}
 
 	if diff := cmp.Diff(expectedData, data); diff != "" {
@@ -295,11 +295,11 @@ func TestTokenEncoder_tokenModifiers(t *testing.T) {
 	}
 	data := te.Encode()
 	expectedData := []uint32{
-		0, 0, 7, 0, 0,
-		0, 8, 8, 7, 1,
-		1, 2, 8, 2, 1,
-		1, 2, 8, 2, 2,
-		1, 2, 9, 2, 3,
+		0, 0, 7, 7, 0,
+		0, 8, 8, 0, 2,
+		1, 2, 8, 5, 2,
+		1, 2, 8, 5, 1,
+		1, 2, 9, 5, 3,
 	}
 
 	if diff := cmp.Diff(expectedData, data); diff != "" {
@@ -378,10 +378,10 @@ func TestTokenEncoder_unsupported(t *testing.T) {
 	}
 	data := te.Encode()
 	expectedData := []uint32{
-		0, 0, 7, 0, 0,
-		1, 2, 8, 1, 1,
-		1, 2, 8, 1, 0,
-		1, 2, 9, 1, 1,
+		0, 0, 7, 1, 0,
+		1, 2, 8, 0, 1,
+		1, 2, 8, 0, 0,
+		1, 2, 9, 0, 1,
 	}
 
 	if diff := cmp.Diff(expectedData, data); diff != "" {

--- a/internal/lsp/token_types.go
+++ b/internal/lsp/token_types.go
@@ -110,6 +110,7 @@ var (
 		TokenTypeParameter,
 		TokenTypeVariable,
 		TokenTypeEnumMember,
+		TokenTypeFunction,
 	}
 	serverTokenModifiers = TokenModifiers{
 		TokenModifierDeprecated,

--- a/internal/lsp/token_types.go
+++ b/internal/lsp/token_types.go
@@ -102,19 +102,19 @@ const (
 // to be registered by VS Code by default, see https://git.io/JIeuV
 var (
 	serverTokenTypes = TokenTypes{
-		TokenTypeType,
-		TokenTypeString,
-		TokenTypeProperty,
+		TokenTypeEnumMember,
+		TokenTypeFunction,
 		TokenTypeKeyword,
 		TokenTypeNumber,
 		TokenTypeParameter,
+		TokenTypeProperty,
+		TokenTypeString,
+		TokenTypeType,
 		TokenTypeVariable,
-		TokenTypeEnumMember,
-		TokenTypeFunction,
 	}
 	serverTokenModifiers = TokenModifiers{
-		TokenModifierDeprecated,
 		TokenModifierDefaultLibrary,
+		TokenModifierDeprecated,
 	}
 )
 


### PR DESCRIPTION
Closes #816

## Before

![Screenshot 2022-03-04 at 15 35 58](https://user-images.githubusercontent.com/287584/156793184-b7a8d8c2-ec00-444c-90f2-a5ddbc969df1.png) ![Screenshot 2022-03-04 at 15 36 10](https://user-images.githubusercontent.com/287584/156793190-3fc97b3c-49d7-4e2c-b173-a0ac1f58390d.png)


## After

![Screenshot 2022-03-04 at 15 36 31](https://user-images.githubusercontent.com/287584/156793232-d7cf8231-5499-4c6d-8e38-f906e490c7db.png) ![Screenshot 2022-03-04 at 15 36 44](https://user-images.githubusercontent.com/287584/156793233-1b07398c-1d86-4ab2-8aa9-2d7bc612184b.png)

--- 

## Related Thoughts

It is possible that we may want to replace the two tokens with something even more accurate, like `TokenTypeString`, `TokenTypeNumber`, `TokenTypeSet`, `TokenTypeList` etc. but it is currently unclear whether anyone would actually benefit from that. We can always revisit supported tokens later.

We can also see that the VSCode grammar highlights types as variables. I would say that keyword scope is more appropriate, as that leaves variable scope for HCL traversals and allows us to visually distinguish the two. i.e. We can adjust the highlighting of primitive types like `string`, `number`, `null` or `bool` in the grammar as well.