### PR TITLE
Use terraform-registry-address for parsing module sources

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/hashicorp/hcl/v2 v2.12.0
 	github.com/hashicorp/terraform-exec v0.16.1
 	github.com/hashicorp/terraform-json v0.13.0
-	github.com/hashicorp/terraform-registry-address v0.0.0-20210816115301-cb2034eba045
+	github.com/hashicorp/terraform-registry-address v0.0.0-20220422093245-eb7bcc2ff473
 	github.com/hashicorp/terraform-schema v0.0.0-20220406123003-d31af6231814
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mh-cbon/go-fmt-fail v0.0.0-20160815164508-67765b3fbcb5

--- a/go.sum
+++ b/go.sum
@@ -323,8 +323,8 @@ github.com/hashicorp/terraform-exec v0.16.1/go.mod h1:aj0lVshy8l+MHhFNoijNHtqTJQ
 github.com/hashicorp/terraform-json v0.13.0 h1:Li9L+lKD1FO5RVFRM1mMMIBDoUHslOniyEi5CM+FWGY=
 github.com/hashicorp/terraform-json v0.13.0/go.mod h1:y5OdLBCT+rxbwnpxZs9kGL7R9ExU76+cpdY8zHwoazk=
 github.com/hashicorp/terraform-registry-address v0.0.0-20210412075316-9b2996cce896/go.mod h1:bzBPnUIkI0RxauU8Dqo+2KrZZ28Cf48s8V6IHt3p4co=
-github.com/hashicorp/terraform-registry-address v0.0.0-20210816115301-cb2034eba045 h1:R/I8ofvXuPcTNoc//N4ruvaHGZcShI/VuU2iXo875Lo=
-github.com/hashicorp/terraform-registry-address v0.0.0-20210816115301-cb2034eba045/go.mod h1:anRyJbe12BZscpFgaeGu9gH12qfdBP094LYFtuAFzd4=
+github.com/hashicorp/terraform-registry-address v0.0.0-20220422093245-eb7bcc2ff473 h1:Vp3YMcnM+TvVMV5TplAhGeuzz3A0562AywL32y71y3Y=
+github.com/hashicorp/terraform-registry-address v0.0.0-20220422093245-eb7bcc2ff473/go.mod h1:bdLC+qQlJIBHKbCMA6GipcuaKjmjcvZlnVdpU583z3Y=
 github.com/hashicorp/terraform-schema v0.0.0-20220406123003-d31af6231814 h1:os3GCpT5LVp8QRt4mEFhNWjq8d2NgXuBDmkAum4P5Pk=
 github.com/hashicorp/terraform-schema v0.0.0-20220406123003-d31af6231814/go.mod h1:DEt9BSd4/rpgLzj912KK9I6n9YbDZn4zrQVYAiUln88=
 github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734 h1:HKLsbzeOsfXmKNpr3GiT18XAblV0BjCbzL8KQAMZGa0=

--- a/internal/terraform/datadir/module_types.go
+++ b/internal/terraform/datadir/module_types.go
@@ -3,7 +3,7 @@ package datadir
 import (
 	"strings"
 
-	tfregistry "github.com/hashicorp/terraform-registry-address"
+	tfaddr "github.com/hashicorp/terraform-registry-address"
 )
 
 type ModuleType string
@@ -27,16 +27,10 @@ var moduleSourceLocalPrefixes = []string{
 // from. It currently supports detecting Terraform Registry modules, GitHub modules, Git modules, and
 // local file paths
 func (r *ModuleRecord) GetModuleType() ModuleType {
-	// TODO: It is technically incorrect to use the package hashicorp/terraform-registry-address
-	// here as it is written to parse Terraform provider addresses and may not work correctly on
-	// Terraform module addresses. The proper approach is to create a new parsing library that is
-	// dedicated to parsing these kinds of addresses correctly, by re-using the logic defined in
-	// the authorative source: hashicorp/terraform/internal/addrs/module_source.go.
-	// However this works enough for now to identify module types for display in vscode-terraform.
 	// Example: terraform-aws-modules/ec2-instance/aws
-	_, err := tfregistry.ParseRawProviderSourceString(r.SourceAddr)
 	// Example: registry.terraform.io/terraform-aws-modules/vpc/aws
-	if err == nil || strings.HasPrefix(r.SourceAddr, "registry.terraform.io/") {
+	moduleSourceRegistry, err := tfaddr.ParseRawModuleSourceRegistry(r.SourceAddr)
+	if err == nil && moduleSourceRegistry.PackageAddr.Host == "registry.terraform.io" {
 		return TFREGISTRY
 	}
 


### PR DESCRIPTION
This PR uses the [latest additions to terraform-registry-address](https://github.com/hashicorp/terraform-registry-address/pull/7) to detect the source of a module.

Related: https://github.com/hashicorp/terraform-ls/pull/872