### PR TITLE
ci: adjust min & max for benchmarks

### DIFF
--- a/.github/gobenchdata-checks.yml
+++ b/.github/gobenchdata-checks.yml
@@ -11,14 +11,14 @@ checks:
   benchmarks: [BenchmarkInitializeFolder_basic/local-single-submodule-no-provider]
   diff: current.NsPerOp / 1000000 # ms
   thresholds:
-    min: 185
+    min: 150
     max: 310
 - package: ./internal/langserver/handlers
   name: local-single-module-random
   benchmarks: [BenchmarkInitializeFolder_basic/local-single-module-random]
   diff: current.NsPerOp / 1000000 # ms
   thresholds:
-    min: 180
+    min: 150
     max: 300
 - package: ./internal/langserver/handlers
   name: local-single-module-aws
@@ -40,7 +40,7 @@ checks:
   diff: current.NsPerOp / 1000000 # ms
   thresholds:
     min: 1570
-    max: 2900
+    max: 3000
 - package: ./internal/langserver/handlers
   name: aws-vpc
   benchmarks: [BenchmarkInitializeFolder_basic/aws-vpc]


### PR DESCRIPTION
This is to address the following benchmark threshold failures:

```json
{ "Status": "fail", "Diffs": [ { "Status": "fail", "Package": "github.com/hashicorp/terraform-ls/internal/langserver/handlers", "Benchmark": "BenchmarkInitializeFolder_basic/aws-eks-2", "Value": 2942.189635 } ], "Thresholds": { "Min": 1570, "Max": 2900 } }
{ "Status": "fail", "Diffs": [ { "Status": "fail", "Package": "github.com/hashicorp/terraform-ls/internal/langserver/handlers", "Benchmark": "BenchmarkInitializeFolder_basic/local-single-module-random-2", "Value": 171.50729 } ], "Thresholds": { "Min": 180, "Max": 300 } }
{ "Status": "fail", "Diffs": [ { "Status": "fail", "Package": "github.com/hashicorp/terraform-ls/internal/langserver/handlers", "Benchmark": "BenchmarkInitializeFolder_basic/local-single-submodule-no-provider-2", "Value": 174.706908 } ], "Thresholds": { "Min": 185, "Max": 310 } }
```