### PR TITLE
Add hooks for dynamic completion

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/hc-install v0.4.0
-	github.com/hashicorp/hcl-lang v0.0.0-20220719100104-053ec0de36b0
+	github.com/hashicorp/hcl-lang v0.0.0-20220801150536-118ac453e267
 	github.com/hashicorp/hcl/v2 v2.13.0
 	github.com/hashicorp/terraform-exec v0.17.2
 	github.com/hashicorp/terraform-json v0.14.0

--- a/go.sum
+++ b/go.sum
@@ -323,8 +323,11 @@ github.com/hashicorp/hc-install v0.4.0 h1:cZkRFr1WVa0Ty6x5fTvL1TuO1flul231rWkGH9
 github.com/hashicorp/hc-install v0.4.0/go.mod h1:5d155H8EC5ewegao9A4PUTMNPZaq+TbOzkJJZ4vrXeI=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/hashicorp/hcl-lang v0.0.0-20220719100104-053ec0de36b0 h1:I/FnNaXCYPU5Vt09KII1iYqZiSvNnTYlRJbmNFXB3R8=
 github.com/hashicorp/hcl-lang v0.0.0-20220719100104-053ec0de36b0/go.mod h1:s6PiZCSfwaQeFs28zZMESYpK+ZivG2QgtwpJG18ZLzA=
+github.com/hashicorp/hcl-lang v0.0.0-20220727102408-593035f5162e h1:2domzzt/gHTQJyhly+3aveYwYCihZr2/NYyjTTJ9mho=
+github.com/hashicorp/hcl-lang v0.0.0-20220727102408-593035f5162e/go.mod h1:s6PiZCSfwaQeFs28zZMESYpK+ZivG2QgtwpJG18ZLzA=
+github.com/hashicorp/hcl-lang v0.0.0-20220801150536-118ac453e267 h1:8Vn+GbhtkSH0rMv4SYF/WJO1j5z1z0vvpvwHPZB3Fxs=
+github.com/hashicorp/hcl-lang v0.0.0-20220801150536-118ac453e267/go.mod h1:zGFgYSTTY5D5F+diri+HFKo2JGLqJb5icJl4CSEGPHk=
 github.com/hashicorp/hcl/v2 v2.13.0 h1:0Apadu1w6M11dyGFxWnmhhcMjkbAiKCv7G1r/2QgCNc=
 github.com/hashicorp/hcl/v2 v2.13.0/go.mod h1:e4z5nxYlWNPdDSNYX+ph14EvWYMFm3eP0zIUqPc2jr0=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=

--- a/internal/decoder/decoder.go
+++ b/internal/decoder/decoder.go
@@ -75,9 +75,11 @@ func varsPathContext(mod *state.Module) (*decoder.PathContext, error) {
 
 func DecoderContext(ctx context.Context) decoder.DecoderContext {
 	dCtx := decoder.DecoderContext{
-		UtmSource:     utm.UtmSource,
-		UtmMedium:     utm.UtmMedium(ctx),
-		UseUtmContent: true,
+		UtmSource:              utm.UtmSource,
+		UtmMedium:              utm.UtmMedium(ctx),
+		UseUtmContent:          true,
+		CompletionHooks:        make(decoder.CompletionFuncMap),
+		CompletionResolveHooks: make(decoder.CompletionResolveFuncMap),
 	}
 
 	cc, err := ilsp.ClientCapabilities(ctx)

--- a/internal/decoder/decoder.go
+++ b/internal/decoder/decoder.go
@@ -74,13 +74,10 @@ func varsPathContext(mod *state.Module) (*decoder.PathContext, error) {
 }
 
 func DecoderContext(ctx context.Context) decoder.DecoderContext {
-	dCtx := decoder.DecoderContext{
-		UtmSource:              utm.UtmSource,
-		UtmMedium:              utm.UtmMedium(ctx),
-		UseUtmContent:          true,
-		CompletionHooks:        make(decoder.CompletionFuncMap),
-		CompletionResolveHooks: make(decoder.CompletionResolveFuncMap),
-	}
+	dCtx := decoder.NewDecoderContext()
+	dCtx.UtmSource = utm.UtmSource
+	dCtx.UtmMedium = utm.UtmMedium(ctx)
+	dCtx.UseUtmContent = true
 
 	cc, err := ilsp.ClientCapabilities(ctx)
 	if err == nil {

--- a/internal/decoder/decoder.go
+++ b/internal/decoder/decoder.go
@@ -15,12 +15,6 @@ import (
 	tfschema "github.com/hashicorp/terraform-schema/schema"
 )
 
-func NewDecoder(ctx context.Context, pathReader decoder.PathReader) *decoder.Decoder {
-	d := decoder.NewDecoder(pathReader)
-	d.SetContext(decoderContext(ctx))
-	return d
-}
-
 func modulePathContext(mod *state.Module, schemaReader state.SchemaReader, modReader ModuleReader) (*decoder.PathContext, error) {
 	schema, err := schemaForModule(mod, schemaReader, modReader)
 	if err != nil {
@@ -79,7 +73,7 @@ func varsPathContext(mod *state.Module) (*decoder.PathContext, error) {
 	return pathCtx, nil
 }
 
-func decoderContext(ctx context.Context) decoder.DecoderContext {
+func DecoderContext(ctx context.Context) decoder.DecoderContext {
 	dCtx := decoder.DecoderContext{
 		UtmSource:     utm.UtmSource,
 		UtmMedium:     utm.UtmMedium(ctx),

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -1,16 +1,6 @@
 // Package hooks enables the implementation of hooks for dynamic
 // autocompletion. Hooks should be added to this package and
-// registered in AppendCompletionHooks in completion_hooks.go.
-//
-// A hook must have the following signature:
-//  func (h *Hooks) Name(ctx context.Context, value cty.Value) ([]decoder.Candidate, error)
-// It receives the current value of the attribute and must return
-// a list of completion candidates.
-//
-// All hooks have access to path, filename and pos via context:
-//  path, ok := decoder.PathFromContext(ctx)
-//  filename, ok := decoder.FilenameFromContext(ctx)
-//  pos, ok := decoder.PosFromContext(ctx)
+// registered via AppendCompletionHooks in completion_hooks.go.
 package hooks
 
 import "github.com/hashicorp/terraform-ls/internal/state"

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -1,0 +1,20 @@
+// Package hooks enables the implementation of hooks for dynamic
+// autocompletion. Hooks should be added to this package and
+// registered in AppendCompletionHooks in completion_hooks.go.
+//
+// A hook must have the following signature:
+//  func (h *Hooks) Name(ctx context.Context, value cty.Value) ([]decoder.Candidate, error)
+// It receives the current value of the attribute and must return
+// a list of completion candidates.
+//
+// All hooks have access to path, filename and pos via context:
+//  path, ok := decoder.PathFromContext(ctx)
+//  filename, ok := decoder.FilenameFromContext(ctx)
+//  pos, ok := decoder.PosFromContext(ctx)
+package hooks
+
+import "github.com/hashicorp/terraform-ls/internal/state"
+
+type Hooks struct {
+	ModStore *state.ModuleStore
+}

--- a/internal/hooks/module_source_local.go
+++ b/internal/hooks/module_source_local.go
@@ -1,0 +1,18 @@
+package hooks
+
+import (
+	"context"
+
+	"github.com/hashicorp/hcl-lang/decoder"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func (h *Hooks) LocalModuleSources(ctx context.Context, value cty.Value) ([]decoder.Candidate, error) {
+	candidates := make([]decoder.Candidate, 0)
+
+	// Obtain indexed modules via h.modStore.List()
+	// TODO filter modules inside .terraform
+	// TODO build candidates
+
+	return candidates, nil
+}

--- a/internal/langserver/handlers/complete.go
+++ b/internal/langserver/handlers/complete.go
@@ -40,7 +40,7 @@ func (svc *service) TextDocumentComplete(ctx context.Context, params lsp.Complet
 	}
 
 	svc.logger.Printf("Looking for candidates at %q -> %#v", doc.Filename, pos)
-	candidates, err := d.CandidatesAtPos(doc.Filename, pos)
+	candidates, err := d.CandidatesAtPos(ctx, doc.Filename, pos)
 	svc.logger.Printf("received candidates: %#v", candidates)
 	return ilsp.ToCompletionList(candidates, cc.TextDocument), err
 }

--- a/internal/langserver/handlers/completion_hooks.go
+++ b/internal/langserver/handlers/completion_hooks.go
@@ -1,0 +1,15 @@
+package handlers
+
+import (
+	"github.com/hashicorp/hcl-lang/decoder"
+	"github.com/hashicorp/terraform-ls/internal/hooks"
+)
+
+func (s *service) AppendCompletionHooks(ctx decoder.DecoderContext) {
+	h := hooks.Hooks{
+		ModStore: s.modStore,
+	}
+
+	ctx.CompletionHooks["CompleteLocalModuleSources"] = h.LocalModuleSources
+
+}

--- a/internal/langserver/handlers/completion_resolve.go
+++ b/internal/langserver/handlers/completion_resolve.go
@@ -9,7 +9,7 @@ import (
 	lsp "github.com/hashicorp/terraform-ls/internal/protocol"
 )
 
-func (svc *service) CompletionItemResolve(ctx context.Context, params lsp.CompletionItemR) (lsp.CompletionItemR, error) {
+func (svc *service) CompletionItemResolve(ctx context.Context, params lsp.CompletionItemWithResolveHook) (lsp.CompletionItemWithResolveHook, error) {
 	cc, err := ilsp.ClientCapabilities(ctx)
 	if err != nil {
 		return params, err

--- a/internal/langserver/handlers/completion_resolve.go
+++ b/internal/langserver/handlers/completion_resolve.go
@@ -1,0 +1,55 @@
+package handlers
+
+import (
+	"context"
+
+	"github.com/hashicorp/hcl-lang/decoder"
+	"github.com/hashicorp/hcl-lang/lang"
+	ilsp "github.com/hashicorp/terraform-ls/internal/lsp"
+	"github.com/hashicorp/terraform-ls/internal/mdplain"
+	lsp "github.com/hashicorp/terraform-ls/internal/protocol"
+)
+
+type CompletionItem struct {
+	lsp.CompletionItem
+
+	ResolveHook *lang.ResolveHook `json:"data,omitempty"`
+}
+
+func (svc *service) CompletionItemResolve(ctx context.Context, params CompletionItem) (CompletionItem, error) {
+	cc, err := ilsp.ClientCapabilities(ctx)
+	if err != nil {
+		return params, err
+	}
+
+	if params.ResolveHook == nil {
+		return params, nil
+	}
+
+	unresolvedCandidate := decoder.UnresolvedCandidate{
+		ResolveHook: params.ResolveHook,
+	}
+
+	resolvedCandidate, err := svc.decoder.ResolveCandidate(ctx, unresolvedCandidate)
+	if err != nil || resolvedCandidate == nil {
+		return params, err
+	}
+
+	if resolvedCandidate.Description.Value != "" {
+		doc := resolvedCandidate.Description.Value
+
+		// TODO: Revisit when MarkupContent is allowed as Documentation
+		// https://github.com/golang/tools/blob/4783bc9b/internal/lsp/protocol/tsprotocol.go#L753
+		doc = mdplain.Clean(doc)
+		params.Documentation = doc
+	}
+	if resolvedCandidate.Detail != "" {
+		params.Detail = resolvedCandidate.Detail
+	}
+	if len(resolvedCandidate.AdditionalTextEdits) > 0 {
+		snippetSupport := cc.TextDocument.Completion.CompletionItem.SnippetSupport
+		params.AdditionalTextEdits = ilsp.TextEdits(resolvedCandidate.AdditionalTextEdits, snippetSupport)
+	}
+
+	return params, nil
+}

--- a/internal/langserver/handlers/completion_resolve.go
+++ b/internal/langserver/handlers/completion_resolve.go
@@ -4,19 +4,12 @@ import (
 	"context"
 
 	"github.com/hashicorp/hcl-lang/decoder"
-	"github.com/hashicorp/hcl-lang/lang"
 	ilsp "github.com/hashicorp/terraform-ls/internal/lsp"
 	"github.com/hashicorp/terraform-ls/internal/mdplain"
 	lsp "github.com/hashicorp/terraform-ls/internal/protocol"
 )
 
-type CompletionItem struct {
-	lsp.CompletionItem
-
-	ResolveHook *lang.ResolveHook `json:"data,omitempty"`
-}
-
-func (svc *service) CompletionItemResolve(ctx context.Context, params CompletionItem) (CompletionItem, error) {
+func (svc *service) CompletionItemResolve(ctx context.Context, params lsp.CompletionItemR) (lsp.CompletionItemR, error) {
 	cc, err := ilsp.ClientCapabilities(ctx)
 	if err != nil {
 		return params, err

--- a/internal/langserver/handlers/completion_resolve_test.go
+++ b/internal/langserver/handlers/completion_resolve_test.go
@@ -1,0 +1,72 @@
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	tfjson "github.com/hashicorp/terraform-json"
+	"github.com/hashicorp/terraform-ls/internal/langserver"
+	"github.com/hashicorp/terraform-ls/internal/langserver/session"
+)
+
+func TestCompletionResolve_withoutInitialization(t *testing.T) {
+	ls := langserver.NewLangServerMock(t, NewMockSession(nil))
+	stop := ls.Start(t)
+	defer stop()
+
+	ls.CallAndExpectError(t, &langserver.CallRequest{
+		Method:    "completionItem/resolve",
+		ReqParams: "{}"}, session.SessionNotInitialized.Err())
+}
+
+func TestCompletionResolve_withoutHook(t *testing.T) {
+	tmpDir := TempDir(t)
+	InitPluginCache(t, tmpDir.Path())
+
+	var testSchema tfjson.ProviderSchemas
+	err := json.Unmarshal([]byte(testModuleSchemaOutput), &testSchema)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ls := langserver.NewLangServerMock(t, NewMockSession(nil))
+	stop := ls.Start(t)
+	defer stop()
+
+	ls.Call(t, &langserver.CallRequest{
+		Method: "initialize",
+		ReqParams: fmt.Sprintf(`{
+		"capabilities": {},
+		"rootUri": %q,
+		"processId": 12345
+	}`, tmpDir.URI)})
+	ls.Notify(t, &langserver.CallRequest{
+		Method:    "initialized",
+		ReqParams: "{}",
+	})
+
+	ls.CallAndExpectResponse(t, &langserver.CallRequest{
+		Method: "completionItem/resolve",
+		ReqParams: fmt.Sprintf(`{
+			"label": "\"test\"",
+			"kind": 1,
+			"data": {
+				"resolve_hook": "test",
+				"path": "%s/main.tf"
+			}
+		}`, TempDir(t).URI),
+	}, fmt.Sprintf(`{
+			"jsonrpc": "2.0",
+			"id": 2,
+			"result": {
+				"label": "\"test\"",
+				"labelDetails": {},
+				"kind": 1,
+				"data": {
+					"resolve_hook": "test",
+					"path": "%s/main.tf"
+				}
+			}
+	}`, TempDir(t).URI))
+}

--- a/internal/langserver/handlers/handlers_test.go
+++ b/internal/langserver/handlers/handlers_test.go
@@ -37,6 +37,7 @@ func initializeResponse(t *testing.T, commandPrefix string) string {
 				},
 				"completionProvider": {
 					"triggerCharacters": [".", "["],
+					"resolveProvider": true,
 					"completionItem":{}
 				},
 				"hoverProvider": true,

--- a/internal/langserver/handlers/initialize.go
+++ b/internal/langserver/handlers/initialize.go
@@ -207,7 +207,7 @@ func initializeResult(ctx context.Context) lsp.InitializeResult {
 				Change:    lsp.Incremental,
 			},
 			CompletionProvider: lsp.CompletionOptions{
-				ResolveProvider:   false,
+				ResolveProvider:   true,
 				TriggerCharacters: []string{".", "["},
 			},
 			CodeActionProvider: lsp.CodeActionOptions{

--- a/internal/langserver/handlers/service.go
+++ b/internal/langserver/handlers/service.go
@@ -484,10 +484,12 @@ func (svc *service) configureSessionDependencies(ctx context.Context, cfgOpts *s
 		svc.stateStore.JobStore, svc.tfExecFactory, svc.registryClient)
 	svc.indexer.SetLogger(svc.logger)
 
-	svc.decoder = idecoder.NewDecoder(ctx, &idecoder.PathReader{
+	svc.decoder = decoder.NewDecoder(&idecoder.PathReader{
 		ModuleReader: svc.modStore,
 		SchemaReader: svc.schemaStore,
 	})
+	decoderContext := idecoder.DecoderContext(ctx)
+	svc.decoder.SetContext(decoderContext)
 
 	err = schemas.PreloadSchemasToStore(svc.stateStore.ProviderSchemas)
 	if err != nil {

--- a/internal/langserver/handlers/service.go
+++ b/internal/langserver/handlers/service.go
@@ -489,6 +489,7 @@ func (svc *service) configureSessionDependencies(ctx context.Context, cfgOpts *s
 		SchemaReader: svc.schemaStore,
 	})
 	decoderContext := idecoder.DecoderContext(ctx)
+	svc.AppendCompletionHooks(decoderContext)
 	svc.decoder.SetContext(decoderContext)
 
 	err = schemas.PreloadSchemasToStore(svc.stateStore.ProviderSchemas)

--- a/internal/langserver/handlers/service.go
+++ b/internal/langserver/handlers/service.go
@@ -217,6 +217,17 @@ func (svc *service) Assigner() (jrpc2.Assigner, error) {
 
 			return handle(ctx, req, svc.TextDocumentComplete)
 		},
+		"completionItem/resolve": func(ctx context.Context, req *jrpc2.Request) (interface{}, error) {
+			err := session.CheckInitializationIsConfirmed()
+			if err != nil {
+				return nil, err
+			}
+
+			ctx = ilsp.WithClientCapabilities(ctx, cc)
+			ctx = lsctx.WithExperimentalFeatures(ctx, &expFeatures)
+
+			return handle(ctx, req, svc.CompletionItemResolve)
+		},
 		"textDocument/hover": func(ctx context.Context, req *jrpc2.Request) (interface{}, error) {
 			err := session.CheckInitializationIsConfirmed()
 			if err != nil {

--- a/internal/lsp/completion.go
+++ b/internal/lsp/completion.go
@@ -72,6 +72,7 @@ func toCompletionItem(candidate lang.Candidate, caps lsp.CompletionClientCapabil
 		Command:             cmd,
 		AdditionalTextEdits: textEdits(candidate.AdditionalTextEdits, snippetSupport),
 		Data:                candidate.ResolveHook,
+		// TODO set deprecated via `tags` if supported.
 	}
 
 	if caps.CompletionItem.DeprecatedSupport {

--- a/internal/lsp/completion.go
+++ b/internal/lsp/completion.go
@@ -70,7 +70,7 @@ func toCompletionItem(candidate lang.Candidate, caps lsp.CompletionClientCapabil
 		Documentation:       doc,
 		TextEdit:            textEdit(candidate.TextEdit, snippetSupport),
 		Command:             cmd,
-		AdditionalTextEdits: textEdits(candidate.AdditionalTextEdits, snippetSupport),
+		AdditionalTextEdits: TextEdits(candidate.AdditionalTextEdits, snippetSupport),
 		Data:                candidate.ResolveHook,
 		// TODO set deprecated via `tags` if supported.
 	}

--- a/internal/lsp/completion.go
+++ b/internal/lsp/completion.go
@@ -71,6 +71,7 @@ func toCompletionItem(candidate lang.Candidate, caps lsp.CompletionClientCapabil
 		TextEdit:            textEdit(candidate.TextEdit, snippetSupport),
 		Command:             cmd,
 		AdditionalTextEdits: textEdits(candidate.AdditionalTextEdits, snippetSupport),
+		Data:                candidate.ResolveHook,
 	}
 
 	if caps.CompletionItem.DeprecatedSupport {

--- a/internal/lsp/completion.go
+++ b/internal/lsp/completion.go
@@ -71,7 +71,6 @@ func toCompletionItem(candidate lang.Candidate, caps lsp.CompletionClientCapabil
 		TextEdit:            textEdit(candidate.TextEdit, snippetSupport),
 		Command:             cmd,
 		AdditionalTextEdits: TextEdits(candidate.AdditionalTextEdits, snippetSupport),
-		// TODO set deprecated via `tags` if supported.
 	}
 
 	if candidate.ResolveHook != nil {

--- a/internal/lsp/completion.go
+++ b/internal/lsp/completion.go
@@ -71,8 +71,11 @@ func toCompletionItem(candidate lang.Candidate, caps lsp.CompletionClientCapabil
 		TextEdit:            textEdit(candidate.TextEdit, snippetSupport),
 		Command:             cmd,
 		AdditionalTextEdits: TextEdits(candidate.AdditionalTextEdits, snippetSupport),
-		Data:                candidate.ResolveHook,
 		// TODO set deprecated via `tags` if supported.
+	}
+
+	if candidate.ResolveHook != nil {
+		item.Data = candidate.ResolveHook
 	}
 
 	if caps.CompletionItem.DeprecatedSupport {

--- a/internal/lsp/text_edits.go
+++ b/internal/lsp/text_edits.go
@@ -19,7 +19,7 @@ func TextEditsFromDocumentChanges(changes document.Changes) []lsp.TextEdit {
 	return edits
 }
 
-func textEdits(tes []lang.TextEdit, snippetSupport bool) []lsp.TextEdit {
+func TextEdits(tes []lang.TextEdit, snippetSupport bool) []lsp.TextEdit {
 	edits := make([]lsp.TextEdit, len(tes))
 
 	for i, te := range tes {

--- a/internal/protocol/completion.go
+++ b/internal/protocol/completion.go
@@ -1,0 +1,9 @@
+package protocol
+
+import "github.com/hashicorp/hcl-lang/lang"
+
+type CompletionItemR struct {
+	CompletionItem
+
+	ResolveHook *lang.ResolveHook `json:"data,omitempty"`
+}

--- a/internal/protocol/completion.go
+++ b/internal/protocol/completion.go
@@ -2,7 +2,7 @@ package protocol
 
 import "github.com/hashicorp/hcl-lang/lang"
 
-type CompletionItemR struct {
+type CompletionItemWithResolveHook struct {
 	CompletionItem
 
 	ResolveHook *lang.ResolveHook `json:"data,omitempty"`


### PR DESCRIPTION
This PR introduces a new `hooks` package, which we can use to implement hooks for dynamic completion. Hooks will be implemented as part of https://github.com/hashicorp/vscode-terraform/issues/672.

We also introduce a new `completionItem/resolve` handler, which editors can use to update a completion item with more detailed data. The data is obtained via the execution of a resolve hook.

---

* Closes https://github.com/hashicorp/terraform-ls/issues/868
* Requires https://github.com/hashicorp/hcl-lang/pull/123