### PR TITLE
Fix corrupted diffs in formatting responses

### DIFF
--- a/internal/hcl/diff.go
+++ b/internal/hcl/diff.go
@@ -62,12 +62,14 @@ func diffLines(filename string, beforeLines, afterLines source.Lines) document.C
 
 	for _, group := range m.GetGroupedOpCodes(context) {
 		for _, c := range group {
-			beforeStart, beforeEnd := c.I1, c.I2
-			afterStart, afterEnd := c.J1, c.J2
-
 			if c.Tag == OpEqual {
 				continue
 			}
+
+			// lines to pick from the original document (to delete/replace/insert to)
+			beforeStart, beforeEnd := c.I1, c.I2
+			// lines to pick from the new document (to replace ^ with)
+			afterStart, afterEnd := c.J1, c.J2
 
 			if c.Tag == OpReplace {
 				var rng *hcl.Range
@@ -121,6 +123,10 @@ func diffLines(filename string, beforeLines, afterLines source.Lines) document.C
 				if beforeStart == beforeEnd {
 					line := beforeLines[beforeStart]
 					insertRng = line.Range.Ptr()
+
+					// We're inserting to the beginning of the line
+					// which we represent as 0-length range in HCL
+					insertRng.End = insertRng.Start
 				} else {
 					for i, line := range beforeLines[beforeStart:beforeEnd] {
 						if i == 0 {

--- a/internal/hcl/diff_test.go
+++ b/internal/hcl/diff_test.go
@@ -179,6 +179,43 @@ ccc`,
 			},
 		},
 		{
+			name: "insertion to existing line",
+			beforeCfg: `resource "aws_lambda_function" "f" {
+    environment {
+        variables = {
+            a = "b"
+        }
+    }
+}
+`,
+			afterCfg: `resource "aws_lambda_function" "f" {
+  environment {
+    variables = {
+      a = "b"
+    }
+  }
+}
+`,
+			expectedChanges: document.Changes{
+				&fileChange{
+					newText: "  environment {\n    variables = {\n      a = \"b\"\n",
+					rng: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 1, Byte: 37},
+						End:      hcl.Pos{Line: 6, Column: 1, Byte: 107},
+					},
+				},
+				&fileChange{
+					newText: "  }\n",
+					rng: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 7, Column: 1, Byte: 113},
+						End:      hcl.Pos{Line: 7, Column: 1, Byte: 113},
+					},
+				},
+			},
+		},
+		{
 			"empty to newline",
 			``,
 			`


### PR DESCRIPTION
Fixes #793

The diff may be confusing to understand but here's another representation of it, confirming the upstream library works pretty much as expected:

```diff
--- test.tf
+++ test.tf
@@ -1,8 +1,8 @@
 resource "aws_lambda_function" "f" {
-    environment {
-        variables = {
-            a = "b"
-        }
+  environment {
+    variables = {
+      a = "b"
     }
+  }
 }

```

Perhaps the algorithm could have joined the two hunks into one, but the result would be pretty much the same.