### PR TITLE
Fix module calls command for remote modules

### DIFF
--- a/internal/langserver/handlers/command/module_calls.go
+++ b/internal/langserver/handlers/command/module_calls.go
@@ -129,5 +129,6 @@ func getModuleDocumentationLink(record datadir.ModuleRecord) string {
 		return ""
 	}
 
-	return fmt.Sprintf(`https://registry.terraform.io/modules/%s/%s`, record.SourceAddr, record.VersionStr)
+	shortName := strings.TrimPrefix(record.SourceAddr, "registry.terraform.io/")
+	return fmt.Sprintf(`https://registry.terraform.io/modules/%s/%s`, shortName, record.VersionStr)
 }

--- a/internal/langserver/handlers/command/module_calls_test.go
+++ b/internal/langserver/handlers/command/module_calls_test.go
@@ -18,7 +18,7 @@ func Test_parseModuleRecords(t *testing.T) {
 			records: []datadir.ModuleRecord{
 				{
 					Key:        "ec2_instances",
-					SourceAddr: "registry.terraform.io/terraform-aws-modules/ec2-instance/aws",
+					SourceAddr: "terraform-aws-modules/ec2-instance/aws",
 					VersionStr: "2.12.0",
 					Dir:        ".terraform\\modules\\ec2_instances",
 				},
@@ -44,7 +44,7 @@ func Test_parseModuleRecords(t *testing.T) {
 			want: []moduleCall{
 				{
 					Name:             "ec2_instances",
-					SourceAddr:       "registry.terraform.io/terraform-aws-modules/ec2-instance/aws",
+					SourceAddr:       "terraform-aws-modules/ec2-instance/aws",
 					Version:          "2.12.0",
 					SourceType:       "tfregistry",
 					DocsLink:         "https://registry.terraform.io/modules/terraform-aws-modules/ec2-instance/aws/2.12.0",
@@ -73,6 +73,45 @@ func Test_parseModuleRecords(t *testing.T) {
 					Version:          "",
 					SourceType:       "github",
 					DocsLink:         "",
+					DependentModules: []moduleCall{},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseModuleRecords(tt.records)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Fatalf("module mismatch: %s", diff)
+			}
+		})
+	}
+}
+
+// With the release of Terraform 1.1.0 module source addresses are now stored normalized
+func Test_parseModuleRecords_v1_1(t *testing.T) {
+	tests := []struct {
+		name    string
+		records []datadir.ModuleRecord
+		want    []moduleCall
+	}{
+		{
+			name: "detects terraform module types",
+			records: []datadir.ModuleRecord{
+				{
+					Key:        "ec2_instances",
+					SourceAddr: "registry.terraform.io/terraform-aws-modules/ec2-instance/aws",
+					VersionStr: "2.12.0",
+					Dir:        ".terraform\\modules\\ec2_instances",
+				},
+			},
+			want: []moduleCall{
+				{
+					Name:             "ec2_instances",
+					SourceAddr:       "registry.terraform.io/terraform-aws-modules/ec2-instance/aws",
+					Version:          "2.12.0",
+					SourceType:       "tfregistry",
+					DocsLink:         "https://registry.terraform.io/modules/terraform-aws-modules/ec2-instance/aws/2.12.0",
 					DependentModules: []moduleCall{},
 				},
 			},

--- a/internal/langserver/handlers/command/module_calls_test.go
+++ b/internal/langserver/handlers/command/module_calls_test.go
@@ -18,7 +18,7 @@ func Test_parseModuleRecords(t *testing.T) {
 			records: []datadir.ModuleRecord{
 				{
 					Key:        "ec2_instances",
-					SourceAddr: "terraform-aws-modules/ec2-instance/aws",
+					SourceAddr: "registry.terraform.io/terraform-aws-modules/ec2-instance/aws",
 					VersionStr: "2.12.0",
 					Dir:        ".terraform\\modules\\ec2_instances",
 				},
@@ -30,7 +30,7 @@ func Test_parseModuleRecords(t *testing.T) {
 				},
 				{
 					Key:        "eks",
-					SourceAddr: "terraform-aws-modules/eks/aws",
+					SourceAddr: "registry.terraform.io/terraform-aws-modules/eks/aws",
 					VersionStr: "17.20.0",
 					Dir:        ".terraform\\modules\\eks",
 				},
@@ -44,7 +44,7 @@ func Test_parseModuleRecords(t *testing.T) {
 			want: []moduleCall{
 				{
 					Name:             "ec2_instances",
-					SourceAddr:       "terraform-aws-modules/ec2-instance/aws",
+					SourceAddr:       "registry.terraform.io/terraform-aws-modules/ec2-instance/aws",
 					Version:          "2.12.0",
 					SourceType:       "tfregistry",
 					DocsLink:         "https://registry.terraform.io/modules/terraform-aws-modules/ec2-instance/aws/2.12.0",
@@ -52,7 +52,7 @@ func Test_parseModuleRecords(t *testing.T) {
 				},
 				{
 					Name:       "eks",
-					SourceAddr: "terraform-aws-modules/eks/aws",
+					SourceAddr: "registry.terraform.io/terraform-aws-modules/eks/aws",
 					Version:    "17.20.0",
 					SourceType: "tfregistry",
 					DocsLink:   "https://registry.terraform.io/modules/terraform-aws-modules/eks/aws/17.20.0",

--- a/internal/langserver/handlers/command/module_calls_test.go
+++ b/internal/langserver/handlers/command/module_calls_test.go
@@ -30,7 +30,7 @@ func Test_parseModuleRecords(t *testing.T) {
 				},
 				{
 					Key:        "eks",
-					SourceAddr: "registry.terraform.io/terraform-aws-modules/eks/aws",
+					SourceAddr: "terraform-aws-modules/eks/aws",
 					VersionStr: "17.20.0",
 					Dir:        ".terraform\\modules\\eks",
 				},
@@ -52,7 +52,7 @@ func Test_parseModuleRecords(t *testing.T) {
 				},
 				{
 					Name:       "eks",
-					SourceAddr: "registry.terraform.io/terraform-aws-modules/eks/aws",
+					SourceAddr: "terraform-aws-modules/eks/aws",
 					Version:    "17.20.0",
 					SourceType: "tfregistry",
 					DocsLink:   "https://registry.terraform.io/modules/terraform-aws-modules/eks/aws/17.20.0",

--- a/internal/terraform/datadir/module_types.go
+++ b/internal/terraform/datadir/module_types.go
@@ -2,8 +2,6 @@ package datadir
 
 import (
 	"strings"
-
-	tfregistry "github.com/hashicorp/terraform-registry-address"
 )
 
 type ModuleType string
@@ -27,14 +25,8 @@ var moduleSourceLocalPrefixes = []string{
 // from. It currently supports detecting Terraform Registry modules, GitHub modules, Git modules, and
 // local file paths
 func (r *ModuleRecord) GetModuleType() ModuleType {
-	// TODO: It is technically incorrect to use the package hashicorp/terraform-registry-address
-	// here as it is written to parse Terraform provider addresses and may not work correctly on
-	// Terraform module addresses. The proper approach is to create a new parsing library that is
-	// dedicated to parsing these kinds of addresses correctly, by re-using the logic defined in
-	// the authorative source: hashicorp/terraform/internal/addrs/module_source.go.
-	// However this works enough for now to identify module types for display in vscode-terraform.
-	// Example: terraform-aws-modules/ec2-instance/aws
-	if _, err := tfregistry.ParseRawProviderSourceString(r.SourceAddr); err == nil {
+	// Example: registry.terraform.io/terraform-aws-modules/vpc/aws
+	if strings.HasPrefix(r.SourceAddr, "registry.terraform.io/") {
 		return TFREGISTRY
 	}
 

--- a/internal/terraform/datadir/module_types.go
+++ b/internal/terraform/datadir/module_types.go
@@ -2,6 +2,8 @@ package datadir
 
 import (
 	"strings"
+
+	tfregistry "github.com/hashicorp/terraform-registry-address"
 )
 
 type ModuleType string
@@ -25,8 +27,16 @@ var moduleSourceLocalPrefixes = []string{
 // from. It currently supports detecting Terraform Registry modules, GitHub modules, Git modules, and
 // local file paths
 func (r *ModuleRecord) GetModuleType() ModuleType {
+	// TODO: It is technically incorrect to use the package hashicorp/terraform-registry-address
+	// here as it is written to parse Terraform provider addresses and may not work correctly on
+	// Terraform module addresses. The proper approach is to create a new parsing library that is
+	// dedicated to parsing these kinds of addresses correctly, by re-using the logic defined in
+	// the authorative source: hashicorp/terraform/internal/addrs/module_source.go.
+	// However this works enough for now to identify module types for display in vscode-terraform.
+	// Example: terraform-aws-modules/ec2-instance/aws
+	_, err := tfregistry.ParseRawProviderSourceString(r.SourceAddr)
 	// Example: registry.terraform.io/terraform-aws-modules/vpc/aws
-	if strings.HasPrefix(r.SourceAddr, "registry.terraform.io/") {
+	if err == nil || strings.HasPrefix(r.SourceAddr, "registry.terraform.io/") {
 		return TFREGISTRY
 	}
 


### PR DESCRIPTION
With the release of [Terraform 1.1.0](https://github.com/hashicorp/terraform/blob/v1.1/CHANGELOG.md#110-december-08-2021) module source addresses are now stored normalized:
> config: Terraform now checks the syntax of and normalizes module source addresses (the source argument in module blocks) during configuration decoding rather than only at module installation time. This is largely just an internal refactoring, but a visible benefit of this change is that the terraform init messages about module downloading will now show the canonical module package address Terraform is downloading from, after interpreting the special shorthands for common cases like GitHub URLs. (https://github.com/hashicorp/terraform/issues/28854)

---

With this change it's not possible anymore to identify remote modules using [`ParseRawProviderSourceString`](https://github.com/hashicorp/terraform-registry-address/blob/5c1c5e1232758d4464405be43fcfdca66fa66318/provider.go#L233).

This PR updates the module source detection for remote modules and with this reenables 'Open Documentation' and displays the correct icon in the extension UI.

## Before

```
2022/04/13 14:58:51 rpc_logger.go:50: Response to "workspace/executeCommand" (ID 73): {"v":0,"module_calls":[{"name":"vpc","source_addr":"registry.terraform.io/terraform-aws-modules/vpc/aws","version":"3.14.0","source_type":"unknown","dependent_modules":[]}]}
```

## After

```
2022/04/13 15:05:19 rpc_logger.go:50: Response to "workspace/executeCommand" (ID 11): {"v":0,"module_calls":[{"name":"vpc","source_addr":"registry.terraform.io/terraform-aws-modules/vpc/aws","version":"3.14.0","source_type":"tfregistry","docs_link":"https://registry.terraform.io/modules/terraform-aws-modules/vpc/aws/3.14.0","dependent_modules":[]}]}
```