### PR TITLE
Provide basic IntelliSense (except for diagnostics) for hidden `*.tf` files

### DIFF
--- a/internal/langserver/handlers/command/validate.go
+++ b/internal/langserver/handlers/command/validate.go
@@ -68,7 +68,7 @@ func (h *CmdHandler) TerraformValidateHandler(ctx context.Context, args cmd.Comm
 	validateDiags := diagnostics.HCLDiagsFromJSON(jsonDiags)
 	diags.EmptyRootDiagnostic()
 	diags.Append("terraform validate", validateDiags)
-	diags.Append("HCL", mod.ModuleDiagnostics.AsMap())
+	diags.Append("HCL", mod.ModuleDiagnostics.AutoloadedOnly().AsMap())
 	diags.Append("HCL", mod.VarsDiagnostics.AutoloadedOnly().AsMap())
 
 	notifier.PublishHCLDiags(ctx, mod.Path, diags)

--- a/internal/langserver/handlers/hooks_module.go
+++ b/internal/langserver/handlers/hooks_module.go
@@ -128,7 +128,7 @@ func updateDiagnostics(dNotifier *diagnostics.Notifier) notifier.Hook {
 			defer dNotifier.PublishHCLDiags(ctx, mod.Path, diags)
 
 			if mod != nil {
-				diags.Append("HCL", mod.ModuleDiagnostics.AsMap())
+				diags.Append("HCL", mod.ModuleDiagnostics.AutoloadedOnly().AsMap())
 				diags.Append("HCL", mod.VarsDiagnostics.AutoloadedOnly().AsMap())
 			}
 		}

--- a/internal/terraform/ast/ast_test.go
+++ b/internal/terraform/ast/ast_test.go
@@ -37,3 +37,32 @@ func TestVarsDiags_autoloadedOnly(t *testing.T) {
 		t.Fatalf("unexpected diagnostics: %s", diff)
 	}
 }
+
+func TestModuleDiags_autoloadedOnly(t *testing.T) {
+	md := ModDiagsFromMap(map[string]hcl.Diagnostics{
+		"alpha.tf": {},
+		"beta.tf": {
+			{
+				Severity: hcl.DiagError,
+				Summary:  "Test error",
+				Detail:   "Test description",
+			},
+		},
+		".hidden.tf": {},
+	})
+	diags := md.AutoloadedOnly().AsMap()
+	expectedDiags := map[string]hcl.Diagnostics{
+		"alpha.tf": {},
+		"beta.tf": {
+			{
+				Severity: hcl.DiagError,
+				Summary:  "Test error",
+				Detail:   "Test description",
+			},
+		},
+	}
+
+	if diff := cmp.Diff(expectedDiags, diags, ctydebug.CmpOptions); diff != "" {
+		t.Fatalf("unexpected diagnostics: %s", diff)
+	}
+}

--- a/internal/terraform/ast/variables.go
+++ b/internal/terraform/ast/variables.go
@@ -69,16 +69,6 @@ func (vd VarsDiags) AutoloadedOnly() VarsDiags {
 	return diags
 }
 
-func (vd VarsDiags) ForFile(name VarsFilename) VarsDiags {
-	diags := make(VarsDiags)
-	for fName, f := range vd {
-		if fName == name {
-			diags[fName] = f
-		}
-	}
-	return diags
-}
-
 func (vd VarsDiags) AsMap() map[string]hcl.Diagnostics {
 	m := make(map[string]hcl.Diagnostics, len(vd))
 	for name, diags := range vd {

--- a/internal/terraform/parser/module_test.go
+++ b/internal/terraform/parser/module_test.go
@@ -37,10 +37,12 @@ func TestParseModuleFiles(t *testing.T) {
 		{
 			"valid-mod-files-with-extra-items",
 			map[string]struct{}{
-				"main.tf": {},
+				".hidden.tf": {},
+				"main.tf":    {},
 			},
 			map[string]hcl.Diagnostics{
-				"main.tf": nil,
+				".hidden.tf": nil,
+				"main.tf":    nil,
 			},
 		},
 		{


### PR DESCRIPTION
Closes https://github.com/hashicorp/terraform-ls/issues/972

Depends on https://github.com/hashicorp/terraform-ls/pull/968

--- 

I label this as enhancement, since Terraform itself doesn't really load hidden files. We can however be more pragmatic about this and still provide some IntelliSense within. The only thing we do _not_ provide is diagnostics, see more on that in https://github.com/hashicorp/terraform-ls/issues/970

## Before

![Screenshot 2022-06-27 at 12 43 18](https://user-images.githubusercontent.com/287584/175933556-997edf92-ba3d-4dcb-9077-b6f78a835362.png)

## After

![Screenshot 2022-06-27 at 12 43 55](https://user-images.githubusercontent.com/287584/175933669-1b66885b-fc41-43cc-a121-6a25d6aadf5e.png)

