### PR TITLE
settings: decode deprecated ignoreDirectoryNames & warn

### DIFF
--- a/internal/langserver/handlers/initialize.go
+++ b/internal/langserver/handlers/initialize.go
@@ -262,6 +262,13 @@ func (svc *service) setupWalker(ctx context.Context, params lsp.InitializeParams
 				options.XLegacyExcludeModulePaths),
 		})
 	}
+	if len(options.XLegacyIgnoreDirectoryNames) != 0 {
+		jrpc2.ServerFromContext(ctx).Notify(ctx, "window/showMessage", &lsp.ShowMessageParams{
+			Type: lsp.Warning,
+			Message: fmt.Sprintf("ignoreDirectoryNames (%q) is deprecated (no-op), use indexing.ignoreDirectoryNames instead",
+				options.XLegacyIgnoreDirectoryNames),
+		})
+	}
 
 	var ignoredPaths []string
 	for _, rawPath := range options.IgnorePaths {

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -29,8 +29,9 @@ type Options struct {
 	TerraformExecTimeout string `mapstructure:"terraformExecTimeout"`
 	TerraformLogFilePath string `mapstructure:"terraformLogFilePath"`
 
-	XLegacyModulePaths        []string `mapstructure:"rootModulePaths"`
-	XLegacyExcludeModulePaths []string `mapstructure:"excludeModulePaths"`
+	XLegacyModulePaths          []string `mapstructure:"rootModulePaths"`
+	XLegacyExcludeModulePaths   []string `mapstructure:"excludeModulePaths"`
+	XLegacyIgnoreDirectoryNames []string `mapstructure:"ignoreDirectoryNames"`
 }
 
 func (o *Options) Validate() error {


### PR DESCRIPTION
This is just a small addition to #1003 to make the warning clearer.

## Before
![Screenshot 2022-07-21 at 11 09 20](https://user-images.githubusercontent.com/287584/180189917-7f557d17-6ab7-4960-8ecf-bf7316e09ff1.png)

## After
![Screenshot 2022-07-21 at 11 12 48](https://user-images.githubusercontent.com/287584/180189919-121a1962-3a8d-4ea6-bcd7-9036eb7547df.png)

