### PR TITLE
benchmarks: use --json instead of piping to results

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -59,7 +59,7 @@ jobs:
             ${DATA_PATH} \
             ${DATA_PATH} \
             --checks.config ${CHECKS_CONFIG_PATH} \
-            2> $RESULTS_PATH # eval returns result JSON to stderr for some reason
+            --json ${RESULTS_PATH}
 
           cat $RESULTS_PATH | jq -e '.Status == "pass"'
       -


### PR DESCRIPTION
It was not intended that this command outputs to stderr by default, and the behaviour will be removed in the future: https://github.com/bobheadxi/gobenchdata/pull/53