### PR TITLE
schemas/gen: exclude delphix-integrations/delphix

### DIFF
--- a/internal/schemas/gen/gen.go
+++ b/internal/schemas/gen/gen.go
@@ -245,15 +245,16 @@ func listProviders(tier string) ([]provider, error) {
 }
 
 var ignore = map[string]bool{
-	"a10networks/vthunder":    true,
-	"harness-io/harness":      true,
-	"HewlettPackard/oneview":  true,
-	"HewlettPackard/hpegl":    true,
-	"jradtilbrook/buildkite":  true,
-	"kvrhdn/honeycombio":      true,
-	"ThalesGroup/ciphertrust": true,
-	"nullstone-io/ns":         true,
-	"zededa/zedcloud":         true,
+	"a10networks/vthunder":         true,
+	"delphix-integrations/delphix": true,
+	"harness-io/harness":           true,
+	"HewlettPackard/oneview":       true,
+	"HewlettPackard/hpegl":         true,
+	"jradtilbrook/buildkite":       true,
+	"kvrhdn/honeycombio":           true,
+	"ThalesGroup/ciphertrust":      true,
+	"nullstone-io/ns":              true,
+	"zededa/zedcloud":              true,
 }
 
 func filter(providers []provider) (filtered []provider) {


### PR DESCRIPTION
This is to address the fact delphix-integrations/delphix only has pre-releases at the moment, resulting in `init` failures:

```
Error: Failed to query available provider packages

Could not retrieve the list of available versions for provider
delphix-integrations/delphix: no available releases match the given
constraints 
```