### PR TITLE
Parse provider versions from lock file before obtaining schema

### DIFF
--- a/internal/langserver/handlers/complete_test.go
+++ b/internal/langserver/handlers/complete_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -45,8 +46,13 @@ func TestModuleCompletion_withValidData_basic(t *testing.T) {
 	tmpDir := TempDir(t)
 	InitPluginCache(t, tmpDir.Path())
 
+	err := ioutil.WriteFile(filepath.Join(tmpDir.Path(), "main.tf"), []byte("provider \"test\" {\n\n}\n"), 0o755)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	var testSchema tfjson.ProviderSchemas
-	err := json.Unmarshal([]byte(testModuleSchemaOutput), &testSchema)
+	err = json.Unmarshal([]byte(testModuleSchemaOutput), &testSchema)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -259,9 +265,13 @@ func TestModuleCompletion_withValidData_basic(t *testing.T) {
 func TestModuleCompletion_withValidDataAndSnippets(t *testing.T) {
 	tmpDir := TempDir(t)
 	InitPluginCache(t, tmpDir.Path())
+	err := ioutil.WriteFile(filepath.Join(tmpDir.Path(), "main.tf"), []byte("provider \"test\" {\n\n}\n"), 0o755)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	var testSchema tfjson.ProviderSchemas
-	err := json.Unmarshal([]byte(testModuleSchemaOutput), &testSchema)
+	err = json.Unmarshal([]byte(testModuleSchemaOutput), &testSchema)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/langserver/handlers/did_change_watched_files_test.go
+++ b/internal/langserver/handlers/did_change_watched_files_test.go
@@ -701,7 +701,7 @@ func TestLangServer_DidChangeWatchedFiles_pluginChange(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	originalTestDir := filepath.Join(testData, "uninitialized-single-submodule")
+	originalTestDir := filepath.Join(testData, "single-fake-provider")
 	testDir := t.TempDir()
 	// Copy test configuration so the test can run in isolation
 	err = copy.Copy(originalTestDir, testDir)
@@ -786,30 +786,6 @@ func TestLangServer_DidChangeWatchedFiles_pluginChange(t *testing.T) {
 	_, err = ss.ProviderSchemas.ProviderSchema(testHandle.Path(), addr, vc)
 	if err == nil {
 		t.Fatal("expected -/foo schema to be missing")
-	}
-
-	// Install Terraform
-	tfVersion := version.Must(version.NewVersion("1.1.7"))
-	i := install.NewInstaller()
-	ctx := context.Background()
-	execPath, err := i.Install(ctx, []src.Installable{
-		&releases.ExactVersion{
-			Product: product.Terraform,
-			Version: tfVersion,
-		},
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Install submodule
-	tf, err := exec.NewExecutor(testHandle.Path(), execPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = tf.Init(ctx)
-	if err != nil {
-		t.Fatal(err)
 	}
 
 	ls.Call(t, &langserver.CallRequest{

--- a/internal/langserver/handlers/document_link_test.go
+++ b/internal/langserver/handlers/document_link_test.go
@@ -3,6 +3,8 @@ package handlers
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"path/filepath"
 	"testing"
 
 	"github.com/hashicorp/go-version"
@@ -17,9 +19,13 @@ import (
 func TestDocumentLink_withValidData(t *testing.T) {
 	tmpDir := TempDir(t)
 	InitPluginCache(t, tmpDir.Path())
+	err := ioutil.WriteFile(filepath.Join(tmpDir.Path(), "main.tf"), []byte("provider \"test\" {\n\n}\n"), 0o755)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	var testSchema tfjson.ProviderSchemas
-	err := json.Unmarshal([]byte(testModuleSchemaOutput), &testSchema)
+	err = json.Unmarshal([]byte(testModuleSchemaOutput), &testSchema)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/langserver/handlers/execute_command_module_providers_test.go
+++ b/internal/langserver/handlers/execute_command_module_providers_test.go
@@ -97,7 +97,7 @@ func TestLangServer_workspaceExecuteCommand_moduleProviders_basic(t *testing.T) 
 		newDefaultProvider("aws"):    version.Must(version.NewVersion("1.2.3")),
 		newDefaultProvider("google"): version.Must(version.NewVersion("2.5.5")),
 	}
-	err = s.Modules.UpdateInstalledProviders(modDir, pVersions)
+	err = s.Modules.UpdateInstalledProviders(modDir, pVersions, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/langserver/handlers/go_to_ref_target_test.go
+++ b/internal/langserver/handlers/go_to_ref_target_test.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"path/filepath"
 	"testing"
 
@@ -118,8 +119,13 @@ func TestDefinition_withLinkToDefLessBlock(t *testing.T) {
 	tmpDir := TempDir(t)
 	InitPluginCache(t, tmpDir.Path())
 
+	err := ioutil.WriteFile(filepath.Join(tmpDir.Path(), "main.tf"), []byte("provider \"test\" {\n\n}\n"), 0o755)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	var testSchema tfjson.ProviderSchemas
-	err := json.Unmarshal([]byte(testModuleSchemaOutput), &testSchema)
+	err = json.Unmarshal([]byte(testModuleSchemaOutput), &testSchema)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -266,8 +272,13 @@ func TestDefinition_withLinkToDefBlock(t *testing.T) {
 	tmpDir := TempDir(t)
 	InitPluginCache(t, tmpDir.Path())
 
+	err := ioutil.WriteFile(filepath.Join(tmpDir.Path(), "main.tf"), []byte("provider \"test\" {\n\n}\n"), 0o755)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	var testSchema tfjson.ProviderSchemas
-	err := json.Unmarshal([]byte(testModuleSchemaOutput), &testSchema)
+	err = json.Unmarshal([]byte(testModuleSchemaOutput), &testSchema)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -598,8 +609,13 @@ func TestDeclaration_withLinkSupport(t *testing.T) {
 	tmpDir := TempDir(t)
 	InitPluginCache(t, tmpDir.Path())
 
+	err := ioutil.WriteFile(filepath.Join(tmpDir.Path(), "main.tf"), []byte("provider \"test\" {\n\n}\n"), 0o755)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	var testSchema tfjson.ProviderSchemas
-	err := json.Unmarshal([]byte(testModuleSchemaOutput), &testSchema)
+	err = json.Unmarshal([]byte(testModuleSchemaOutput), &testSchema)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/langserver/handlers/testdata/single-fake-provider/main.tf
+++ b/internal/langserver/handlers/testdata/single-fake-provider/main.tf
@@ -1,0 +1,3 @@
+provider "foo" {
+
+}

--- a/internal/state/module.go
+++ b/internal/state/module.go
@@ -92,7 +92,8 @@ type Module struct {
 	TerraformVersionErr   error
 	TerraformVersionState op.OpState
 
-	InstalledProviders InstalledProviders
+	InstalledProviders      InstalledProviders
+	InstalledProvidersState op.OpState
 
 	ProviderSchemaErr   error
 	ProviderSchemaState op.OpState
@@ -385,6 +386,97 @@ func (s *ModuleStore) ModuleCalls(modPath string) (tfmod.ModuleCalls, error) {
 	return modCalls, err
 }
 
+func (s *ModuleStore) ProviderRequirementsForModule(modPath string) (tfmod.ProviderRequirements, error) {
+	return s.providerRequirementsForModule(modPath, 0)
+}
+
+func (s *ModuleStore) providerRequirementsForModule(modPath string, level int) (tfmod.ProviderRequirements, error) {
+	// This is just a naive way of checking for cycles, so we don't end up
+	// crashing due to stack overflow.
+	//
+	// Cycles are however unlikely - at least for installed modules, since
+	// Terraform would return error when attempting to install modules
+	// with cycles.
+	if level > s.MaxModuleNesting {
+		return nil, fmt.Errorf("%s: too deep module nesting (%d)", modPath, s.MaxModuleNesting)
+	}
+	mod, err := s.ModuleByPath(modPath)
+	if err != nil {
+		return nil, err
+	}
+
+	level++
+
+	requirements := make(tfmod.ProviderRequirements, 0)
+	for k, v := range mod.Meta.ProviderRequirements {
+		requirements[k] = v
+	}
+
+	for _, mc := range mod.Meta.ModuleCalls {
+		localAddr, ok := mc.SourceAddr.(tfmod.LocalSourceAddr)
+		if !ok {
+			continue
+		}
+
+		fullPath := filepath.Join(modPath, localAddr.String())
+
+		pr, err := s.providerRequirementsForModule(fullPath, level)
+		if err != nil {
+			return requirements, err
+		}
+		for pAddr, pCons := range pr {
+			if cons, ok := requirements[pAddr]; ok {
+				for _, c := range pCons {
+					if !constraintContains(cons, c) {
+						requirements[pAddr] = append(requirements[pAddr], c)
+					}
+				}
+			}
+			requirements[pAddr] = pCons
+		}
+	}
+
+	if mod.ModManifest != nil {
+		for _, record := range mod.ModManifest.Records {
+			_, ok := record.SourceAddr.(tfmod.LocalSourceAddr)
+			if ok {
+				continue
+			}
+
+			if record.IsRoot() {
+				continue
+			}
+
+			fullPath := filepath.Join(modPath, record.Dir)
+			pr, err := s.providerRequirementsForModule(fullPath, level)
+			if err != nil {
+				continue
+			}
+			for pAddr, pCons := range pr {
+				if cons, ok := requirements[pAddr]; ok {
+					for _, c := range pCons {
+						if !constraintContains(cons, c) {
+							requirements[pAddr] = append(requirements[pAddr], c)
+						}
+					}
+				}
+				requirements[pAddr] = pCons
+			}
+		}
+	}
+
+	return requirements, nil
+}
+
+func constraintContains(vCons version.Constraints, cons *version.Constraint) bool {
+	for _, c := range vCons {
+		if c == cons {
+			return true
+		}
+	}
+	return false
+}
+
 func (s *ModuleStore) LocalModuleMeta(modPath string) (*tfmod.Meta, error) {
 	mod, err := s.ModuleByPath(modPath)
 	if err != nil {
@@ -452,8 +544,11 @@ func moduleCopyByPath(txn *memdb.Txn, path string) (*Module, error) {
 	return mod.Copy(), nil
 }
 
-func (s *ModuleStore) UpdateInstalledProviders(path string, pvs map[tfaddr.Provider]*version.Version) error {
+func (s *ModuleStore) UpdateInstalledProviders(path string, pvs map[tfaddr.Provider]*version.Version, pvErr error) error {
 	txn := s.db.Txn(true)
+	txn.Defer(func() {
+		s.SetInstalledProvidersState(path, op.OpStateLoaded)
+	})
 	defer txn.Abort()
 
 	oldMod, err := moduleByPath(txn, path)
@@ -462,20 +557,7 @@ func (s *ModuleStore) UpdateInstalledProviders(path string, pvs map[tfaddr.Provi
 	}
 
 	mod := oldMod.Copy()
-
-	// Providers may come from different sources (schema or version command)
-	// and we don't get their versions in both cases, so we make sure the existing
-	// versions are retained to get the most of both sources.
-	newProviders := make(map[tfaddr.Provider]*version.Version, 0)
-	for addr, pv := range pvs {
-		if pv == nil {
-			if v, ok := oldMod.InstalledProviders[addr]; ok && v != nil {
-				pv = v
-			}
-		}
-		newProviders[addr] = pv
-	}
-	mod.InstalledProviders = newProviders
+	mod.InstalledProviders = pvs
 
 	err = txn.Insert(s.tableName, mod)
 	if err != nil {
@@ -483,6 +565,26 @@ func (s *ModuleStore) UpdateInstalledProviders(path string, pvs map[tfaddr.Provi
 	}
 
 	err = s.queueModuleChange(txn, oldMod, mod)
+	if err != nil {
+		return err
+	}
+
+	txn.Commit()
+	return nil
+}
+
+func (s *ModuleStore) SetInstalledProvidersState(path string, state op.OpState) error {
+	txn := s.db.Txn(true)
+	defer txn.Abort()
+
+	mod, err := moduleCopyByPath(txn, path)
+	if err != nil {
+		return err
+	}
+
+	mod.InstalledProvidersState = state
+
+	err = txn.Insert(s.tableName, mod)
 	if err != nil {
 		return err
 	}

--- a/internal/state/module.go
+++ b/internal/state/module.go
@@ -93,6 +93,7 @@ type Module struct {
 	TerraformVersionState op.OpState
 
 	InstalledProviders      InstalledProviders
+	InstalledProvidersErr   error
 	InstalledProvidersState op.OpState
 
 	ProviderSchemaErr   error
@@ -143,6 +144,9 @@ func (m *Module) Copy() *Module {
 
 		ProviderSchemaErr:   m.ProviderSchemaErr,
 		ProviderSchemaState: m.ProviderSchemaState,
+
+		InstalledProvidersErr:   m.InstalledProvidersErr,
+		InstalledProvidersState: m.InstalledProvidersState,
 
 		RefTargets:      m.RefTargets.Copy(),
 		RefTargetsErr:   m.RefTargetsErr,
@@ -217,13 +221,14 @@ func (m *Module) Copy() *Module {
 
 func newModule(modPath string) *Module {
 	return &Module{
-		Path:                  modPath,
-		ModManifestState:      op.OpStateUnknown,
-		TerraformVersionState: op.OpStateUnknown,
-		ProviderSchemaState:   op.OpStateUnknown,
-		RefTargetsState:       op.OpStateUnknown,
-		ModuleParsingState:    op.OpStateUnknown,
-		MetaState:             op.OpStateUnknown,
+		Path:                    modPath,
+		ModManifestState:        op.OpStateUnknown,
+		TerraformVersionState:   op.OpStateUnknown,
+		ProviderSchemaState:     op.OpStateUnknown,
+		InstalledProvidersState: op.OpStateUnknown,
+		RefTargetsState:         op.OpStateUnknown,
+		ModuleParsingState:      op.OpStateUnknown,
+		MetaState:               op.OpStateUnknown,
 	}
 }
 
@@ -558,6 +563,7 @@ func (s *ModuleStore) UpdateInstalledProviders(path string, pvs map[tfaddr.Provi
 
 	mod := oldMod.Copy()
 	mod.InstalledProviders = pvs
+	mod.InstalledProvidersErr = pvErr
 
 	err = txn.Insert(s.tableName, mod)
 	if err != nil {

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -234,6 +234,10 @@ type ModuleStore struct {
 
 	// TimeProvider provides current time (for mocking time.Now in tests)
 	TimeProvider func() time.Time
+
+	// MaxModuleNesting represents how many nesting levels we'd attempt
+	// to parse provider requirements before returning error.
+	MaxModuleNesting int
 }
 
 type ModuleChangeStore struct {
@@ -289,10 +293,11 @@ func NewStateStore() (*StateStore, error) {
 			nextJobLowPrioMu:  &sync.Mutex{},
 		},
 		Modules: &ModuleStore{
-			db:           db,
-			tableName:    moduleTableName,
-			logger:       defaultLogger,
-			TimeProvider: time.Now,
+			db:               db,
+			tableName:        moduleTableName,
+			logger:           defaultLogger,
+			TimeProvider:     time.Now,
+			MaxModuleNesting: 50,
 		},
 		ProviderSchemas: &ProviderSchemaStore{
 			db:        db,

--- a/internal/terraform/datadir/module_manifest.go
+++ b/internal/terraform/datadir/module_manifest.go
@@ -13,6 +13,10 @@ import (
 	tfmod "github.com/hashicorp/terraform-schema/module"
 )
 
+var manifestPathElements = []string{
+	DataDirName, "modules", "modules.json",
+}
+
 func ModuleManifestFilePath(fs fs.StatFS, modulePath string) (string, bool) {
 	manifestPath := filepath.Join(
 		append([]string{modulePath},

--- a/internal/terraform/datadir/paths.go
+++ b/internal/terraform/datadir/paths.go
@@ -9,19 +9,6 @@ import (
 
 const DataDirName = ".terraform"
 
-var pluginLockFilePathElements = [][]string{
-	// Terraform >= 0.14
-	{".terraform.lock.hcl"},
-	// Terraform >= v0.13
-	{DataDirName, "plugins", "selections.json"},
-	// Terraform >= v0.12
-	{DataDirName, "plugins", runtime.GOOS + "_" + runtime.GOARCH, "lock.json"},
-}
-
-var manifestPathElements = []string{
-	DataDirName, "modules", "modules.json",
-}
-
 func watchableModuleDirs(modPath string) []string {
 	return []string{
 		filepath.Join(modPath, DataDirName),

--- a/internal/terraform/datadir/plugin_lock_file.go
+++ b/internal/terraform/datadir/plugin_lock_file.go
@@ -1,9 +1,28 @@
 package datadir
 
 import (
+	"encoding/json"
+	"errors"
 	"io/fs"
 	"path/filepath"
+	"regexp"
+	"runtime"
+
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	tfaddr "github.com/hashicorp/terraform-registry-address"
+	"github.com/zclconf/go-cty/cty"
 )
+
+var pluginLockFilePathElements = [][]string{
+	// Terraform >= 0.14
+	{".terraform.lock.hcl"},
+	// Terraform >= v0.13
+	{DataDirName, "plugins", "selections.json"},
+	// Terraform >= v0.12
+	{DataDirName, "plugins", runtime.GOOS + "_" + runtime.GOARCH, "lock.json"},
+}
 
 func PluginLockFilePath(fs fs.StatFS, modPath string) (string, bool) {
 	for _, pathElems := range pluginLockFilePathElements {
@@ -15,4 +34,183 @@ func PluginLockFilePath(fs fs.StatFS, modPath string) (string, bool) {
 	}
 
 	return "", false
+}
+
+type PluginVersionMap map[tfaddr.Provider]*version.Version
+
+type FS interface {
+	ReadFile(name string) ([]byte, error)
+	ReadDir(name string) ([]fs.DirEntry, error)
+}
+
+func ParsePluginVersions(filesystem FS, modPath string) (PluginVersionMap, error) {
+	pvm, err := parsePluginLockFile_v014(filesystem, modPath)
+	if err != nil {
+		if !errors.Is(err, fs.ErrNotExist) {
+			return nil, err
+		}
+	} else {
+		return pvm, nil
+	}
+
+	pvm, err = parsePluginLockFile_v013(filesystem, modPath)
+	if err != nil {
+		if !errors.Is(err, fs.ErrNotExist) {
+			return nil, err
+		}
+	} else {
+		return pvm, nil
+	}
+
+	return parsePluginDir_v012(filesystem, modPath)
+}
+
+// parsePluginDir_v012 parses the 0.12-style datadir.
+// See https://github.com/hashicorp/terraform/blob/v0.12.0/plugin/discovery/find.go#L45
+func parsePluginDir_v012(filesystem FS, modPath string) (PluginVersionMap, error) {
+	// Unfortunately the lock.json from 0.12 only contains hashes, not versions
+	// so we have to imply the versions from filenames (which is what Terraform 0.12 does too)
+	dirPath := filepath.Join(modPath, DataDirName, "plugins", runtime.GOOS+"_"+runtime.GOARCH)
+	entries, err := filesystem.ReadDir(dirPath)
+	if err != nil {
+		return nil, err
+	}
+
+	// terraform-provider-aws_v4.23.0_x5
+	filenameRe := regexp.MustCompile(`^terraform-provider-([^_]+)_(v[^_]+)`)
+
+	pvm := make(PluginVersionMap, 0)
+	for _, entry := range entries {
+		name := entry.Name()
+
+		matches := filenameRe.FindStringSubmatch(name)
+		if len(matches) != 3 {
+			continue
+		}
+
+		providerName, err := tfaddr.ParseProviderPart(matches[1])
+		if err != nil {
+			continue
+		}
+		providerVersion, err := version.NewVersion(matches[2])
+		if err != nil {
+			continue
+		}
+
+		pvm[legacyProviderAddr(providerName)] = providerVersion
+	}
+
+	return pvm, nil
+}
+
+func legacyProviderAddr(name string) tfaddr.Provider {
+	return tfaddr.Provider{
+		Hostname:  tfaddr.DefaultProviderRegistryHost,
+		Namespace: tfaddr.LegacyProviderNamespace,
+		Type:      name,
+	}
+}
+
+func parsePluginLockFile_v013(filesystem FS, modPath string) (PluginVersionMap, error) {
+	fullPath := filepath.Join(modPath, DataDirName, "plugins", "selections.json")
+
+	src, err := filesystem.ReadFile(fullPath)
+	if err != nil {
+		return nil, err
+	}
+
+	file := selectionFile{}
+	err = json.Unmarshal(src, &file)
+	if err != nil {
+		return nil, err
+	}
+
+	pvm := make(PluginVersionMap, 0)
+	for rawAddress, sel := range file {
+		pAddr, err := tfaddr.ParseProviderSource(rawAddress)
+		if err != nil {
+			continue
+		}
+		pvm[pAddr] = sel.Version
+	}
+
+	return pvm, nil
+}
+
+type selectionFile map[string]selection
+
+type selection struct {
+	Version *version.Version
+}
+
+func parsePluginLockFile_v014(filesystem FS, modPath string) (PluginVersionMap, error) {
+	fullPath := filepath.Join(modPath, ".terraform.lock.hcl")
+
+	src, err := filesystem.ReadFile(fullPath)
+	if err != nil {
+		return nil, err
+	}
+
+	cfg, diags := hclsyntax.ParseConfig(src, ".terraform.lock.hcl", hcl.InitialPos)
+	if diags.HasErrors() {
+		return nil, diags
+	}
+
+	// We precautiosly use PartialContent, to avoid this breaking
+	// in case Terraform CLI introduces new blocks
+	body, _, diags := cfg.Body.PartialContent(lockFileSchema)
+	if diags.HasErrors() {
+		return nil, diags
+	}
+
+	pvm := make(PluginVersionMap, 0)
+	for _, block := range body.Blocks.OfType("provider") {
+		if len(block.Labels) != 1 {
+			continue
+		}
+
+		pAddr, err := tfaddr.ParseProviderSource(block.Labels[0])
+		if err != nil {
+			continue
+		}
+
+		pBody, _, diags := block.Body.PartialContent(providerSchema)
+		if diags.HasErrors() {
+			continue
+		}
+
+		val, diags := pBody.Attributes["version"].Expr.Value(nil)
+		if diags.HasErrors() {
+			continue
+		}
+		if val.Type() != cty.String {
+			continue
+		}
+		pVersion, err := version.NewVersion(val.AsString())
+		if err != nil {
+			continue
+		}
+
+		pvm[pAddr] = pVersion
+	}
+
+	return pvm, nil
+}
+
+var lockFileSchema = &hcl.BodySchema{
+	Blocks: []hcl.BlockHeaderSchema{
+		{
+			Type:       "provider",
+			LabelNames: []string{"source"},
+		},
+	},
+}
+
+var providerSchema = &hcl.BodySchema{
+	Attributes: []hcl.AttributeSchema{
+		{
+			Name:     "version",
+			Required: true,
+		},
+	},
 }

--- a/internal/terraform/datadir/plugin_lock_file_test.go
+++ b/internal/terraform/datadir/plugin_lock_file_test.go
@@ -1,0 +1,131 @@
+package datadir
+
+import (
+	"io/fs"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"testing/fstest"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/go-version"
+	tfaddr "github.com/hashicorp/terraform-registry-address"
+)
+
+func TestParsePluginVersions_basic012(t *testing.T) {
+	// TODO: Replace OS-specific separator with '/'
+	// See https://github.com/hashicorp/terraform-ls/issues/1025
+	fs := fstest.MapFS{
+		"foo-module": &fstest.MapFile{Mode: fs.ModeDir},
+		filepath.Join("foo-module", ".terraform"):                                                                                       &fstest.MapFile{Mode: fs.ModeDir},
+		filepath.Join("foo-module", ".terraform", "plugins"):                                                                            &fstest.MapFile{Mode: fs.ModeDir},
+		filepath.Join("foo-module", ".terraform", "plugins", runtime.GOOS+"_"+runtime.GOARCH):                                           &fstest.MapFile{Mode: fs.ModeDir},
+		filepath.Join("foo-module", ".terraform", "plugins", runtime.GOOS+"_"+runtime.GOARCH) + "/terraform-provider-aws_v4.23.0_x5":    &fstest.MapFile{},
+		filepath.Join("foo-module", ".terraform", "plugins", runtime.GOOS+"_"+runtime.GOARCH) + "/terraform-provider-google_v4.29.0_x5": &fstest.MapFile{},
+	}
+	expectedVersions := PluginVersionMap{
+		legacyProviderAddr("aws"):    version.Must(version.NewVersion("4.23.0")),
+		legacyProviderAddr("google"): version.Must(version.NewVersion("4.29.0")),
+	}
+	versions, err := ParsePluginVersions(fs, "foo-module")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if diff := cmp.Diff(expectedVersions, versions); diff != "" {
+		t.Fatalf("unexpected versions: %s", diff)
+	}
+}
+
+func TestParsePluginVersions_basic013(t *testing.T) {
+	fs := fstest.MapFS{
+		"foo-module": &fstest.MapFile{Mode: fs.ModeDir},
+		filepath.Join("foo-module", ".terraform"):            &fstest.MapFile{Mode: fs.ModeDir},
+		filepath.Join("foo-module", ".terraform", "plugins"): &fstest.MapFile{Mode: fs.ModeDir},
+		filepath.Join("foo-module", ".terraform", "plugins", "selections.json"): &fstest.MapFile{
+			Data: []byte(`{
+  "registry.terraform.io/hashicorp/aws": {
+    "hash": "h1:j6RGCfnoLBpzQVOKUbGyxf4EJtRvQClKplO+WdXL5O0=",
+    "version": "4.23.0"
+  },
+  "registry.terraform.io/hashicorp/google": {
+    "hash": "h1:vZdocusWLMUSeRLI3W3dd3bgKYovGntsaHiXFIfM484=",
+    "version": "4.29.0"
+  }
+}`),
+		},
+	}
+	expectedVersions := PluginVersionMap{
+		tfaddr.MustParseProviderSource("hashicorp/aws"):    version.Must(version.NewVersion("4.23.0")),
+		tfaddr.MustParseProviderSource("hashicorp/google"): version.Must(version.NewVersion("4.29.0")),
+	}
+	versions, err := ParsePluginVersions(fs, "foo-module")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if diff := cmp.Diff(expectedVersions, versions); diff != "" {
+		t.Fatalf("unexpected versions: %s", diff)
+	}
+}
+
+func TestParsePluginVersions_basic014(t *testing.T) {
+	fs := fstest.MapFS{
+		"foo-module": &fstest.MapFile{Mode: fs.ModeDir},
+		filepath.Join("foo-module", ".terraform.lock.hcl"): &fstest.MapFile{
+			Data: []byte(`# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "4.23.0"
+  hashes = [
+    "h1:j6RGCfnoLBpzQVOKUbGyxf4EJtRvQClKplO+WdXL5O0=",
+    "zh:17adbedc9a80afc571a8de7b9bfccbe2359e2b3ce1fffd02b456d92248ec9294",
+    "zh:23d8956b031d78466de82a3d2bbe8c76cc58482c931af311580b8eaef4e6a38f",
+    "zh:343fe19e9a9f3021e26f4af68ff7f4828582070f986b6e5e5b23d89df5514643",
+    "zh:6b8ff83d884b161939b90a18a4da43dd464c4b984f54b5f537b2870ce6bd94bc",
+    "zh:7777d614d5e9d589ad5508eecf4c6d8f47d50fcbaf5d40fa7921064240a6b440",
+    "zh:82f4578861a6fd0cde9a04a1926920bd72d993d524e5b34d7738d4eff3634c44",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a08fefc153bbe0586389e814979cf7185c50fcddbb2082725991ed02742e7d1e",
+    "zh:ae789c0e7cb777d98934387f8888090ccb2d8973ef10e5ece541e8b624e1fb00",
+    "zh:b4608aab78b4dbb32c629595797107fc5a84d1b8f0682f183793d13837f0ecf0",
+    "zh:ed2c791c2354764b565f9ba4be7fc845c619c1a32cefadd3154a5665b312ab00",
+    "zh:f94ac0072a8545eebabf417bc0acbdc77c31c006ad8760834ee8ee5cdb64e743",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/google" {
+  version = "4.29.0"
+  hashes = [
+    "h1:vZdocusWLMUSeRLI3W3dd3bgKYovGntsaHiXFIfM484=",
+    "zh:00ac3a2c7006d349147809961839be1ceda83d5c620aa30541064e2507b72f35",
+    "zh:1602bdc71667abfbcc34c15944decabc5e05e167e49ce4045dc13ba234a27995",
+    "zh:173c2fb837c9c1a9b103ca9f9ade456effc705a5539ddab2a7de0b1e3d59af73",
+    "zh:231c28cc9698c9ce87218f9a8073dd30aa51b97511bf57e533b7780581cb2e4f",
+    "zh:2423c1f8065b309fc7340b880fa898f877e715c734b5322c12d004335c7591d4",
+    "zh:2c0d650520e32d8d884a4fb83cf3527605a8cadab557a0857290a3b14b85f6e5",
+    "zh:8ef536b0cb362a377e058c4105d4748cd7c4b083376abc829ce8d66396c589c7",
+    "zh:9da3e2987cd737b843f0a8558b400af1f0fe60929cd23788800a1114818d982d",
+    "zh:ad727c5eba4cce83a44f3747637876462686465e64ac40099a084935a538bb57",
+    "zh:b3895af9e06d0142ef5c6bbdd8dd0b2acb4dffa9c6631b9b6b984719c157cc1b",
+    "zh:d7be31e59a254f952f4e03bedbf4dfbd6717f5e9e5d31e1add52711f6da4aedb",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+`),
+		},
+	}
+	expectedVersions := PluginVersionMap{
+		tfaddr.MustParseProviderSource("hashicorp/aws"):    version.Must(version.NewVersion("4.23.0")),
+		tfaddr.MustParseProviderSource("hashicorp/google"): version.Must(version.NewVersion("4.29.0")),
+	}
+	versions, err := ParsePluginVersions(fs, "foo-module")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if diff := cmp.Diff(expectedVersions, versions); diff != "" {
+		t.Fatalf("unexpected versions: %s", diff)
+	}
+}

--- a/internal/terraform/module/module_ops_test.go
+++ b/internal/terraform/module/module_ops_test.go
@@ -3,10 +3,12 @@ package module
 import (
 	"context"
 	"fmt"
+	"io/fs"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
 	"testing"
+	"testing/fstest"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
@@ -15,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-ls/internal/filesystem"
 	"github.com/hashicorp/terraform-ls/internal/registry"
 	"github.com/hashicorp/terraform-ls/internal/state"
+	"github.com/hashicorp/terraform-ls/internal/terraform/module/operation"
 	tfaddr "github.com/hashicorp/terraform-registry-address"
 	tfregistry "github.com/hashicorp/terraform-schema/registry"
 	"github.com/zclconf/go-cty-debug/ctydebug"
@@ -325,4 +328,63 @@ var expectedModuleData = &tfregistry.ModuleData{
 			Description: lang.Markdown("elasticsearch username"),
 		},
 	},
+}
+
+func TestParseProviderVersions(t *testing.T) {
+	modPath := "testdir"
+
+	fs := fstest.MapFS{
+		modPath: &fstest.MapFile{Mode: fs.ModeDir},
+		filepath.Join(modPath, ".terraform.lock.hcl"): &fstest.MapFile{
+			Data: []byte(`provider "registry.terraform.io/hashicorp/aws" {
+  version = "4.23.0"
+  hashes = [
+    "h1:j6RGCfnoLBpzQVOKUbGyxf4EJtRvQClKplO+WdXL5O0=",
+    "zh:17adbedc9a80afc571a8de7b9bfccbe2359e2b3ce1fffd02b456d92248ec9294",
+    "zh:23d8956b031d78466de82a3d2bbe8c76cc58482c931af311580b8eaef4e6a38f",
+    "zh:343fe19e9a9f3021e26f4af68ff7f4828582070f986b6e5e5b23d89df5514643",
+    "zh:6b8ff83d884b161939b90a18a4da43dd464c4b984f54b5f537b2870ce6bd94bc",
+    "zh:7777d614d5e9d589ad5508eecf4c6d8f47d50fcbaf5d40fa7921064240a6b440",
+    "zh:82f4578861a6fd0cde9a04a1926920bd72d993d524e5b34d7738d4eff3634c44",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a08fefc153bbe0586389e814979cf7185c50fcddbb2082725991ed02742e7d1e",
+    "zh:ae789c0e7cb777d98934387f8888090ccb2d8973ef10e5ece541e8b624e1fb00",
+    "zh:b4608aab78b4dbb32c629595797107fc5a84d1b8f0682f183793d13837f0ecf0",
+    "zh:ed2c791c2354764b565f9ba4be7fc845c619c1a32cefadd3154a5665b312ab00",
+    "zh:f94ac0072a8545eebabf417bc0acbdc77c31c006ad8760834ee8ee5cdb64e743",
+  ]
+}
+`),
+		},
+	}
+
+	ss, err := state.NewStateStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = ss.Modules.Add(modPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = ParseProviderVersions(fs, ss.Modules, modPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mod, err := ss.Modules.ModuleByPath(modPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if mod.InstalledProvidersState != operation.OpStateLoaded {
+		t.Fatalf("expected state to be loaded, %q given", mod.InstalledProvidersState)
+	}
+	expectedInstalledProviders := state.InstalledProviders{
+		tfaddr.MustParseProviderSource("hashicorp/aws"): version.Must(version.NewVersion("4.23.0")),
+	}
+	if diff := cmp.Diff(expectedInstalledProviders, mod.InstalledProviders); diff != "" {
+		t.Fatalf("unexpected providers: %s", diff)
+	}
 }

--- a/internal/terraform/module/operation/op_type_string.go
+++ b/internal/terraform/module/operation/op_type_string.go
@@ -19,11 +19,12 @@ func _() {
 	_ = x[OpTypeDecodeReferenceOrigins-8]
 	_ = x[OpTypeDecodeVarsReferences-9]
 	_ = x[OpTypeGetModuleDataFromRegistry-10]
+	_ = x[OpTypeParseProviderVersions-11]
 }
 
-const _OpType_name = "OpTypeUnknownOpTypeGetTerraformVersionOpTypeObtainSchemaOpTypeParseModuleConfigurationOpTypeParseVariablesOpTypeParseModuleManifestOpTypeLoadModuleMetadataOpTypeDecodeReferenceTargetsOpTypeDecodeReferenceOriginsOpTypeDecodeVarsReferencesOpTypeGetModuleDataFromRegistry"
+const _OpType_name = "OpTypeUnknownOpTypeGetTerraformVersionOpTypeObtainSchemaOpTypeParseModuleConfigurationOpTypeParseVariablesOpTypeParseModuleManifestOpTypeLoadModuleMetadataOpTypeDecodeReferenceTargetsOpTypeDecodeReferenceOriginsOpTypeDecodeVarsReferencesOpTypeGetModuleDataFromRegistryOpTypeParseProviderVersions"
 
-var _OpType_index = [...]uint16{0, 13, 38, 56, 86, 106, 131, 155, 183, 211, 237, 268}
+var _OpType_index = [...]uint16{0, 13, 38, 56, 86, 106, 131, 155, 183, 211, 237, 268, 295}
 
 func (i OpType) String() string {
 	if i >= OpType(len(_OpType_index)-1) {

--- a/internal/terraform/module/operation/operation.go
+++ b/internal/terraform/module/operation/operation.go
@@ -25,4 +25,5 @@ const (
 	OpTypeDecodeReferenceOrigins
 	OpTypeDecodeVarsReferences
 	OpTypeGetModuleDataFromRegistry
+	OpTypeParseProviderVersions
 )

--- a/internal/walker/walker_test.go
+++ b/internal/walker/walker_test.go
@@ -387,6 +387,7 @@ func TestWalker_complexModules(t *testing.T) {
 			pa := state.NewPathAwaiter(ss.WalkerPaths, false)
 			indexer := indexer.NewIndexer(fs, ss.Modules, ss.ProviderSchemas, ss.RegistryModules, ss.JobStore,
 				exec.NewMockExecutor(tfCalls), registry.NewClient())
+			indexer.SetLogger(testLogger())
 			w := NewWalker(fs, pa, ss.Modules, indexer.WalkedModule)
 			w.Collector = NewWalkerCollector()
 			w.SetLogger(testLogger())


### PR DESCRIPTION
Depends on https://github.com/hashicorp/terraform-ls/pull/1021 (`DependsOn`)

Closes https://github.com/hashicorp/terraform-ls/issues/992

--- 

This introduces `ParsePluginVersions` which can parse provider/plugin versions as encoded by any version from Terraform v0.12. Attached tests probably best explain the differences between the versions.

Secondly the PR introduces `ParseProviderVersions` job, which leverages the mentioned function to parse the versions. This becomes the only way we obtain provider versions (previously it was `terraform version -json` as part of `GetTerraformVersion` job).

Lastly I raised https://github.com/hashicorp/terraform-ls/issues/1025 to further explain and eventually address the problem with path separators. With `testing/fstest` (or at least for the `ReadDir` implementation there) we have to use both OS-specific separator, but still use `/` to separate the "listable" files from dirs in a dir which we'll call `ReadDir()` on, otherwise `\` are treated as any other character, basically making them part of the opaque file/dir name.