### PR TITLE
goreleaser: Remove brew publishing

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -88,27 +88,6 @@ signs:
     args: ["sign", "--dearmor", "--file", "${artifact}", "--out", "${signature}"]
     artifacts: checksum
 
-brews:
-  -
-    tap:
-      owner: hashicorp
-      name: homebrew-tap
-      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
-    skip_upload: auto
-    url_template: "https://releases.hashicorp.com/terraform-ls/{{ .Version }}/{{ .ArtifactName }}"
-    commit_author:
-      name: hc-espd-packager
-      email: team-product-delivery@hashicorp.com
-    folder: Formula
-    homepage: "https://github.com/hashicorp/terraform-ls"
-    description: "Terraform Language Server"
-    conflicts:
-      - terraform-ls
-    install: |
-      bin.install "terraform-ls"
-    test: |
-      system "#{bin}/terraform-ls --version"
-
 publishers:
   - name: "hc-releases"
     checksum: true


### PR DESCRIPTION
We can publish homebrew formulas via internal tooling, which also better fits into the new release pipeline. We already send the SNS notification which has the ability to trigger the publishing.

See also https://github.com/hashicorp/homebrew-tap/pull/174

This also avoids the need for the release tooling to ignore `*.rb` files as release artifacts in `dist` folder, which currently cause release failures.