### PR TITLE
ci: fix reference to gobenchdata

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -69,7 +69,7 @@ jobs:
         run: |
           BENCHDATA="go run go.bobheadxi.dev/gobenchdata"
           RESULTS_PATH="${{ runner.temp }}/benchdata-results.json"
-          gobenchdata checks report $RESULTS_PATH
+          $BENCHDATA checks report $RESULTS_PATH
       -
         name: Upload benchmark data as artifact
         if: ${{ always() && !cancelled() }}


### PR DESCRIPTION
This was unfortunately missed in https://github.com/hashicorp/terraform-ls/pull/907

The nightly run failed because of that:

https://github.com/hashicorp/terraform-ls/runs/6363134590?check_suite_focus=true#step:9:8

```
/home/runner/work/_temp/e2222aa7-0e94-4603-a77a-a82f434cd9bf.sh: line 3: gobenchdata: command not found
Error: Process completed with exit code 127.
```