### PR TITLE
Add utm parameters to `module.*` commands

### DIFF
--- a/internal/decoder/decoder.go
+++ b/internal/decoder/decoder.go
@@ -11,6 +11,7 @@ import (
 	lsp "github.com/hashicorp/terraform-ls/internal/protocol"
 	"github.com/hashicorp/terraform-ls/internal/state"
 	"github.com/hashicorp/terraform-ls/internal/terraform/ast"
+	"github.com/hashicorp/terraform-ls/internal/utm"
 	tfschema "github.com/hashicorp/terraform-schema/schema"
 )
 
@@ -80,7 +81,8 @@ func varsPathContext(mod *state.Module) (*decoder.PathContext, error) {
 
 func decoderContext(ctx context.Context) decoder.DecoderContext {
 	dCtx := decoder.DecoderContext{
-		UtmSource:     "terraform-ls",
+		UtmSource:     utm.UtmSource,
+		UtmMedium:     utm.UtmMedium(ctx),
 		UseUtmContent: true,
 	}
 
@@ -92,9 +94,5 @@ func decoderContext(ctx context.Context) decoder.DecoderContext {
 		}
 	}
 
-	clientName, ok := ilsp.ClientName(ctx)
-	if ok {
-		dCtx.UtmMedium = clientName
-	}
 	return dCtx
 }

--- a/internal/langserver/handlers/command/docs_url.go
+++ b/internal/langserver/handlers/command/docs_url.go
@@ -1,0 +1,29 @@
+package command
+
+import (
+	"context"
+	"net/url"
+
+	"github.com/hashicorp/terraform-ls/internal/utm"
+)
+
+func docsURL(ctx context.Context, rawURL, utmContent string) (*url.URL, error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, err
+	}
+
+	q := u.Query()
+	q.Set("utm_source", utm.UtmSource)
+	if medium := utm.UtmMedium(ctx); medium != "" {
+		q.Set("utm_medium", medium)
+	}
+
+	if utmContent != "" {
+		q.Set("utm_content", utmContent)
+	}
+
+	u.RawQuery = q.Encode()
+
+	return u, nil
+}

--- a/internal/langserver/handlers/command/handler.go
+++ b/internal/langserver/handlers/command/handler.go
@@ -1,7 +1,12 @@
 package command
 
-import "github.com/hashicorp/terraform-ls/internal/state"
+import (
+	"log"
+
+	"github.com/hashicorp/terraform-ls/internal/state"
+)
 
 type CmdHandler struct {
 	StateStore *state.StateStore
+	Logger     *log.Logger
 }

--- a/internal/langserver/handlers/command/module_calls.go
+++ b/internal/langserver/handlers/command/module_calls.go
@@ -57,17 +57,12 @@ func (h *CmdHandler) ModuleCallsHandler(ctx context.Context, args cmd.CommandArg
 		return response, nil
 	}
 
-	modCalls, err := parseModuleRecords(ctx, found.ModManifest.Records)
-	if err != nil {
-		return response, err
-	}
-
-	response.ModuleCalls = modCalls
+	response.ModuleCalls = h.parseModuleRecords(ctx, found.ModManifest.Records)
 
 	return response, nil
 }
 
-func parseModuleRecords(ctx context.Context, records []datadir.ModuleRecord) ([]moduleCall, error) {
+func (h *CmdHandler) parseModuleRecords(ctx context.Context, records []datadir.ModuleRecord) []moduleCall {
 	// sort all records by key so that dependent modules are found
 	// after primary modules
 	sort.SliceStable(records, func(i, j int) bool {
@@ -96,7 +91,7 @@ func parseModuleRecords(ctx context.Context, records []datadir.ModuleRecord) ([]
 
 		docsLink, err := getModuleDocumentationLink(ctx, manifest)
 		if err != nil {
-			return nil, err
+			h.Logger.Printf("failed to get module docs link: %s", err)
 		}
 
 		// build what we know
@@ -131,7 +126,7 @@ func parseModuleRecords(ctx context.Context, records []datadir.ModuleRecord) ([]
 		return list[i].Name < list[j].Name
 	})
 
-	return list, nil
+	return list
 }
 
 func getModuleDocumentationLink(ctx context.Context, record datadir.ModuleRecord) (string, error) {

--- a/internal/langserver/handlers/command/module_calls_test.go
+++ b/internal/langserver/handlers/command/module_calls_test.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -80,7 +81,12 @@ func Test_parseModuleRecords(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := parseModuleRecords(tt.records)
+			ctx := context.Background()
+			// TODO: utm_media? / client name?
+			got, err := parseModuleRecords(ctx, tt.records)
+			if err != nil {
+				t.Fatal(err)
+			}
 			if diff := cmp.Diff(tt.want, got); diff != "" {
 				t.Fatalf("module mismatch: %s", diff)
 			}
@@ -119,7 +125,12 @@ func Test_parseModuleRecords_v1_1(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := parseModuleRecords(tt.records)
+			ctx := context.Background()
+			// TODO: utm_media? / client name?
+			got, err := parseModuleRecords(ctx, tt.records)
+			if err != nil {
+				t.Fatal(err)
+			}
 			if diff := cmp.Diff(tt.want, got); diff != "" {
 				t.Fatalf("module mismatch: %s", diff)
 			}

--- a/internal/langserver/handlers/command/module_calls_test.go
+++ b/internal/langserver/handlers/command/module_calls_test.go
@@ -48,7 +48,7 @@ func Test_parseModuleRecords(t *testing.T) {
 					SourceAddr:       "terraform-aws-modules/ec2-instance/aws",
 					Version:          "2.12.0",
 					SourceType:       "tfregistry",
-					DocsLink:         "https://registry.terraform.io/modules/terraform-aws-modules/ec2-instance/aws/2.12.0",
+					DocsLink:         "https://registry.terraform.io/modules/terraform-aws-modules/ec2-instance/aws/2.12.0?utm_content=workspace%2FexecuteCommand%2Fmodule.calls&utm_source=terraform-ls",
 					DependentModules: []moduleCall{},
 				},
 				{
@@ -56,7 +56,7 @@ func Test_parseModuleRecords(t *testing.T) {
 					SourceAddr: "terraform-aws-modules/eks/aws",
 					Version:    "17.20.0",
 					SourceType: "tfregistry",
-					DocsLink:   "https://registry.terraform.io/modules/terraform-aws-modules/eks/aws/17.20.0",
+					DocsLink:   "https://registry.terraform.io/modules/terraform-aws-modules/eks/aws/17.20.0?utm_content=workspace%2FexecuteCommand%2Fmodule.calls&utm_source=terraform-ls",
 					DependentModules: []moduleCall{
 						{
 							Name:             "fargate",
@@ -82,7 +82,6 @@ func Test_parseModuleRecords(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
-			// TODO: utm_media? / client name?
 			got, err := parseModuleRecords(ctx, tt.records)
 			if err != nil {
 				t.Fatal(err)
@@ -117,7 +116,7 @@ func Test_parseModuleRecords_v1_1(t *testing.T) {
 					SourceAddr:       "registry.terraform.io/terraform-aws-modules/ec2-instance/aws",
 					Version:          "2.12.0",
 					SourceType:       "tfregistry",
-					DocsLink:         "https://registry.terraform.io/modules/terraform-aws-modules/ec2-instance/aws/2.12.0",
+					DocsLink:         "https://registry.terraform.io/modules/terraform-aws-modules/ec2-instance/aws/2.12.0?utm_content=workspace%2FexecuteCommand%2Fmodule.calls&utm_source=terraform-ls",
 					DependentModules: []moduleCall{},
 				},
 			},

--- a/internal/langserver/handlers/command/module_calls_test.go
+++ b/internal/langserver/handlers/command/module_calls_test.go
@@ -82,10 +82,8 @@ func Test_parseModuleRecords(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
-			got, err := parseModuleRecords(ctx, tt.records)
-			if err != nil {
-				t.Fatal(err)
-			}
+			h := &CmdHandler{}
+			got := h.parseModuleRecords(ctx, tt.records)
 			if diff := cmp.Diff(tt.want, got); diff != "" {
 				t.Fatalf("module mismatch: %s", diff)
 			}
@@ -125,11 +123,8 @@ func Test_parseModuleRecords_v1_1(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
-			// TODO: utm_media? / client name?
-			got, err := parseModuleRecords(ctx, tt.records)
-			if err != nil {
-				t.Fatal(err)
-			}
+			h := &CmdHandler{}
+			got := h.parseModuleRecords(ctx, tt.records)
 			if diff := cmp.Diff(tt.want, got); diff != "" {
 				t.Fatalf("module mismatch: %s", diff)
 			}

--- a/internal/langserver/handlers/execute_command.go
+++ b/internal/langserver/handlers/execute_command.go
@@ -15,6 +15,7 @@ import (
 func cmdHandlers(svc *service) cmd.Handlers {
 	cmdHandler := &command.CmdHandler{
 		StateStore: svc.stateStore,
+		Logger:     svc.logger,
 	}
 	return cmd.Handlers{
 		cmd.Name("rootmodules"):        removedHandler("use module.callers instead"),

--- a/internal/langserver/handlers/execute_command_module_providers_test.go
+++ b/internal/langserver/handlers/execute_command_module_providers_test.go
@@ -143,12 +143,12 @@ func TestLangServer_workspaceExecuteCommand_moduleProviders_basic(t *testing.T) 
 				"registry.terraform.io/hashicorp/aws": {
 					"display_name": "hashicorp/aws",
 					"version_constraint":"1.2.3",
-					"docs_link": "https://registry.terraform.io/providers/hashicorp/aws/latest"
+					"docs_link": "https://registry.terraform.io/providers/hashicorp/aws/latest?utm_content=workspace%2FexecuteCommand%2Fmodule.providers\u0026utm_source=terraform-ls"
 				},
 				"registry.terraform.io/hashicorp/google": {
 					"display_name": "hashicorp/google",
 					"version_constraint": "\u003e= 2.0.0",
-					"docs_link": "https://registry.terraform.io/providers/hashicorp/google/latest"
+					"docs_link": "https://registry.terraform.io/providers/hashicorp/google/latest?utm_content=workspace%2FexecuteCommand%2Fmodule.providers\u0026utm_source=terraform-ls"
 				}
 			},
 			"installed_providers":{

--- a/internal/langserver/handlers/service.go
+++ b/internal/langserver/handlers/service.go
@@ -305,6 +305,7 @@ func (svc *service) Assigner() (jrpc2.Assigner, error) {
 			ctx = lsctx.WithWatcher(ctx, svc.watcher)
 			ctx = lsctx.WithRootDirectory(ctx, &rootDir)
 			ctx = lsctx.WithDiagnosticsNotifier(ctx, svc.diagsNotifier)
+			ctx = ilsp.ContextWithClientName(ctx, &clientName)
 			ctx = exec.WithExecutorOpts(ctx, svc.tfExecOpts)
 			ctx = exec.WithExecutorFactory(ctx, svc.tfExecFactory)
 

--- a/internal/utm/utm.go
+++ b/internal/utm/utm.go
@@ -1,0 +1,18 @@
+package utm
+
+import (
+	"context"
+
+	ilsp "github.com/hashicorp/terraform-ls/internal/lsp"
+)
+
+const UtmSource = "terraform-ls"
+
+func UtmMedium(ctx context.Context) string {
+	clientName, ok := ilsp.ClientName(ctx)
+	if ok {
+		return clientName
+	}
+
+	return ""
+}


### PR DESCRIPTION
Closes https://github.com/hashicorp/terraform-ls/issues/911

## Before

```
2022/05/20 12:41:18 rpc_logger.go:29: Incoming request for "workspace/executeCommand" (ID 15): {"command":"terraform-ls.module.providers","arguments":["uri=file:///private/var/workspace/tf-test"]}
2022/05/20 12:41:18 rpc_logger.go:50: Response to "workspace/executeCommand" (ID 15): {"v":0,"provider_requirements":{"registry.terraform.io/hashicorp/aws":{"display_name":"hashicorp/aws","docs_link":"https://registry.terraform.io/providers/hashicorp/aws/latest"}},"installed_providers":{"registry.terraform.io/hashicorp/aws":"4.14.0"}}
```

```
2022/05/20 12:41:18 rpc_logger.go:29: Incoming request for "workspace/executeCommand" (ID 16): {"command":"terraform-ls.module.calls","arguments":["uri=file:///private/var/workspace/tf-test"]}
2022/05/20 12:41:18 rpc_logger.go:50: Response to "workspace/executeCommand" (ID 16): {"v":0,"module_calls":[{"name":"vpc","source_addr":"registry.terraform.io/terraform-aws-modules/vpc/aws","version":"3.14.0","source_type":"tfregistry","docs_link":"https://registry.terraform.io/modules/terraform-aws-modules/vpc/aws/3.14.0","dependent_modules":[]}]}
```

## After

```
2022/05/20 12:39:16 rpc_logger.go:29: Incoming request for "workspace/executeCommand" (ID 125): {"command":"terraform-ls.module.providers","arguments":["uri=file:///private/var/workspace/tf-test"]}
2022/05/20 12:39:16 rpc_logger.go:50: Response to "workspace/executeCommand" (ID 125): {"v":0,"provider_requirements":{"registry.terraform.io/hashicorp/aws":{"display_name":"hashicorp/aws","docs_link":"https://registry.terraform.io/providers/hashicorp/aws/latest?utm_content=workspace%2FexecuteCommand%2Fmodule.providers\u0026utm_medium=Visual+Studio+Code\u0026utm_source=terraform-ls"}},"installed_providers":{"registry.terraform.io/hashicorp/aws":"4.14.0"}}
```

```
2022/05/20 12:39:16 rpc_logger.go:29: Incoming request for "workspace/executeCommand" (ID 126): {"command":"terraform-ls.module.calls","arguments":["uri=file:///private/var/workspace/tf-test"]}
2022/05/20 12:39:16 rpc_logger.go:50: Response to "workspace/executeCommand" (ID 126): {"v":0,"module_calls":[{"name":"vpc","source_addr":"registry.terraform.io/terraform-aws-modules/vpc/aws","version":"3.14.0","source_type":"tfregistry","docs_link":"https://registry.terraform.io/modules/terraform-aws-modules/vpc/aws/3.14.0?utm_content=workspace%2FexecuteCommand%2Fmodule.calls\u0026utm_medium=Visual+Studio+Code\u0026utm_source=terraform-ls","dependent_modules":[]}]}
```