### PR TITLE
deps: bump terraform-schema to 408b2ae

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/hashicorp/terraform-exec v0.17.2
 	github.com/hashicorp/terraform-json v0.14.0
 	github.com/hashicorp/terraform-registry-address v0.0.0-20220623143253-7d51757b572c
-	github.com/hashicorp/terraform-schema v0.0.0-20220708120958-1a218af064d0
+	github.com/hashicorp/terraform-schema v0.0.0-20220708122804-408b2aefd4d6
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mh-cbon/go-fmt-fail v0.0.0-20160815164508-67765b3fbcb5
 	github.com/mitchellh/cli v1.1.4

--- a/go.sum
+++ b/go.sum
@@ -344,8 +344,8 @@ github.com/hashicorp/terraform-json v0.14.0 h1:sh9iZ1Y8IFJLx+xQiKHGud6/TSUCM0N8e
 github.com/hashicorp/terraform-json v0.14.0/go.mod h1:5A9HIWPkk4e5aeeXIBbkcOvaZbIYnAIkEyqP2pNSckM=
 github.com/hashicorp/terraform-registry-address v0.0.0-20220623143253-7d51757b572c h1:D8aRO6+mTqHfLsK/BC3j5OAoogv1WLRWzY1AaTo3rBg=
 github.com/hashicorp/terraform-registry-address v0.0.0-20220623143253-7d51757b572c/go.mod h1:Wn3Na71knbXc1G8Lh+yu/dQWWJeFQEpDeJMtWMtlmNI=
-github.com/hashicorp/terraform-schema v0.0.0-20220708120958-1a218af064d0 h1:GXmF/3qrN23YiKC/ubb6jOrAkRFs1lFMCTkM811bRZg=
-github.com/hashicorp/terraform-schema v0.0.0-20220708120958-1a218af064d0/go.mod h1:GL+zHwXHrTc/MfKnQP8K2Z4hmaTck85ndiIbvZueMng=
+github.com/hashicorp/terraform-schema v0.0.0-20220708122804-408b2aefd4d6 h1:nyYG4twPkXiAUnLSgF5HfhKUGNp3rErv2sYOS2bDsZY=
+github.com/hashicorp/terraform-schema v0.0.0-20220708122804-408b2aefd4d6/go.mod h1:GL+zHwXHrTc/MfKnQP8K2Z4hmaTck85ndiIbvZueMng=
 github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734 h1:HKLsbzeOsfXmKNpr3GiT18XAblV0BjCbzL8KQAMZGa0=
 github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734/go.mod h1:kNDNcF7sN4DocDLBkQYz73HGKwN1ANB1blq4lIYLYvg=
 github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=


### PR DESCRIPTION
Depends on https://github.com/hashicorp/terraform-ls/pull/987

---

Brings in https://github.com/hashicorp/terraform-schema/pull/121 and https://github.com/hashicorp/terraform-schema/pull/123

## UX Impact

<img width="478" alt="Screenshot 2022-07-08 at 13 45 30" src="https://user-images.githubusercontent.com/287584/177995100-3be834f4-e5de-4be2-ab9f-cd6fbf6f3d81.png">
<img width="532" alt="Screenshot 2022-07-08 at 13 45 42" src="https://user-images.githubusercontent.com/287584/177995103-28977cad-0f9a-4e53-8e71-40a283b8a44d.png">
<img width="492" alt="Screenshot 2022-07-08 at 13 45 55" src="https://user-images.githubusercontent.com/287584/177995105-a123b1f7-915e-4236-a527-77e531c165f5.png">
<img width="464" alt="Screenshot 2022-07-08 at 13 46 11" src="https://user-images.githubusercontent.com/287584/177995108-f9d866d9-73e4-4d00-bc78-990f2670d0b5.png">
<img width="513" alt="Screenshot 2022-07-08 at 13 46 42" src="https://user-images.githubusercontent.com/287584/177995111-d5ea7350-f5a2-40ac-b9f7-18da8c1c20bc.png">

