### PR TITLE
ci: bump google-network & awk-eks benchmark thresholds

### DIFF
--- a/.github/gobenchdata-checks.yml
+++ b/.github/gobenchdata-checks.yml
@@ -61,7 +61,7 @@ checks:
   diff: current.NsPerOp / 1000000 # ms
   thresholds:
     min: 1430
-    max: 2470
+    max: 2700
 - package: ./internal/langserver/handlers
   name: google-gke
   benchmarks: [BenchmarkInitializeFolder_basic/google-gke]

--- a/.github/gobenchdata-checks.yml
+++ b/.github/gobenchdata-checks.yml
@@ -40,7 +40,7 @@ checks:
   diff: current.NsPerOp / 1000000 # ms
   thresholds:
     min: 1570
-    max: 2500
+    max: 2900
 - package: ./internal/langserver/handlers
   name: aws-vpc
   benchmarks: [BenchmarkInitializeFolder_basic/aws-vpc]


### PR DESCRIPTION
This is to address the recent nightly failures:

```json
{
  "Status": "fail",
  "Diffs": [
    {
      "Status": "fail",
      "Package": "github.com/hashicorp/terraform-ls/internal/langserver/handlers",
      "Benchmark": "BenchmarkInitializeFolder_basic/google-network-2",
      "Value": 2622.730844
    }
  ],
  "Thresholds": {
    "Min": 1430,
    "Max": 2470
  }
}
```
https://github.com/hashicorp/terraform-ls/runs/5879240603?check_suite_focus=true#step:9:1

```json
{
  "Status": "fail",
  "Diffs": [
    {
      "Status": "fail",
      "Package": "github.com/hashicorp/terraform-ls/internal/langserver/handlers",
      "Benchmark": "BenchmarkInitializeFolder_basic/aws-eks-2",
      "Value": 2874.628341
    }
  ],
  "Thresholds": {
    "Min": 1570,
    "Max": 2500
  }
}
```

https://github.com/hashicorp/terraform-ls/runs/5965803013?check_suite_focus=true#step:9:1