### PR TITLE
Add version to module calls

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,12 +14,12 @@ require (
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/go-version v1.4.0
 	github.com/hashicorp/hc-install v0.3.1
-	github.com/hashicorp/hcl-lang v0.0.0-20220406121211-c20527a75592
+	github.com/hashicorp/hcl-lang v0.0.0-20220421093840-480fdfd2ecb5
 	github.com/hashicorp/hcl/v2 v2.12.0
 	github.com/hashicorp/terraform-exec v0.16.1
 	github.com/hashicorp/terraform-json v0.13.0
 	github.com/hashicorp/terraform-registry-address v0.0.0-20220422093245-eb7bcc2ff473
-	github.com/hashicorp/terraform-schema v0.0.0-20220406123003-d31af6231814
+	github.com/hashicorp/terraform-schema v0.0.0-20220425141842-cda625299dc9
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mh-cbon/go-fmt-fail v0.0.0-20160815164508-67765b3fbcb5
 	github.com/mitchellh/cli v1.1.3

--- a/go.sum
+++ b/go.sum
@@ -306,8 +306,8 @@ github.com/hashicorp/hc-install v0.3.1 h1:VIjllE6KyAI1A244G8kTaHXy+TL5/XYzvrtFi8
 github.com/hashicorp/hc-install v0.3.1/go.mod h1:3LCdWcCDS1gaHC9mhHCGbkYfoY6vdsKohGjugbZdZak=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/hashicorp/hcl-lang v0.0.0-20220406121211-c20527a75592 h1:pSTtkCAbU+SLxw6J59ihqFDX5lJ9xR/fhqaOng1kQXY=
-github.com/hashicorp/hcl-lang v0.0.0-20220406121211-c20527a75592/go.mod h1:oQgcOV8OizFyZfZh3FbQSsQtvtTv8hD23MLAxfn3E+E=
+github.com/hashicorp/hcl-lang v0.0.0-20220421093840-480fdfd2ecb5 h1:A18R+0Emk5YuXo22u44wxwHAnNHLDK6NHxXl2CIQGlU=
+github.com/hashicorp/hcl-lang v0.0.0-20220421093840-480fdfd2ecb5/go.mod h1:oQgcOV8OizFyZfZh3FbQSsQtvtTv8hD23MLAxfn3E+E=
 github.com/hashicorp/hcl/v2 v2.11.1/go.mod h1:FwWsfWEjyV/CMj8s/gqAuiviY72rJ1/oayI9WftqcKg=
 github.com/hashicorp/hcl/v2 v2.12.0 h1:PsYxySWpMD4KPaoJLnsHwtK5Qptvj/4Q6s0t4sUxZf4=
 github.com/hashicorp/hcl/v2 v2.12.0/go.mod h1:FwWsfWEjyV/CMj8s/gqAuiviY72rJ1/oayI9WftqcKg=
@@ -322,11 +322,10 @@ github.com/hashicorp/terraform-exec v0.16.1 h1:NAwZFJW2L2SaCBVZoVaH8LPImLOGbPLkS
 github.com/hashicorp/terraform-exec v0.16.1/go.mod h1:aj0lVshy8l+MHhFNoijNHtqTJQI3Xlowv5EOsEaGO7M=
 github.com/hashicorp/terraform-json v0.13.0 h1:Li9L+lKD1FO5RVFRM1mMMIBDoUHslOniyEi5CM+FWGY=
 github.com/hashicorp/terraform-json v0.13.0/go.mod h1:y5OdLBCT+rxbwnpxZs9kGL7R9ExU76+cpdY8zHwoazk=
-github.com/hashicorp/terraform-registry-address v0.0.0-20210412075316-9b2996cce896/go.mod h1:bzBPnUIkI0RxauU8Dqo+2KrZZ28Cf48s8V6IHt3p4co=
 github.com/hashicorp/terraform-registry-address v0.0.0-20220422093245-eb7bcc2ff473 h1:Vp3YMcnM+TvVMV5TplAhGeuzz3A0562AywL32y71y3Y=
 github.com/hashicorp/terraform-registry-address v0.0.0-20220422093245-eb7bcc2ff473/go.mod h1:bdLC+qQlJIBHKbCMA6GipcuaKjmjcvZlnVdpU583z3Y=
-github.com/hashicorp/terraform-schema v0.0.0-20220406123003-d31af6231814 h1:os3GCpT5LVp8QRt4mEFhNWjq8d2NgXuBDmkAum4P5Pk=
-github.com/hashicorp/terraform-schema v0.0.0-20220406123003-d31af6231814/go.mod h1:DEt9BSd4/rpgLzj912KK9I6n9YbDZn4zrQVYAiUln88=
+github.com/hashicorp/terraform-schema v0.0.0-20220425141842-cda625299dc9 h1:lnwLYkgs6ot8QCcoLodn50IjjV0yG/vGeZDVMCVBwp0=
+github.com/hashicorp/terraform-schema v0.0.0-20220425141842-cda625299dc9/go.mod h1:R6g3l4kOXPSYVNIKt330PHRXmjVqmI2PEITTBZeGtrk=
 github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734 h1:HKLsbzeOsfXmKNpr3GiT18XAblV0BjCbzL8KQAMZGa0=
 github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734/go.mod h1:kNDNcF7sN4DocDLBkQYz73HGKwN1ANB1blq4lIYLYvg=
 github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=

--- a/internal/state/module.go
+++ b/internal/state/module.go
@@ -318,6 +318,7 @@ func (s *ModuleStore) ModuleCalls(modPath string) ([]tfmod.ModuleCall, error) {
 				result = append(result, tfmod.ModuleCall{
 					LocalName:  record.Key,
 					SourceAddr: record.SourceAddr,
+					Version:    record.VersionStr,
 					Path:       filepath.Join(modPath, record.Dir),
 				})
 			}


### PR DESCRIPTION
Depends on 
* https://github.com/hashicorp/hcl-lang/pull/115
* https://github.com/hashicorp/terraform-schema/pull/103

This PR populates the version field for `ModuleCall` and pulls in the latest `terraform-schema` and `hcl-lang` changes.

All this enables linking the source attribute for remote modules to the documentation.