### PR TITLE
docs: remove `rootmodule` cmd from docs

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -184,5 +184,3 @@ installed version.
   }
 }
 ```
-
-### `rootmodules` (DEPRECATED, use `module.callers` instead)


### PR DESCRIPTION
Forgot to do this in https://github.com/hashicorp/terraform-ls/pull/846