### PR TITLE
Schemas: Exclude nttcom/ecl

### DIFF
--- a/internal/schemas/gen/gen.go
+++ b/internal/schemas/gen/gen.go
@@ -267,6 +267,7 @@ var ignore = map[string]bool{
 	"zededa/zedcloud":              true,
 	"lightstep/lightstep":          true,
 	"thousandeyes/thousandeyes":    true,
+	"nttcom/ecl":                   true,
 }
 
 var darwinArm64Ignore = map[string]bool{


### PR DESCRIPTION
The latest release 2.4.5 is missing on GitHub, https://github.com/hashicorp/terraform-ls/runs/7615086797?check_suite_focus=true