### PR TITLE
github: Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @hashicorp/tf-editor-experience


### PR DESCRIPTION
Similar to https://github.com/hashicorp/vscode-terraform/pull/1038

> This will automatically add the TF Editor Experience group as reviewer to all pull requests that are marked ready for review.

More docs at https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners