### PR TITLE
schemas: Exclude harness/harness-platform from embedding

### DIFF
--- a/internal/schemas/gen/gen.go
+++ b/internal/schemas/gen/gen.go
@@ -248,6 +248,7 @@ var ignore = map[string]bool{
 	"a10networks/vthunder":         true,
 	"delphix-integrations/delphix": true,
 	"harness-io/harness":           true,
+	"harness/harness-platform":     true,
 	"HewlettPackard/oneview":       true,
 	"HewlettPackard/hpegl":         true,
 	"jradtilbrook/buildkite":       true,


### PR DESCRIPTION
Looks like that provider was published but artifacts remain unavailable because the repo is private

```
Error while installing harness/harness-platform v0.0.4: could not query
provider registry for registry.terraform.io/harness/harness-platform: failed
to retrieve authentication checksums for provider: 404 Not Found
```
