### PR TITLE
langserver: ignore duplicate document versions in textDocument/didChange

### DIFF
--- a/internal/langserver/handlers/did_change.go
+++ b/internal/langserver/handlers/did_change.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/hashicorp/terraform-ls/internal/document"
 	ilsp "github.com/hashicorp/terraform-ls/internal/lsp"
@@ -30,10 +29,10 @@ func (svc *service) TextDocumentDidChange(ctx context.Context, params lsp.DidCha
 
 	// Versions don't have to be consecutive, but they must be increasing
 	if newVersion <= doc.Version {
-		svc.stateStore.DocumentStore.CloseDocument(dh)
-		return fmt.Errorf("Old version (%d) received, current version is %d. "+
-			"Unable to update %s. This is likely a bug, please report it.",
+		svc.logger.Printf("Old document version (%d) received, current version is %d. "+
+			"Ignoring this update for %s. This is likely a client bug, please report it.",
 			newVersion, doc.Version, p.TextDocument.URI)
+		return nil
 	}
 
 	changes := ilsp.DocumentChanges(params.ContentChanges)


### PR DESCRIPTION
Fixes #310

Related to

 - https://github.com/sublimelsp/LSP/issues/1470
 - https://github.com/neovim/neovim/issues/18734
 - https://github.com/hashicorp/terraform-ls/issues/927
 - https://github.com/hashicorp/terraform-ls/issues/936
