### PR TITLE
ci: Output benchmark results as markdown table

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -67,9 +67,9 @@ jobs:
         id: report
         if: ${{ failure() && !cancelled() }}
         run: |
+          BENCHDATA="go run go.bobheadxi.dev/gobenchdata"
           RESULTS_PATH="${{ runner.temp }}/benchdata-results.json"
-          FAILURES=`cat ${RESULTS_PATH} | jq '.Checks[] | select(.Status == "fail")'`
-          echo $FAILURES
+          gobenchdata checks report $RESULTS_PATH
       -
         name: Upload benchmark data as artifact
         if: ${{ always() && !cancelled() }}

--- a/results.json
+++ b/results.json
@@ -1,0 +1,64 @@
+{
+	"Checks": {
+		"aws-consul": {
+			"Status": "fail",
+			"Diffs": [
+				{
+					"Status": "fail",
+					"Package": "github.com/hashicorp/terraform-ls/internal/langserver/handlers",
+					"Benchmark": "BenchmarkInitializeFolder_basic/aws-consul-2",
+					"Value": 2128.919215
+				}
+			],
+			"Thresholds": {
+				"Min": 1360,
+				"Max": 2100
+			}
+		},
+		"aws-eks": {
+			"Status": "fail",
+			"Diffs": [
+				{
+					"Status": "fail",
+					"Package": "github.com/hashicorp/terraform-ls/internal/langserver/handlers",
+					"Benchmark": "BenchmarkInitializeFolder_basic/aws-eks-2",
+					"Value": 3130.552208
+				}
+			],
+			"Thresholds": {
+				"Min": 1570,
+				"Max": 3000
+			}
+		},
+		"aws-vpc": {
+			"Status": "fail",
+			"Diffs": [
+				{
+					"Status": "fail",
+					"Package": "github.com/hashicorp/terraform-ls/internal/langserver/handlers",
+					"Benchmark": "BenchmarkInitializeFolder_basic/aws-vpc-2",
+					"Value": 2211.930272
+				}
+			],
+			"Thresholds": {
+				"Min": 1400,
+				"Max": 2050
+			}
+		},
+		"local-single-module-aws": {
+			"Status": "fail",
+			"Diffs": [
+				{
+					"Status": "fail",
+					"Package": "github.com/hashicorp/terraform-ls/internal/langserver/handlers",
+					"Benchmark": "BenchmarkInitializeFolder_basic/local-single-module-aws-2",
+					"Value": 1985.022098
+				}
+			],
+			"Thresholds": {
+				"Min": 1240,
+				"Max": 1950
+			}
+		}
+	}
+}


### PR DESCRIPTION
As suggested in https://github.com/hashicorp/terraform-ls/pull/840#discussion_r859404814

## Before

```
{ "Status": "fail", "Diffs": [ { "Status": "fail", "Package": "github.com/hashicorp/terraform-ls/internal/langserver/handlers", "Benchmark": "BenchmarkInitializeFolder_basic/aws-consul-2", "Value": 2128.919215 } ], "Thresholds": { "Min": 1360, "Max": 2100 } } { "Status": "fail", "Diffs": [ { "Status": "fail", "Package": "github.com/hashicorp/terraform-ls/internal/langserver/handlers", "Benchmark": "BenchmarkInitializeFolder_basic/aws-eks-2", "Value": 3130.552208 } ], "Thresholds": { "Min": 1570, "Max": 3000 } } { "Status": "fail", "Diffs": [ { "Status": "fail", "Package": "github.com/hashicorp/terraform-ls/internal/langserver/handlers", "Benchmark": "BenchmarkInitializeFolder_basic/aws-vpc-2", "Value": 2211.930272 } ], "Thresholds": { "Min": 1400, "Max": 2050 } } { "Status": "fail", "Diffs": [ { "Status": "fail", "Package": "github.com/hashicorp/terraform-ls/internal/langserver/handlers", "Benchmark": "BenchmarkInitializeFolder_basic/local-single-module-aws-2", "Value": 1985.022098 } ], "Thresholds": { "Min": 1240, "Max": 1950 } }
```

## After

This may not be entirely accurate as we'd also report successful benchmarks, but I don't have the data handy to pipe it there.

```md
|    | BASE | CURRENT | PASSED CHECKS | FAILED CHECKS | TOTAL |
|----|------|---------|---------------|---------------|-------|
| 🤷‍♂️ |      |         |             0 |             4 |     4 |

|    |          CHECK          |                            PACKAGE                             |                         BENCHMARK                         |  DIFF   |            COMMENT             |
|----|-------------------------|----------------------------------------------------------------|-----------------------------------------------------------|---------|--------------------------------|
| ❌ | local-single-module-aws | github.com/hashicorp/terraform-ls/internal/langserver/handlers | BenchmarkInitializeFolder_basic/local-single-module-aws-2 | 1985.02 | exceeded maximum 1950.000000   |
|    |                         |                                                                |                                                           |         | (+35.02)                       |
| ❌ | aws-consul              | github.com/hashicorp/terraform-ls/internal/langserver/handlers | BenchmarkInitializeFolder_basic/aws-consul-2              | 2128.92 | exceeded maximum 2100.000000   |
|    |                         |                                                                |                                                           |         | (+28.92)                       |
| ❌ | aws-eks                 | github.com/hashicorp/terraform-ls/internal/langserver/handlers | BenchmarkInitializeFolder_basic/aws-eks-2                 | 3130.55 | exceeded maximum 3000.000000   |
|    |                         |                                                                |                                                           |         | (+130.55)                      |
| ❌ | aws-vpc                 | github.com/hashicorp/terraform-ls/internal/langserver/handlers | BenchmarkInitializeFolder_basic/aws-vpc-2                 | 2211.93 | exceeded maximum 2050.000000   |
|    |                         |                                                                |                                                           |         | (+161.93)                      |

```