### PR TITLE
ci: adjust benchmarks

### DIFF
--- a/.github/gobenchdata-checks.yml
+++ b/.github/gobenchdata-checks.yml
@@ -4,7 +4,7 @@ checks:
   benchmarks: [BenchmarkInitializeFolder_basic/local-single-module-no-provider]
   diff: current.NsPerOp / 1000000 # ms
   thresholds:
-    min: 29
+    min: 25
     max: 55
 - package: ./internal/langserver/handlers
   name: local-single-submodule-no-provider

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   benchmarks:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       -
         name: Checkout


### PR DESCRIPTION
To address some recent failures and cancellations:

```json
{
  "Status": "fail",
  "Diffs": [
    {
      "Status": "fail",
      "Package": "github.com/hashicorp/terraform-ls/internal/langserver/handlers",
      "Benchmark": "BenchmarkInitializeFolder_basic/local-single-module-no-provider-2",
      "Value": 28.653373
    }
  ],
  "Thresholds": {
    "Min": 29,
    "Max": 55
  }
}
```
https://github.com/hashicorp/terraform-ls/runs/6051484898?check_suite_focus=true

https://github.com/hashicorp/terraform-ls/runs/6071802295?check_suite_focus=true