### PR TITLE
ci: reduce min threshold for k8s-metrics-server benchmark

### DIFF
--- a/.github/gobenchdata-checks.yml
+++ b/.github/gobenchdata-checks.yml
@@ -74,7 +74,7 @@ checks:
   benchmarks: [BenchmarkInitializeFolder_basic/k8s-metrics-server]
   diff: current.NsPerOp / 1000000 # ms
   thresholds:
-    min: 1060
+    min: 1000
     max: 2800
 - package: ./internal/langserver/handlers
   name: k8s-dashboard


### PR DESCRIPTION
This is to address the following nightly failure:

https://github.com/hashicorp/terraform-ls/runs/5983427527?check_suite_focus=true#step:9:1

```json
{
  "Status": "fail",
  "Diffs": [
    {
      "Status": "fail",
      "Package": "github.com/hashicorp/terraform-ls/internal/langserver/handlers",
      "Benchmark": "BenchmarkInitializeFolder_basic/k8s-metrics-server-2",
      "Value": 1057.225971
    }
  ],
  "Thresholds": {
    "Min": 1060,
    "Max": 2800
  }
}
```