### PR TITLE
schemas: Exclude logicmonitor/logicmonitor from embedding

### DIFF
--- a/internal/schemas/gen/gen.go
+++ b/internal/schemas/gen/gen.go
@@ -253,6 +253,7 @@ var ignore = map[string]bool{
 	"HewlettPackard/hpegl":         true,
 	"jradtilbrook/buildkite":       true,
 	"kvrhdn/honeycombio":           true,
+	"logicmonitor/logicmonitor":    true,
 	"ThalesGroup/ciphertrust":      true,
 	"nullstone-io/ns":              true,
 	"zededa/zedcloud":              true,


### PR DESCRIPTION
Looks like they accidentally republished their 2.0.0 version.

```
Error while installing logicmonitor/logicmonitor v2.0.0: checksum list has unexpected SHA-256 hash
797cc1ddcf904a87652a4eb9f3eb3fb515ecdf5da870adae2e81c9f925462116 (expected
9b251be98d9c819321930466a7e5b0d68ade3579925d18e84a55d3a17f2795f4)
```