### PR TITLE
Decode module calls (for uninitialized modules)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/hashicorp/terraform-exec v0.16.1
 	github.com/hashicorp/terraform-json v0.13.0
 	github.com/hashicorp/terraform-registry-address v0.0.0-20220422093245-eb7bcc2ff473
-	github.com/hashicorp/terraform-schema v0.0.0-20220503104102-49d5d60cc80c
+	github.com/hashicorp/terraform-schema v0.0.0-20220509053855-1e3acbcfd531
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mh-cbon/go-fmt-fail v0.0.0-20160815164508-67765b3fbcb5
 	github.com/mitchellh/cli v1.1.3

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/hashicorp/terraform-exec v0.16.1
 	github.com/hashicorp/terraform-json v0.13.0
 	github.com/hashicorp/terraform-registry-address v0.0.0-20220422093245-eb7bcc2ff473
-	github.com/hashicorp/terraform-schema v0.0.0-20220425141842-cda625299dc9
+	github.com/hashicorp/terraform-schema v0.0.0-20220503104102-49d5d60cc80c
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mh-cbon/go-fmt-fail v0.0.0-20160815164508-67765b3fbcb5
 	github.com/mitchellh/cli v1.1.3

--- a/go.sum
+++ b/go.sum
@@ -326,8 +326,8 @@ github.com/hashicorp/terraform-json v0.13.0 h1:Li9L+lKD1FO5RVFRM1mMMIBDoUHslOniy
 github.com/hashicorp/terraform-json v0.13.0/go.mod h1:y5OdLBCT+rxbwnpxZs9kGL7R9ExU76+cpdY8zHwoazk=
 github.com/hashicorp/terraform-registry-address v0.0.0-20220422093245-eb7bcc2ff473 h1:Vp3YMcnM+TvVMV5TplAhGeuzz3A0562AywL32y71y3Y=
 github.com/hashicorp/terraform-registry-address v0.0.0-20220422093245-eb7bcc2ff473/go.mod h1:bdLC+qQlJIBHKbCMA6GipcuaKjmjcvZlnVdpU583z3Y=
-github.com/hashicorp/terraform-schema v0.0.0-20220425141842-cda625299dc9 h1:lnwLYkgs6ot8QCcoLodn50IjjV0yG/vGeZDVMCVBwp0=
-github.com/hashicorp/terraform-schema v0.0.0-20220425141842-cda625299dc9/go.mod h1:R6g3l4kOXPSYVNIKt330PHRXmjVqmI2PEITTBZeGtrk=
+github.com/hashicorp/terraform-schema v0.0.0-20220503104102-49d5d60cc80c h1:NM46aa8KFyfFdG1ceVQvzzp6O9o2wZ7ir1mhx/3WGt8=
+github.com/hashicorp/terraform-schema v0.0.0-20220503104102-49d5d60cc80c/go.mod h1:rLQP6aOmOcA+C68h3Ea7utboW/UWwgn5m8i/pE5rm28=
 github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734 h1:HKLsbzeOsfXmKNpr3GiT18XAblV0BjCbzL8KQAMZGa0=
 github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734/go.mod h1:kNDNcF7sN4DocDLBkQYz73HGKwN1ANB1blq4lIYLYvg=
 github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=

--- a/go.sum
+++ b/go.sum
@@ -326,8 +326,8 @@ github.com/hashicorp/terraform-json v0.13.0 h1:Li9L+lKD1FO5RVFRM1mMMIBDoUHslOniy
 github.com/hashicorp/terraform-json v0.13.0/go.mod h1:y5OdLBCT+rxbwnpxZs9kGL7R9ExU76+cpdY8zHwoazk=
 github.com/hashicorp/terraform-registry-address v0.0.0-20220422093245-eb7bcc2ff473 h1:Vp3YMcnM+TvVMV5TplAhGeuzz3A0562AywL32y71y3Y=
 github.com/hashicorp/terraform-registry-address v0.0.0-20220422093245-eb7bcc2ff473/go.mod h1:bdLC+qQlJIBHKbCMA6GipcuaKjmjcvZlnVdpU583z3Y=
-github.com/hashicorp/terraform-schema v0.0.0-20220503104102-49d5d60cc80c h1:NM46aa8KFyfFdG1ceVQvzzp6O9o2wZ7ir1mhx/3WGt8=
-github.com/hashicorp/terraform-schema v0.0.0-20220503104102-49d5d60cc80c/go.mod h1:rLQP6aOmOcA+C68h3Ea7utboW/UWwgn5m8i/pE5rm28=
+github.com/hashicorp/terraform-schema v0.0.0-20220509053855-1e3acbcfd531 h1:CVBByNVwgdRBKz6hdrL547Rw6RU4QF7sDnxvISdoBxM=
+github.com/hashicorp/terraform-schema v0.0.0-20220509053855-1e3acbcfd531/go.mod h1:rLQP6aOmOcA+C68h3Ea7utboW/UWwgn5m8i/pE5rm28=
 github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734 h1:HKLsbzeOsfXmKNpr3GiT18XAblV0BjCbzL8KQAMZGa0=
 github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734/go.mod h1:kNDNcF7sN4DocDLBkQYz73HGKwN1ANB1blq4lIYLYvg=
 github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=

--- a/internal/decoder/module_schema.go
+++ b/internal/decoder/module_schema.go
@@ -37,6 +37,7 @@ func schemaForModule(mod *state.Module, schemaReader state.SchemaReader, modRead
 		ProviderReferences:   mod.Meta.ProviderReferences,
 		Variables:            mod.Meta.Variables,
 		Filenames:            mod.Meta.Filenames,
+		ModuleCalls:          mod.Meta.ModuleCalls,
 	}
 
 	return sm.SchemaForModule(meta)

--- a/internal/decoder/path_reader.go
+++ b/internal/decoder/path_reader.go
@@ -14,7 +14,7 @@ import (
 type ModuleReader interface {
 	ModuleByPath(modPath string) (*state.Module, error)
 	List() ([]*state.Module, error)
-	ModuleCalls(modPath string) ([]tfmod.ModuleCall, error)
+	ModuleCalls(modPath string) (tfmod.ModuleCalls, error)
 	ModuleMeta(modPath string) (*tfmod.Meta, error)
 }
 

--- a/internal/state/module.go
+++ b/internal/state/module.go
@@ -23,6 +23,7 @@ type ModuleMetadata struct {
 	Variables            map[string]tfmod.Variable
 	Outputs              map[string]tfmod.Output
 	Filenames            []string
+	ModuleCalls          map[string]tfmod.ModuleCall
 }
 
 func (mm ModuleMetadata) Copy() ModuleMetadata {
@@ -65,6 +66,13 @@ func (mm ModuleMetadata) Copy() ModuleMetadata {
 		newMm.Outputs = make(map[string]tfmod.Output, len(mm.Outputs))
 		for name, output := range mm.Outputs {
 			newMm.Outputs[name] = output
+		}
+	}
+
+	if mm.ModuleCalls != nil {
+		newMm.ModuleCalls = make(map[string]tfmod.ModuleCall, len(mm.ModuleCalls))
+		for name, moduleCall := range mm.ModuleCalls {
+			newMm.ModuleCalls[name] = moduleCall
 		}
 	}
 
@@ -340,6 +348,7 @@ func (s *ModuleStore) ModuleMeta(modPath string) (*tfmod.Meta, error) {
 		Variables:            mod.Meta.Variables,
 		Outputs:              mod.Meta.Outputs,
 		Filenames:            mod.Meta.Filenames,
+		ModuleCalls:          mod.Meta.ModuleCalls,
 	}, nil
 }
 
@@ -705,6 +714,7 @@ func (s *ModuleStore) UpdateMetadata(path string, meta *tfmod.Meta, mErr error) 
 		Variables:            meta.Variables,
 		Outputs:              meta.Outputs,
 		Filenames:            meta.Filenames,
+		ModuleCalls:          meta.ModuleCalls,
 	}
 	mod.MetaErr = mErr
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -192,7 +192,7 @@ type ModuleReader interface {
 }
 
 type ModuleCallReader interface {
-	ModuleCalls(modPath string) ([]tfmod.ModuleCall, error)
+	ModuleCalls(modPath string) (tfmod.ModuleCalls, error)
 	ModuleMeta(modPath string) (*tfmod.Meta, error)
 }
 

--- a/internal/terraform/module/watcher.go
+++ b/internal/terraform/module/watcher.go
@@ -365,7 +365,9 @@ func decodeCalledModulesFunc(fs ReadOnlyFS, modStore *state.ModuleStore, schemaR
 			return
 		}
 
-		for _, mc := range moduleCalls {
+		// TODO: walk through declared modules too - maybe deduplicated?
+
+		for _, mc := range moduleCalls.Installed {
 			fi, err := os.Stat(mc.Path)
 			if err != nil || !fi.IsDir() {
 				continue


### PR DESCRIPTION
Depends on:

* https://github.com/hashicorp/terraform-schema/pull/106
* https://github.com/hashicorp/terraform-schema/pull/109

This PR makes use of the new early decoded module calls introduced in https://github.com/hashicorp/terraform-schema/pull/106. We save those in `state.ModuleMetadata` and use them only in `ModuleStore.ModuleCalls()` for now.

Since `ModuleStore.ModuleCalls()` is only used within the watcher, which then requires access to the `moduleCall.Path`, the early decoded modules don't do much, since they're missing the path. But the upcoming features will make better use of that.

Closes https://github.com/hashicorp/terraform-ls/issues/882