### PR TITLE
Add files to ModuleMetadata

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,12 +14,12 @@ require (
 	github.com/hashicorp/go-uuid v1.0.2
 	github.com/hashicorp/go-version v1.4.0
 	github.com/hashicorp/hc-install v0.3.1
-	github.com/hashicorp/hcl-lang v0.0.0-20220316204834-49ffde67ce68
+	github.com/hashicorp/hcl-lang v0.0.0-20220406121211-c20527a75592
 	github.com/hashicorp/hcl/v2 v2.11.1
 	github.com/hashicorp/terraform-exec v0.16.0
 	github.com/hashicorp/terraform-json v0.13.0
 	github.com/hashicorp/terraform-registry-address v0.0.0-20210816115301-cb2034eba045
-	github.com/hashicorp/terraform-schema v0.0.0-20220316204916-c6585b866d6d
+	github.com/hashicorp/terraform-schema v0.0.0-20220406123003-d31af6231814
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mh-cbon/go-fmt-fail v0.0.0-20160815164508-67765b3fbcb5
 	github.com/mitchellh/cli v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -295,8 +295,8 @@ github.com/hashicorp/hc-install v0.3.1 h1:VIjllE6KyAI1A244G8kTaHXy+TL5/XYzvrtFi8
 github.com/hashicorp/hc-install v0.3.1/go.mod h1:3LCdWcCDS1gaHC9mhHCGbkYfoY6vdsKohGjugbZdZak=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/hashicorp/hcl-lang v0.0.0-20220316204834-49ffde67ce68 h1:CdUL7gJYGdJheCfAmCWNE65wimdo9YWJSqB/+NtfWPc=
-github.com/hashicorp/hcl-lang v0.0.0-20220316204834-49ffde67ce68/go.mod h1:oQgcOV8OizFyZfZh3FbQSsQtvtTv8hD23MLAxfn3E+E=
+github.com/hashicorp/hcl-lang v0.0.0-20220406121211-c20527a75592 h1:pSTtkCAbU+SLxw6J59ihqFDX5lJ9xR/fhqaOng1kQXY=
+github.com/hashicorp/hcl-lang v0.0.0-20220406121211-c20527a75592/go.mod h1:oQgcOV8OizFyZfZh3FbQSsQtvtTv8hD23MLAxfn3E+E=
 github.com/hashicorp/hcl/v2 v2.11.1 h1:yTyWcXcm9XB0TEkyU/JCRU6rYy4K+mgLtzn2wlrJbcc=
 github.com/hashicorp/hcl/v2 v2.11.1/go.mod h1:FwWsfWEjyV/CMj8s/gqAuiviY72rJ1/oayI9WftqcKg=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
@@ -313,8 +313,8 @@ github.com/hashicorp/terraform-json v0.13.0/go.mod h1:y5OdLBCT+rxbwnpxZs9kGL7R9E
 github.com/hashicorp/terraform-registry-address v0.0.0-20210412075316-9b2996cce896/go.mod h1:bzBPnUIkI0RxauU8Dqo+2KrZZ28Cf48s8V6IHt3p4co=
 github.com/hashicorp/terraform-registry-address v0.0.0-20210816115301-cb2034eba045 h1:R/I8ofvXuPcTNoc//N4ruvaHGZcShI/VuU2iXo875Lo=
 github.com/hashicorp/terraform-registry-address v0.0.0-20210816115301-cb2034eba045/go.mod h1:anRyJbe12BZscpFgaeGu9gH12qfdBP094LYFtuAFzd4=
-github.com/hashicorp/terraform-schema v0.0.0-20220316204916-c6585b866d6d h1:XLelo71INyUNDHQAWnGwsfAA5Ccj9LqtbaejBUzYKhc=
-github.com/hashicorp/terraform-schema v0.0.0-20220316204916-c6585b866d6d/go.mod h1:i0M64K9OfxlLRuFOThK1KRi9+20Y9XbyWpgPaEycbec=
+github.com/hashicorp/terraform-schema v0.0.0-20220406123003-d31af6231814 h1:os3GCpT5LVp8QRt4mEFhNWjq8d2NgXuBDmkAum4P5Pk=
+github.com/hashicorp/terraform-schema v0.0.0-20220406123003-d31af6231814/go.mod h1:DEt9BSd4/rpgLzj912KK9I6n9YbDZn4zrQVYAiUln88=
 github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734 h1:HKLsbzeOsfXmKNpr3GiT18XAblV0BjCbzL8KQAMZGa0=
 github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734/go.mod h1:kNDNcF7sN4DocDLBkQYz73HGKwN1ANB1blq4lIYLYvg=
 github.com/huandu/xstrings v1.3.2 h1:L18LIDzqlW6xN2rEkpdV8+oL/IXWJ1APd+vsdYy4Wdw=

--- a/internal/decoder/module_schema.go
+++ b/internal/decoder/module_schema.go
@@ -36,6 +36,7 @@ func schemaForModule(mod *state.Module, schemaReader state.SchemaReader, modRead
 		ProviderRequirements: mod.Meta.ProviderRequirements,
 		ProviderReferences:   mod.Meta.ProviderReferences,
 		Variables:            mod.Meta.Variables,
+		Filenames:            mod.Meta.Filenames,
 	}
 
 	return sm.SchemaForModule(meta)

--- a/internal/state/module.go
+++ b/internal/state/module.go
@@ -22,12 +22,14 @@ type ModuleMetadata struct {
 	ProviderRequirements tfmod.ProviderRequirements
 	Variables            map[string]tfmod.Variable
 	Outputs              map[string]tfmod.Output
+	Filenames            []string
 }
 
 func (mm ModuleMetadata) Copy() ModuleMetadata {
 	newMm := ModuleMetadata{
 		// version.Constraints is practically immutable once parsed
 		CoreRequirements: mm.CoreRequirements,
+		Filenames:        mm.Filenames,
 	}
 
 	if mm.Backend != nil {
@@ -336,6 +338,7 @@ func (s *ModuleStore) ModuleMeta(modPath string) (*tfmod.Meta, error) {
 		CoreRequirements:     mod.Meta.CoreRequirements,
 		Variables:            mod.Meta.Variables,
 		Outputs:              mod.Meta.Outputs,
+		Filenames:            mod.Meta.Filenames,
 	}, nil
 }
 
@@ -700,6 +703,7 @@ func (s *ModuleStore) UpdateMetadata(path string, meta *tfmod.Meta, mErr error) 
 		ProviderRequirements: meta.ProviderRequirements,
 		Variables:            meta.Variables,
 		Outputs:              meta.Outputs,
+		Filenames:            meta.Filenames,
 	}
 	mod.MetaErr = mErr
 


### PR DESCRIPTION
This PR adds a `Files` attribute to `ModuleMetadata` to complement the changes in https://github.com/hashicorp/terraform-schema/pull/101. With the changes to the earlydecoder we now keep a list of files inside a module.

Depends on https://github.com/hashicorp/terraform-schema/pull/101

Depends on https://github.com/hashicorp/hcl-lang/pull/112

Closes https://github.com/hashicorp/terraform-ls/issues/558
