### PR TITLE
handlers/command: Return partially parsed metadata from `module.providers`

### DIFF
--- a/internal/langserver/handlers/command/module_providers.go
+++ b/internal/langserver/handlers/command/module_providers.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/creachadair/jrpc2/code"
 	"github.com/hashicorp/terraform-ls/internal/langserver/cmd"
-	op "github.com/hashicorp/terraform-ls/internal/terraform/module/operation"
 	"github.com/hashicorp/terraform-ls/internal/uri"
 	tfaddr "github.com/hashicorp/terraform-registry-address"
 )
@@ -48,10 +47,6 @@ func (h *CmdHandler) ModuleProvidersHandler(ctx context.Context, args cmd.Comman
 
 	mod, _ := h.StateStore.Modules.ModuleByPath(modPath)
 	if mod == nil {
-		return response, nil
-	}
-
-	if mod.MetaState == op.OpStateUnknown || mod.MetaErr != nil {
 		return response, nil
 	}
 


### PR DESCRIPTION
Fixes #906

## Before

![Screenshot 2022-06-14 at 09 52 23](https://user-images.githubusercontent.com/287584/173536452-2fb5c4d4-aa54-4394-bf03-d8767c2ed6e3.png)

## After
![Screenshot 2022-06-14 at 09 51 22](https://user-images.githubusercontent.com/287584/173536202-65ff47da-3b23-4af9-8d46-0ba11fc37b63.png)

