### PR TITLE
schemas: Improve logging & ignoring when generating schemas

### DIFF
--- a/internal/schemas/gen/gen.go
+++ b/internal/schemas/gen/gen.go
@@ -257,12 +257,12 @@ var ignore = map[string]bool{
 	"delphix-integrations/delphix": true,
 	"harness-io/harness":           true,
 	"harness/harness-platform":     true,
-	"HewlettPackard/oneview":       true,
-	"HewlettPackard/hpegl":         true,
+	"hewlettpackard/oneview":       true,
+	"hewlettpackard/hpegl":         true,
 	"jradtilbrook/buildkite":       true,
 	"kvrhdn/honeycombio":           true,
 	"logicmonitor/logicmonitor":    true,
-	"ThalesGroup/ciphertrust":      true,
+	"thalesgroup/ciphertrust":      true,
 	"nullstone-io/ns":              true,
 	"zededa/zedcloud":              true,
 	"lightstep/lightstep":          true,
@@ -316,10 +316,10 @@ var darwinArm64Ignore = map[string]bool{
 
 func filter(providers []provider) (filtered []provider) {
 	for _, provider := range providers {
-		if ok := ignore[provider.Source()]; ok {
+		src := strings.ToLower(provider.Source())
+		if ok := ignore[src]; ok {
 			continue
 		}
-		src := strings.ToLower(provider.Source())
 		if runtime.GOOS == "darwin" && runtime.GOARCH == "arm64" {
 			if ok := darwinArm64Ignore[src]; ok {
 				continue

--- a/internal/schemas/gen/gen.go
+++ b/internal/schemas/gen/gen.go
@@ -13,6 +13,8 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 
 	"github.com/hashicorp/go-version"
 	hcinstall "github.com/hashicorp/hc-install"
@@ -267,10 +269,61 @@ var ignore = map[string]bool{
 	"thousandeyes/thousandeyes":    true,
 }
 
+var darwinArm64Ignore = map[string]bool{
+	"a10networks/thunder":         true,
+	"alertmixer/amixr":            true,
+	"aristanetworks/cloudvision":  true,
+	"bluecatlabs/bluecat":         true,
+	"ciscodevnet/ciscoasa":        true,
+	"ciscodevnet/mso":             true,
+	"ciscodevnet/sdwan":           true,
+	"cloudtamer-io/cloudtamerio":  true,
+	"cohesity/cohesity":           true,
+	"commvault/commvault":         true,
+	"consensys/quorum":            true,
+	"f5networks/bigip":            true,
+	"gocachebr/gocache":           true,
+	"hashicorp/opc":               true,
+	"hashicorp/oraclepaas":        true,
+	"hashicorp/template":          true,
+	"icinga/icinga2":              true,
+	"infobloxopen/infoblox":       true,
+	"infracost/infracost":         true,
+	"instaclustr/instaclustr":     true,
+	"ionos-cloud/profitbricks":    true,
+	"juniper/junos-vsrx":          true,
+	"llnw/limelight":              true,
+	"netapp/netapp-elementsw":     true,
+	"nirmata/nirmata":             true,
+	"nttcom/ecl":                  true,
+	"nutanix/nutanixkps":          true,
+	"oktadeveloper/oktaasa":       true,
+	"phoenixnap/pnap":             true,
+	"purestorage-openconnect/cbs": true,
+	"rafaysystems/rafay":          true,
+	"rundeck/rundeck":             true,
+	"sematext/sematext":           true,
+	"skytap/skytap":               true,
+	"splunk/synthetics":           true,
+	"splunk/victorops":            true,
+	"statuscakedev/statuscake":    true,
+	"transloadit/transloadit":     true,
+	"valtix-security/valtix":      true,
+	"vmware-tanzu/carvel":         true,
+	"wallix/waapm":                true,
+	"william20111/thousandeyes":   true,
+}
+
 func filter(providers []provider) (filtered []provider) {
 	for _, provider := range providers {
 		if ok := ignore[provider.Source()]; ok {
 			continue
+		}
+		src := strings.ToLower(provider.Source())
+		if runtime.GOOS == "darwin" && runtime.GOARCH == "arm64" {
+			if ok := darwinArm64Ignore[src]; ok {
+				continue
+			}
 		}
 		filtered = append(filtered, provider)
 	}

--- a/internal/schemas/gen/gen.go
+++ b/internal/schemas/gen/gen.go
@@ -108,8 +108,6 @@ func gen() error {
 
 	defer i.Remove(ctx)
 
-	log.Println("running terraform init")
-
 	cwd, err := os.Getwd()
 	if err != nil {
 		return err
@@ -119,6 +117,14 @@ func gen() error {
 	if err != nil {
 		return err
 	}
+
+	coreVersion, _, err := tf.Version(ctx, false)
+	if err != nil {
+		return err
+	}
+	log.Printf("using Terraform %s", coreVersion)
+
+	log.Println("running terraform init")
 
 	err = tf.Init(ctx, tfexec.Upgrade(true))
 	if err != nil {


### PR DESCRIPTION
This is to help maintainers in local dev environments, where we may be using M1 Mac. Prior to this patch, generating schemas would fail as many providers don't provide builds for darwin/arm64.

For context I started this patch as I was trying to reproduce and debug these weird failures:
https://github.com/hashicorp/terraform-ls/runs/7467545895?check_suite_focus=true#step:6:43

```
Error: Failed to install provider
Error while installing bluecatlabs/bluecat v1.0.0: local error: tls: bad
record MAC
Error: Failed to install provider
Error while installing dome9/dome9 v1.27.1: local error: tls: bad record MAC
Error: Failed to install provider
Error while installing vmware/avi v22.1.1: local error: tls: bad record MAC
Error: Failed to install provider
Error while installing couchbasecloud/couchbasecapella v0.1.1: local error:
tls: bad record MAC
```

but in the interest of avoiding the rabbit hole I stopped when I couldn't reproduce it after a few runs.