### PR TITLE
main: allow version metadata to be set

### DIFF
--- a/version.go
+++ b/version.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"fmt"
-
 	goversion "github.com/hashicorp/go-version"
 )
 
@@ -12,7 +10,10 @@ var version = "0.0.0"
 // A pre-release marker for the version. If this is "" (empty string)
 // then it means that it is a final release. Otherwise, this is a pre-release
 // such as "dev" (in development), "beta", "rc1", etc.
-var prerelease = "dev"
+var versionPrerelease = "dev"
+
+// Version (build) metadata, such as homebrew
+var versionMetadata = ""
 
 func init() {
 	// Verify that the version is proper semantic version, which should always be the case.
@@ -24,8 +25,14 @@ func init() {
 
 // VersionString returns the complete version string, including prerelease
 func VersionString() string {
-	if prerelease != "" {
-		return fmt.Sprintf("%s-%s", version, prerelease)
+	v := version
+	if versionPrerelease != "" {
+		v += "-" + versionPrerelease
 	}
-	return version
+
+	if versionMetadata != "" {
+		v += "+" + versionMetadata
+	}
+
+	return v
 }


### PR DESCRIPTION
This allows us - or more importantly anyone other than us - to set build metadata when building LS.

In particular this allows us to update the community Homebrew formula to help more easily distinguish LS installed from the Homebrew community tap from our own builds - which can be useful when troubleshooting - see e.g. https://github.com/hashicorp/terraform-ls/issues/944#issuecomment-1151095285

https://github.com/Homebrew/homebrew-core/blob/dc4bba37bc14ca0a7796656638d6f4df86cc3e0d/Formula/oras.rb#L21-L25

## How to test

```sh
go build -ldflags="-s -w -X main.version=0.1.0 -X main.versionMeta=homebrew"
```
```sh
./terraform-ls version
0.1.0-dev+homebrew
platform: darwin/arm64
go: go1.18.2
compiler: gc
```
```
./terraform-ls version -json
```
```json
{
  "version": "0.1.0-dev+homebrew",
  "go": "go1.18.2",
  "os": "darwin",
  "arch": "arm64",
  "compiler": "gc"
}
```