### PR TITLE
fix: Ensure loading of parent directory after lower level directories works

### DIFF
--- a/internal/state/documents.go
+++ b/internal/state/documents.go
@@ -148,7 +148,7 @@ func (s *DocumentStore) CloseDocument(dh document.Handle) error {
 
 func (s *DocumentStore) ListDocumentsInDir(dirHandle document.DirHandle) ([]*document.Document, error) {
 	txn := s.db.Txn(false)
-	it, err := txn.Get(s.tableName, "id_prefix", dirHandle)
+	it, err := txn.Get(s.tableName, "dir", dirHandle)
 	if err != nil {
 		return nil, err
 	}
@@ -176,7 +176,7 @@ func (s *DocumentStore) IsDocumentOpen(dh document.Handle) (bool, error) {
 func (s *DocumentStore) HasOpenDocuments(dirHandle document.DirHandle) (bool, error) {
 	txn := s.db.Txn(false)
 
-	obj, err := txn.First(s.tableName, "id_prefix", dirHandle)
+	obj, err := txn.First(s.tableName, "dir", dirHandle)
 	if err != nil {
 		return false, err
 	}

--- a/internal/state/jobs.go
+++ b/internal/state/jobs.go
@@ -335,7 +335,7 @@ func (js *JobStore) FinishJob(id job.ID, jobErr error, deferredJobIds ...job.ID)
 		return fmt.Errorf("failed to copy a job: %w", err)
 	}
 
-	js.logger.Printf("JOBS: Finishing job %q: %q for %q (err = %#v, deferredJobs: %q)",
+	js.logger.Printf("JOBS: Finishing job %q: %q for %q (err = %s, deferredJobs: %q)",
 		sj.ID, sj.Type, sj.Dir, jobErr, deferredJobIds)
 
 	_, err = txn.DeleteAll(js.tableName, "id", id)

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -38,6 +38,10 @@ var dbSchema = &memdb.DBSchema{
 						},
 					},
 				},
+				"dir": {
+					Name:    "dir",
+					Indexer: &DirHandleFieldIndexer{Field: "Dir"},
+				},
 			},
 		},
 		jobsTableName: {


### PR DESCRIPTION
## Background

Previously if a nested directory/module was opened, kept open, and a parent directory was then opened, that parent directory would fail to load, resulting in `file not found` errors in the log and causing all IntelliSense for the parent to not be available.

The bug was introduced as part of https://github.com/hashicorp/terraform-ls/pull/771 (i.e. affects 0.26.0+)

## Before
![2022-04-06 09 47 22](https://user-images.githubusercontent.com/287584/161935057-fb5f28b5-2ce8-4af8-9a03-82cfee962ecf.gif)

## After
![2022-04-06 09 46 37](https://user-images.githubusercontent.com/287584/161935012-29e021e7-98b9-4cc5-8a93-95496ad45c98.gif)

