### PR TITLE
fix: avoid crash on invalid URIs

### DIFF
--- a/internal/langserver/handlers/did_open.go
+++ b/internal/langserver/handlers/did_open.go
@@ -2,19 +2,35 @@ package handlers
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/creachadair/jrpc2"
 	"github.com/hashicorp/terraform-ls/internal/document"
 	"github.com/hashicorp/terraform-ls/internal/job"
-	ilsp "github.com/hashicorp/terraform-ls/internal/lsp"
 	lsp "github.com/hashicorp/terraform-ls/internal/protocol"
 	"github.com/hashicorp/terraform-ls/internal/state"
 	"github.com/hashicorp/terraform-ls/internal/terraform/exec"
 	"github.com/hashicorp/terraform-ls/internal/terraform/module"
 	op "github.com/hashicorp/terraform-ls/internal/terraform/module/operation"
+	"github.com/hashicorp/terraform-ls/internal/uri"
 )
 
 func (svc *service) TextDocumentDidOpen(ctx context.Context, params lsp.DidOpenTextDocumentParams) error {
-	dh := ilsp.HandleFromDocumentURI(params.TextDocument.URI)
+	docURI := string(params.TextDocument.URI)
+
+	// URIs are always checked during initialize request, but
+	// we still allow single-file mode, therefore invalid URIs
+	// can still land here, so we check for those.
+	if !uri.IsURIValid(docURI) {
+		jrpc2.ServerFromContext(ctx).Notify(ctx, "window/showMessage", &lsp.ShowMessageParams{
+			Type: lsp.Warning,
+			Message: fmt.Sprintf("Ignoring workspace folder (unsupport or invalid URI) %s."+
+				" This is most likely bug, please report it.", docURI),
+		})
+		return fmt.Errorf("invalid URI: %s", docURI)
+	}
+
+	dh := document.HandleFromURI(docURI)
 
 	err := svc.stateStore.DocumentStore.OpenDocument(dh, params.TextDocument.LanguageID,
 		int(params.TextDocument.Version), []byte(params.TextDocument.Text))


### PR DESCRIPTION
The language server isn't able to do anything with invalid/unsupported URIs, such as the ones listed in https://github.com/hashicorp/vscode-terraform/issues/1159

There's a broader question of whether these URIs should even be send to LS. Given that the known majority of such URIs come from VS Code, I created a separate ticket https://github.com/hashicorp/vscode-terraform/issues/1159 to discuss the problem there.

Prior to this patch it would crash when encountered such a URI during `initialize`, `textDocument/didOpen` or `workspace/didChangeWorkspaceFolders`, as reported in https://github.com/hashicorp/terraform-ls/issues/959

We already handle this gracefully in custom commands:

https://github.com/hashicorp/terraform-ls/blob/000cb538ca2325e8e7f7c8d1da86b3ea411942ba/internal/langserver/handlers/command/module_calls.go#L42-L44

https://github.com/hashicorp/terraform-ls/blob/000cb538ca2325e8e7f7c8d1da86b3ea411942ba/internal/langserver/handlers/command/module_callers.go#L30-L32

https://github.com/hashicorp/terraform-ls/blob/000cb538ca2325e8e7f7c8d1da86b3ea411942ba/internal/langserver/handlers/command/module_providers.go#L39-L41

https://github.com/hashicorp/terraform-ls/blob/000cb538ca2325e8e7f7c8d1da86b3ea411942ba/internal/langserver/handlers/command/init.go#L23-L25

https://github.com/hashicorp/terraform-ls/blob/000cb538ca2325e8e7f7c8d1da86b3ea411942ba/internal/langserver/handlers/command/validate.go#L25-L27