### PR TITLE
indexer/walker: Avoid running jobs where not needed

### DIFF
--- a/.github/gobenchdata-checks.yml
+++ b/.github/gobenchdata-checks.yml
@@ -4,21 +4,21 @@ checks:
     benchmarks: [BenchmarkInitializeFolder_basic/local-single-module-no-provider]
     diff: current.NsPerOp / 1000000 # ms
     thresholds:
-      min: 25
-      max: 55
+      min: 3
+      max: 20
   - package: ./internal/langserver/handlers
     name: local-single-submodule-no-provider
     benchmarks: [BenchmarkInitializeFolder_basic/local-single-submodule-no-provider]
     diff: current.NsPerOp / 1000000 # ms
     thresholds:
-      min: 140
-      max: 310
+      min: 100
+      max: 250
   - package: ./internal/langserver/handlers
     name: local-single-module-random
     benchmarks: [BenchmarkInitializeFolder_basic/local-single-module-random]
     diff: current.NsPerOp / 1000000 # ms
     thresholds:
-      min: 140
+      min: 100
       max: 300
   - package: ./internal/langserver/handlers
     name: local-single-module-aws
@@ -47,35 +47,35 @@ checks:
     diff: current.NsPerOp / 1000000 # ms
     thresholds:
       min: 1400
-      max: 2200
+      max: 5000
   - package: ./internal/langserver/handlers
     name: google-project
     benchmarks: [BenchmarkInitializeFolder_basic/google-project]
     diff: current.NsPerOp / 1000000 # ms
     thresholds:
       min: 1570
-      max: 2450
+      max: 9000
   - package: ./internal/langserver/handlers
     name: google-network
     benchmarks: [BenchmarkInitializeFolder_basic/google-network]
     diff: current.NsPerOp / 1000000 # ms
     thresholds:
       min: 1430
-      max: 2700
+      max: 15000
   - package: ./internal/langserver/handlers
     name: google-gke
     benchmarks: [BenchmarkInitializeFolder_basic/google-gke]
     diff: current.NsPerOp / 1000000 # ms
     thresholds:
       min: 1500
-      max: 5100
+      max: 20000
   - package: ./internal/langserver/handlers
     name: k8s-metrics-server
     benchmarks: [BenchmarkInitializeFolder_basic/k8s-metrics-server]
     diff: current.NsPerOp / 1000000 # ms
     thresholds:
       min: 1000
-      max: 3200
+      max: 4000
   - package: ./internal/langserver/handlers
     name: k8s-dashboard
     benchmarks: [BenchmarkInitializeFolder_basic/k8s-dashboard]

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -41,7 +41,7 @@ jobs:
             -bench=InitializeFolder_basic \
             -run=^# \
             -benchtime=60s \
-            -timeout=30m | tee ${{ runner.temp }}/benchmarks.txt
+            -timeout=60m | tee ${{ runner.temp }}/benchmarks.txt
       -
         name: Evaluate benchmarks
         id: bench-eval

--- a/internal/indexer/document_change.go
+++ b/internal/indexer/document_change.go
@@ -15,7 +15,7 @@ func (idx *Indexer) DocumentChanged(modHandle document.DirHandle) (job.IDs, erro
 	parseId, err := idx.jobStore.EnqueueJob(job.Job{
 		Dir: modHandle,
 		Func: func(ctx context.Context) error {
-			return module.ParseModuleConfiguration(idx.fs, idx.modStore, modHandle.Path())
+			return module.ParseModuleConfiguration(ctx, idx.fs, idx.modStore, modHandle.Path())
 		},
 		Type: op.OpTypeParseModuleConfiguration.String(),
 	})
@@ -33,7 +33,7 @@ func (idx *Indexer) DocumentChanged(modHandle document.DirHandle) (job.IDs, erro
 	parseVarsId, err := idx.jobStore.EnqueueJob(job.Job{
 		Dir: modHandle,
 		Func: func(ctx context.Context) error {
-			return module.ParseVariables(idx.fs, idx.modStore, modHandle.Path())
+			return module.ParseVariables(ctx, idx.fs, idx.modStore, modHandle.Path())
 		},
 		Type: op.OpTypeParseVariables.String(),
 	})
@@ -64,7 +64,7 @@ func (idx *Indexer) decodeModule(modHandle document.DirHandle, dependsOn job.IDs
 	metaId, err := idx.jobStore.EnqueueJob(job.Job{
 		Dir: modHandle,
 		Func: func(ctx context.Context) error {
-			return module.LoadModuleMetadata(idx.modStore, modHandle.Path())
+			return module.LoadModuleMetadata(ctx, idx.modStore, modHandle.Path())
 		},
 		Type:      op.OpTypeLoadModuleMetadata.String(),
 		DependsOn: dependsOn,

--- a/internal/indexer/document_open.go
+++ b/internal/indexer/document_open.go
@@ -40,7 +40,7 @@ func (idx *Indexer) DocumentOpened(modHandle document.DirHandle) (job.IDs, error
 	parseId, err := idx.jobStore.EnqueueJob(job.Job{
 		Dir: modHandle,
 		Func: func(ctx context.Context) error {
-			return module.ParseModuleConfiguration(idx.fs, idx.modStore, modHandle.Path())
+			return module.ParseModuleConfiguration(ctx, idx.fs, idx.modStore, modHandle.Path())
 		},
 		Type: op.OpTypeParseModuleConfiguration.String(),
 	})
@@ -58,7 +58,7 @@ func (idx *Indexer) DocumentOpened(modHandle document.DirHandle) (job.IDs, error
 	parseVarsId, err := idx.jobStore.EnqueueJob(job.Job{
 		Dir: modHandle,
 		Func: func(ctx context.Context) error {
-			return module.ParseVariables(idx.fs, idx.modStore, modHandle.Path())
+			return module.ParseVariables(ctx, idx.fs, idx.modStore, modHandle.Path())
 		},
 		Type: op.OpTypeParseVariables.String(),
 	})

--- a/internal/indexer/document_open.go
+++ b/internal/indexer/document_open.go
@@ -42,14 +42,15 @@ func (idx *Indexer) DocumentOpened(modHandle document.DirHandle) (job.IDs, error
 		Func: func(ctx context.Context) error {
 			return module.ParseModuleConfiguration(ctx, idx.fs, idx.modStore, modHandle.Path())
 		},
-		Type: op.OpTypeParseModuleConfiguration.String(),
+		Type:        op.OpTypeParseModuleConfiguration.String(),
+		IgnoreState: true,
 	})
 	if err != nil {
 		return ids, err
 	}
 	ids = append(ids, parseId)
 
-	modIds, err := idx.decodeModule(modHandle, job.IDs{parseId})
+	modIds, err := idx.decodeModule(modHandle, job.IDs{parseId}, true)
 	if err != nil {
 		return ids, err
 	}
@@ -60,7 +61,8 @@ func (idx *Indexer) DocumentOpened(modHandle document.DirHandle) (job.IDs, error
 		Func: func(ctx context.Context) error {
 			return module.ParseVariables(ctx, idx.fs, idx.modStore, modHandle.Path())
 		},
-		Type: op.OpTypeParseVariables.String(),
+		Type:        op.OpTypeParseVariables.String(),
+		IgnoreState: true,
 	})
 	if err != nil {
 		return ids, err

--- a/internal/indexer/module_calls.go
+++ b/internal/indexer/module_calls.go
@@ -43,7 +43,7 @@ func (idx *Indexer) decodeInstalledModuleCalls(modHandle document.DirHandle) (jo
 		parseId, err := idx.jobStore.EnqueueJob(job.Job{
 			Dir: mcHandle,
 			Func: func(ctx context.Context) error {
-				return module.ParseModuleConfiguration(idx.fs, idx.modStore, mcPath)
+				return module.ParseModuleConfiguration(ctx, idx.fs, idx.modStore, mcPath)
 			},
 			Type: op.OpTypeParseModuleConfiguration.String(),
 		})
@@ -60,7 +60,7 @@ func (idx *Indexer) decodeInstalledModuleCalls(modHandle document.DirHandle) (jo
 				Dir:  mcHandle,
 				Type: op.OpTypeLoadModuleMetadata.String(),
 				Func: func(ctx context.Context) error {
-					return module.LoadModuleMetadata(idx.modStore, mcPath)
+					return module.LoadModuleMetadata(ctx, idx.modStore, mcPath)
 				},
 				DependsOn: job.IDs{parseId},
 			})
@@ -84,7 +84,7 @@ func (idx *Indexer) decodeInstalledModuleCalls(modHandle document.DirHandle) (jo
 		varsParseId, err := idx.jobStore.EnqueueJob(job.Job{
 			Dir: mcHandle,
 			Func: func(ctx context.Context) error {
-				return module.ParseVariables(idx.fs, idx.modStore, mcPath)
+				return module.ParseVariables(ctx, idx.fs, idx.modStore, mcPath)
 			},
 			Type: op.OpTypeParseVariables.String(),
 		})

--- a/internal/indexer/module_calls.go
+++ b/internal/indexer/module_calls.go
@@ -11,7 +11,7 @@ import (
 	op "github.com/hashicorp/terraform-ls/internal/terraform/module/operation"
 )
 
-func (idx *Indexer) decodeInstalledModuleCalls(modHandle document.DirHandle) (job.IDs, error) {
+func (idx *Indexer) decodeInstalledModuleCalls(modHandle document.DirHandle, ignoreState bool) (job.IDs, error) {
 	jobIds := make(job.IDs, 0)
 
 	moduleCalls, err := idx.modStore.ModuleCalls(modHandle.Path())
@@ -45,7 +45,8 @@ func (idx *Indexer) decodeInstalledModuleCalls(modHandle document.DirHandle) (jo
 			Func: func(ctx context.Context) error {
 				return module.ParseModuleConfiguration(ctx, idx.fs, idx.modStore, mcPath)
 			},
-			Type: op.OpTypeParseModuleConfiguration.String(),
+			Type:        op.OpTypeParseModuleConfiguration.String(),
+			IgnoreState: ignoreState,
 		})
 		if err != nil {
 			multierror.Append(errs, err)
@@ -62,7 +63,8 @@ func (idx *Indexer) decodeInstalledModuleCalls(modHandle document.DirHandle) (jo
 				Func: func(ctx context.Context) error {
 					return module.LoadModuleMetadata(ctx, idx.modStore, mcPath)
 				},
-				DependsOn: job.IDs{parseId},
+				DependsOn:   job.IDs{parseId},
+				IgnoreState: ignoreState,
 			})
 			if err != nil {
 				multierror.Append(errs, err)
@@ -73,7 +75,7 @@ func (idx *Indexer) decodeInstalledModuleCalls(modHandle document.DirHandle) (jo
 		}
 
 		if parseId != "" {
-			ids, err := idx.collectReferences(mcHandle, refCollectionDeps)
+			ids, err := idx.collectReferences(mcHandle, refCollectionDeps, ignoreState)
 			if err != nil {
 				multierror.Append(errs, err)
 			} else {
@@ -86,7 +88,8 @@ func (idx *Indexer) decodeInstalledModuleCalls(modHandle document.DirHandle) (jo
 			Func: func(ctx context.Context) error {
 				return module.ParseVariables(ctx, idx.fs, idx.modStore, mcPath)
 			},
-			Type: op.OpTypeParseVariables.String(),
+			Type:        op.OpTypeParseVariables.String(),
+			IgnoreState: ignoreState,
 		})
 		if err != nil {
 			multierror.Append(errs, err)
@@ -100,8 +103,9 @@ func (idx *Indexer) decodeInstalledModuleCalls(modHandle document.DirHandle) (jo
 				Func: func(ctx context.Context) error {
 					return module.DecodeVarsReferences(ctx, idx.modStore, idx.schemaStore, mcPath)
 				},
-				Type:      op.OpTypeDecodeVarsReferences.String(),
-				DependsOn: job.IDs{varsParseId},
+				Type:        op.OpTypeDecodeVarsReferences.String(),
+				DependsOn:   job.IDs{varsParseId},
+				IgnoreState: ignoreState,
 			})
 			if err != nil {
 				multierror.Append(errs, err)
@@ -114,7 +118,7 @@ func (idx *Indexer) decodeInstalledModuleCalls(modHandle document.DirHandle) (jo
 	return jobIds, errs.ErrorOrNil()
 }
 
-func (idx *Indexer) collectReferences(modHandle document.DirHandle, dependsOn job.IDs) (job.IDs, error) {
+func (idx *Indexer) collectReferences(modHandle document.DirHandle, dependsOn job.IDs, ignoreState bool) (job.IDs, error) {
 	ids := make(job.IDs, 0)
 
 	var errs *multierror.Error
@@ -124,8 +128,9 @@ func (idx *Indexer) collectReferences(modHandle document.DirHandle, dependsOn jo
 		Func: func(ctx context.Context) error {
 			return module.DecodeReferenceTargets(ctx, idx.modStore, idx.schemaStore, modHandle.Path())
 		},
-		Type:      op.OpTypeDecodeReferenceTargets.String(),
-		DependsOn: dependsOn,
+		Type:        op.OpTypeDecodeReferenceTargets.String(),
+		DependsOn:   dependsOn,
+		IgnoreState: ignoreState,
 	})
 	if err != nil {
 		errs = multierror.Append(errs, err)
@@ -138,8 +143,9 @@ func (idx *Indexer) collectReferences(modHandle document.DirHandle, dependsOn jo
 		Func: func(ctx context.Context) error {
 			return module.DecodeReferenceOrigins(ctx, idx.modStore, idx.schemaStore, modHandle.Path())
 		},
-		Type:      op.OpTypeDecodeReferenceOrigins.String(),
-		DependsOn: dependsOn,
+		Type:        op.OpTypeDecodeReferenceOrigins.String(),
+		DependsOn:   dependsOn,
+		IgnoreState: ignoreState,
 	})
 	if err != nil {
 		errs = multierror.Append(errs, err)

--- a/internal/indexer/walker.go
+++ b/internal/indexer/walker.go
@@ -97,7 +97,7 @@ func (idx *Indexer) WalkedModule(ctx context.Context, modHandle document.DirHand
 			},
 			Type: op.OpTypeParseModuleManifest.String(),
 			Defer: func(ctx context.Context, jobErr error) (job.IDs, error) {
-				return idx.decodeInstalledModuleCalls(modHandle)
+				return idx.decodeInstalledModuleCalls(modHandle, false)
 			},
 		})
 		if err != nil {
@@ -114,7 +114,7 @@ func (idx *Indexer) WalkedModule(ctx context.Context, modHandle document.DirHand
 		pSchemaVerId, err := idx.jobStore.EnqueueJob(job.Job{
 			Dir: modHandle,
 			Func: func(ctx context.Context) error {
-				return module.ParseProviderVersions(idx.fs, idx.modStore, modHandle.Path())
+				return module.ParseProviderVersions(ctx, idx.fs, idx.modStore, modHandle.Path())
 			},
 			Type:      op.OpTypeParseProviderVersions.String(),
 			DependsOn: providerVersionDeps,
@@ -144,7 +144,7 @@ func (idx *Indexer) WalkedModule(ctx context.Context, modHandle document.DirHand
 	}
 
 	if parseId != "" {
-		rIds, err := idx.collectReferences(modHandle, refCollectionDeps)
+		rIds, err := idx.collectReferences(modHandle, refCollectionDeps, false)
 		if err != nil {
 			errs = multierror.Append(errs, err)
 		} else {

--- a/internal/indexer/walker.go
+++ b/internal/indexer/walker.go
@@ -22,7 +22,7 @@ func (idx *Indexer) WalkedModule(ctx context.Context, modHandle document.DirHand
 	parseId, err := idx.jobStore.EnqueueJob(job.Job{
 		Dir: modHandle,
 		Func: func(ctx context.Context) error {
-			return module.ParseModuleConfiguration(idx.fs, idx.modStore, modHandle.Path())
+			return module.ParseModuleConfiguration(ctx, idx.fs, idx.modStore, modHandle.Path())
 		},
 		Type: op.OpTypeParseModuleConfiguration.String(),
 	})
@@ -40,7 +40,7 @@ func (idx *Indexer) WalkedModule(ctx context.Context, modHandle document.DirHand
 			Dir:  modHandle,
 			Type: op.OpTypeLoadModuleMetadata.String(),
 			Func: func(ctx context.Context) error {
-				return module.LoadModuleMetadata(idx.modStore, modHandle.Path())
+				return module.LoadModuleMetadata(ctx, idx.modStore, modHandle.Path())
 			},
 			DependsOn: job.IDs{parseId},
 		})
@@ -56,7 +56,7 @@ func (idx *Indexer) WalkedModule(ctx context.Context, modHandle document.DirHand
 	parseVarsId, err := idx.jobStore.EnqueueJob(job.Job{
 		Dir: modHandle,
 		Func: func(ctx context.Context) error {
-			return module.ParseVariables(idx.fs, idx.modStore, modHandle.Path())
+			return module.ParseVariables(ctx, idx.fs, idx.modStore, modHandle.Path())
 		},
 		Type: op.OpTypeParseVariables.String(),
 	})
@@ -93,7 +93,7 @@ func (idx *Indexer) WalkedModule(ctx context.Context, modHandle document.DirHand
 		modManifestId, err = idx.jobStore.EnqueueJob(job.Job{
 			Dir: modHandle,
 			Func: func(ctx context.Context) error {
-				return module.ParseModuleManifest(idx.fs, idx.modStore, modHandle.Path())
+				return module.ParseModuleManifest(ctx, idx.fs, idx.modStore, modHandle.Path())
 			},
 			Type: op.OpTypeParseModuleManifest.String(),
 			Defer: func(ctx context.Context, jobErr error) (job.IDs, error) {

--- a/internal/indexer/walker.go
+++ b/internal/indexer/walker.go
@@ -111,47 +111,29 @@ func (idx *Indexer) WalkedModule(ctx context.Context, modHandle document.DirHand
 	}
 
 	if dataDir.PluginLockFilePath != "" {
-		pSchemaId, err := idx.jobStore.EnqueueJob(job.Job{
+		pSchemaVerId, err := idx.jobStore.EnqueueJob(job.Job{
 			Dir: modHandle,
 			Func: func(ctx context.Context) error {
 				return module.ParseProviderVersions(idx.fs, idx.modStore, modHandle.Path())
 			},
 			Type:      op.OpTypeParseProviderVersions.String(),
 			DependsOn: providerVersionDeps,
-			Defer: func(ctx context.Context, jobErr error) (job.IDs, error) {
-				ids := make(job.IDs, 0)
+		})
+		if err != nil {
+			errs = multierror.Append(errs, err)
+		} else {
+			ids = append(ids, pSchemaVerId)
+			refCollectionDeps = append(refCollectionDeps, pSchemaVerId)
+		}
 
-				pReqs, err := idx.modStore.ProviderRequirementsForModule(modHandle.Path())
-				if err != nil {
-					return ids, err
-				}
-
-				exist, err := idx.schemaStore.AllSchemasExist(pReqs)
-				if err != nil {
-					return ids, err
-				}
-				if exist {
-					idx.logger.Printf("Avoiding obtaining schemas as they all exist: %#v", pReqs)
-					// avoid obtaining schemas if we already have it
-					return ids, nil
-				}
-				idx.logger.Printf("Obtaining schemas for: %#v", pReqs)
-
-				id, err := idx.jobStore.EnqueueJob(job.Job{
-					Dir: modHandle,
-					Func: func(ctx context.Context) error {
-						ctx = exec.WithExecutorFactory(ctx, idx.tfExecFactory)
-						return module.ObtainSchema(ctx, idx.modStore, idx.schemaStore, modHandle.Path())
-					},
-					Type: op.OpTypeObtainSchema.String(),
-				})
-				if err != nil {
-					return ids, err
-				}
-				ids = append(ids, id)
-
-				return ids, nil
+		pSchemaId, err := idx.jobStore.EnqueueJob(job.Job{
+			Dir: modHandle,
+			Func: func(ctx context.Context) error {
+				ctx = exec.WithExecutorFactory(ctx, idx.tfExecFactory)
+				return module.ObtainSchema(ctx, idx.modStore, idx.schemaStore, modHandle.Path())
 			},
+			Type:      op.OpTypeObtainSchema.String(),
+			DependsOn: job.IDs{pSchemaVerId},
 		})
 		if err != nil {
 			errs = multierror.Append(errs, err)

--- a/internal/indexer/walker.go
+++ b/internal/indexer/walker.go
@@ -111,6 +111,7 @@ func (idx *Indexer) WalkedModule(ctx context.Context, modHandle document.DirHand
 	}
 
 	if dataDir.PluginLockFilePath != "" {
+		dependsOn := make(job.IDs, 0)
 		pSchemaVerId, err := idx.jobStore.EnqueueJob(job.Job{
 			Dir: modHandle,
 			Func: func(ctx context.Context) error {
@@ -123,6 +124,7 @@ func (idx *Indexer) WalkedModule(ctx context.Context, modHandle document.DirHand
 			errs = multierror.Append(errs, err)
 		} else {
 			ids = append(ids, pSchemaVerId)
+			dependsOn = append(dependsOn, pSchemaVerId)
 			refCollectionDeps = append(refCollectionDeps, pSchemaVerId)
 		}
 
@@ -133,7 +135,7 @@ func (idx *Indexer) WalkedModule(ctx context.Context, modHandle document.DirHand
 				return module.ObtainSchema(ctx, idx.modStore, idx.schemaStore, modHandle.Path())
 			},
 			Type:      op.OpTypeObtainSchema.String(),
-			DependsOn: job.IDs{pSchemaVerId},
+			DependsOn: dependsOn,
 		})
 		if err != nil {
 			errs = multierror.Append(errs, err)

--- a/internal/indexer/watcher.go
+++ b/internal/indexer/watcher.go
@@ -35,6 +35,7 @@ func (idx *Indexer) ModuleManifestChanged(ctx context.Context, modHandle documen
 
 func (idx *Indexer) PluginLockChanged(ctx context.Context, modHandle document.DirHandle) (job.IDs, error) {
 	ids := make(job.IDs, 0)
+	dependsOn := make(job.IDs, 0)
 	var errs *multierror.Error
 
 	pSchemaVerId, err := idx.jobStore.EnqueueJob(job.Job{
@@ -49,6 +50,7 @@ func (idx *Indexer) PluginLockChanged(ctx context.Context, modHandle document.Di
 		errs = multierror.Append(errs, err)
 	} else {
 		ids = append(ids, pSchemaVerId)
+		dependsOn = append(dependsOn, pSchemaVerId)
 	}
 
 	pSchemaId, err := idx.jobStore.EnqueueJob(job.Job{
@@ -59,7 +61,7 @@ func (idx *Indexer) PluginLockChanged(ctx context.Context, modHandle document.Di
 		},
 		IgnoreState: true,
 		Type:        op.OpTypeObtainSchema.String(),
-		DependsOn:   job.IDs{pSchemaVerId},
+		DependsOn:   dependsOn,
 	})
 	if err != nil {
 		errs = multierror.Append(errs, err)

--- a/internal/indexer/watcher.go
+++ b/internal/indexer/watcher.go
@@ -17,7 +17,7 @@ func (idx *Indexer) ModuleManifestChanged(ctx context.Context, modHandle documen
 	modManifestId, err := idx.jobStore.EnqueueJob(job.Job{
 		Dir: modHandle,
 		Func: func(ctx context.Context) error {
-			return module.ParseModuleManifest(idx.fs, idx.modStore, modHandle.Path())
+			return module.ParseModuleManifest(ctx, idx.fs, idx.modStore, modHandle.Path())
 		},
 		Type: op.OpTypeParseModuleManifest.String(),
 		Defer: func(ctx context.Context, jobErr error) (job.IDs, error) {

--- a/internal/job/ignore_state.go
+++ b/internal/job/ignore_state.go
@@ -1,0 +1,30 @@
+package job
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-ls/internal/document"
+)
+
+type ignoreState struct{}
+
+func IgnoreState(ctx context.Context) bool {
+	v, ok := ctx.Value(ignoreState{}).(bool)
+	if !ok {
+		return false
+	}
+	return v
+}
+
+func WithIgnoreState(ctx context.Context, ignore bool) context.Context {
+	return context.WithValue(ctx, ignoreState{}, ignore)
+}
+
+type StateNotChangedErr struct {
+	Dir document.DirHandle
+}
+
+func (e StateNotChangedErr) Error() string {
+	return fmt.Sprintf("%s: state not changed", e.Dir.URI)
+}

--- a/internal/job/job.go
+++ b/internal/job/job.go
@@ -32,6 +32,11 @@ type Job struct {
 	// This will be taken into account when scheduling, so that only
 	// jobs with no dependencies are dispatched at any time.
 	DependsOn IDs
+
+	// IgnoreState indicates to the job (as defined by Func)
+	// whether to ignore existing state, i.e. whether to invalidate cache.
+	// It is up to [Func] to read this flag from ctx and reflect it.
+	IgnoreState bool
 }
 
 // DeferFunc represents a deferred function scheduling more jobs
@@ -41,12 +46,13 @@ type DeferFunc func(ctx context.Context, jobErr error) (IDs, error)
 
 func (job Job) Copy() Job {
 	return Job{
-		Func:      job.Func,
-		Dir:       job.Dir,
-		Type:      job.Type,
-		Priority:  job.Priority,
-		Defer:     job.Defer,
-		DependsOn: job.DependsOn.Copy(),
+		Func:        job.Func,
+		Dir:         job.Dir,
+		Type:        job.Type,
+		Priority:    job.Priority,
+		Defer:       job.Defer,
+		IgnoreState: job.IgnoreState,
+		DependsOn:   job.DependsOn.Copy(),
 	}
 }
 

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -65,6 +65,8 @@ func (s *Scheduler) eval(ctx context.Context) {
 			return
 		}
 
+		ctx = job.WithIgnoreState(ctx, nextJob.IgnoreState)
+
 		jobErr := nextJob.Func(ctx)
 
 		deferredJobIds := make(job.IDs, 0)

--- a/internal/state/jobs.go
+++ b/internal/state/jobs.go
@@ -58,22 +58,6 @@ const (
 )
 
 func (js *JobStore) EnqueueJob(newJob job.Job) (job.ID, error) {
-	jobID, queued, err := js.jobExists(newJob, StateQueued)
-	if err != nil {
-		return "", err
-	}
-	if queued {
-		return jobID, nil
-	}
-
-	jobID, running, err := js.jobExists(newJob, StateRunning)
-	if err != nil {
-		return "", err
-	}
-	if running {
-		return jobID, nil
-	}
-
 	txn := js.db.Txn(true)
 	defer txn.Abort()
 
@@ -98,7 +82,7 @@ func (js *JobStore) EnqueueJob(newJob job.Job) (job.ID, error) {
 		State:     StateQueued,
 	}
 
-	err = txn.Insert(js.tableName, sJob)
+	err := txn.Insert(js.tableName, sJob)
 	if err != nil {
 		return "", fmt.Errorf("failed to insert new job: %w", err)
 	}

--- a/internal/state/jobs.go
+++ b/internal/state/jobs.go
@@ -103,8 +103,8 @@ func (js *JobStore) EnqueueJob(newJob job.Job) (job.ID, error) {
 		return "", fmt.Errorf("failed to insert new job: %w", err)
 	}
 
-	js.logger.Printf("JOBS: Enqueueing new job %q: %q for %q (IsDirOpen: %t)",
-		sJob.ID, sJob.Type, sJob.Dir, sJob.IsDirOpen)
+	js.logger.Printf("JOBS: Enqueueing new job %q: %q for %q (IsDirOpen: %t, IgnoreState: %t)",
+		sJob.ID, sJob.Type, sJob.Dir, sJob.IsDirOpen, sJob.IgnoreState)
 
 	txn.Commit()
 

--- a/internal/terraform/module/module_ops_test.go
+++ b/internal/terraform/module/module_ops_test.go
@@ -43,12 +43,12 @@ func TestGetModuleDataFromRegistry_singleModule(t *testing.T) {
 	}
 
 	fs := filesystem.NewFilesystem(ss.DocumentStore)
-	err = ParseModuleConfiguration(fs, ss.Modules, modPath)
+	err = ParseModuleConfiguration(ctx, fs, ss.Modules, modPath)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = LoadModuleMetadata(ss.Modules, modPath)
+	err = LoadModuleMetadata(ctx, ss.Modules, modPath)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -115,12 +115,12 @@ func TestGetModuleDataFromRegistry_moduleNotFound(t *testing.T) {
 	}
 
 	fs := filesystem.NewFilesystem(ss.DocumentStore)
-	err = ParseModuleConfiguration(fs, ss.Modules, modPath)
+	err = ParseModuleConfiguration(ctx, fs, ss.Modules, modPath)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = LoadModuleMetadata(ss.Modules, modPath)
+	err = LoadModuleMetadata(ctx, ss.Modules, modPath)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -194,12 +194,12 @@ func TestGetModuleDataFromRegistry_apiTimeout(t *testing.T) {
 	}
 
 	fs := filesystem.NewFilesystem(ss.DocumentStore)
-	err = ParseModuleConfiguration(fs, ss.Modules, modPath)
+	err = ParseModuleConfiguration(ctx, fs, ss.Modules, modPath)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = LoadModuleMetadata(ss.Modules, modPath)
+	err = LoadModuleMetadata(ctx, ss.Modules, modPath)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/terraform/module/module_ops_test.go
+++ b/internal/terraform/module/module_ops_test.go
@@ -368,7 +368,8 @@ func TestParseProviderVersions(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = ParseProviderVersions(fs, ss.Modules, modPath)
+	ctx := context.Background()
+	err = ParseProviderVersions(ctx, fs, ss.Modules, modPath)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Closes #1002

Depends on #1027

--- 

## Background

The removal of de-duplication upon job enqueuing is necessary to avoid various bugs and race conditions where we'd deduplicate jobs which appear to be same, but have different `Defer` or `DependsOn`, i.e. we'd be overly aggressive in the deduplication efforts.

It is worth clarifying here that this PR doesn't affect jobs which run as part of text synchronization - i.e. `textDocument/didOpen`, `textDocument/didChange` or `workspace/didChangeWatchedFiles`. It only aims to reduce the duplicated work as part of the walker (which is triggered by `initialize`), which would occur if the user has deep workspace which takes a while to index via walker, and opens a few (yet unindexed) modules, which get indexed as a priority.

For `textDocument/didChange` and `workspace/didChangeWatchedFiles` it is expected that the jobs _do_ need to run since we _know_ something has changed. We could attempt to do some de-duplication there as well, but it's probably going to have low impact.

For `textDocument/didOpen` - we treat any opened document as a change currently, because we have no way to tell whether it matches the contents on disk. This is IMO a common case, where user would start without any open files, walker indexes everything, and then they open any module and we re-index the whole module again, and we do it again for **every single file** they open. Reducing duplicated work here is just little more involved, so I filed a separate ticket for that: https://github.com/hashicorp/terraform-ls/issues/1031

### Benchmarks

I am (finally) updating the benchmarks as part of the PR, which may suggest that this PR has negative performance impact, but it's little more complicated as we're really reflecting a few PRs, each contributing to those numbers in slightly different way:

 - https://github.com/hashicorp/terraform-ls/pull/997 increased the total number of jobs in most cases
 - https://github.com/hashicorp/terraform-ls/pull/1014 reduced time as we no longer run `terraform providers schema -json` when it's not necessary. Previously we'd run it on _every_ indexed & initialized module.
   - This impacts cases of deep workspace hierarchies with initialized modules which use the same provider versions, which also makes more effective use of the embedded schemas now.
 - https://github.com/hashicorp/terraform-ls/pull/1027 removed 1 job (`terraform version`) entirely from the walker indexing. It now runs only on the text synchronization methods.
