### PR TITLE
state: Introduce `DependsOn` for N-to-1 job dependencies

### DIFF
--- a/internal/indexer/document_change.go
+++ b/internal/indexer/document_change.go
@@ -12,107 +12,108 @@ import (
 func (idx *Indexer) DocumentChanged(modHandle document.DirHandle) (job.IDs, error) {
 	ids := make(job.IDs, 0)
 
-	id, err := idx.jobStore.EnqueueJob(job.Job{
+	parseId, err := idx.jobStore.EnqueueJob(job.Job{
 		Dir: modHandle,
 		Func: func(ctx context.Context) error {
 			return module.ParseModuleConfiguration(idx.fs, idx.modStore, modHandle.Path())
 		},
 		Type: op.OpTypeParseModuleConfiguration.String(),
-		Defer: func(ctx context.Context, jobErr error) (job.IDs, error) {
-			return idx.decodeModule(ctx, modHandle)
-		},
 	})
 	if err != nil {
 		return ids, err
 	}
-	ids = append(ids, id)
+	ids = append(ids, parseId)
 
-	id, err = idx.jobStore.EnqueueJob(job.Job{
+	modIds, err := idx.decodeModule(modHandle, job.IDs{parseId})
+	if err != nil {
+		return ids, err
+	}
+	ids = append(ids, modIds...)
+
+	parseVarsId, err := idx.jobStore.EnqueueJob(job.Job{
 		Dir: modHandle,
 		Func: func(ctx context.Context) error {
 			return module.ParseVariables(idx.fs, idx.modStore, modHandle.Path())
 		},
 		Type: op.OpTypeParseVariables.String(),
-		Defer: func(ctx context.Context, jobErr error) (job.IDs, error) {
-			ids := make(job.IDs, 0)
-			id, err := idx.jobStore.EnqueueJob(job.Job{
-				Dir: modHandle,
-				Func: func(ctx context.Context) error {
-					return module.DecodeVarsReferences(ctx, idx.modStore, idx.schemaStore, modHandle.Path())
-				},
-				Type: op.OpTypeDecodeVarsReferences.String(),
-			})
-			if err != nil {
-				return ids, err
-			}
-			ids = append(ids, id)
-			return ids, nil
-		},
 	})
 	if err != nil {
 		return ids, err
 	}
-	ids = append(ids, id)
+	ids = append(ids, parseVarsId)
+
+	varsRefsId, err := idx.jobStore.EnqueueJob(job.Job{
+		Dir: modHandle,
+		Func: func(ctx context.Context) error {
+			return module.DecodeVarsReferences(ctx, idx.modStore, idx.schemaStore, modHandle.Path())
+		},
+		Type:      op.OpTypeDecodeVarsReferences.String(),
+		DependsOn: job.IDs{parseVarsId},
+	})
+	if err != nil {
+		return ids, err
+	}
+	ids = append(ids, varsRefsId)
 
 	return ids, nil
 }
 
-func (idx *Indexer) decodeModule(ctx context.Context, modHandle document.DirHandle) (job.IDs, error) {
+func (idx *Indexer) decodeModule(modHandle document.DirHandle, dependsOn job.IDs) (job.IDs, error) {
 	ids := make(job.IDs, 0)
 
-	id, err := idx.jobStore.EnqueueJob(job.Job{
+	metaId, err := idx.jobStore.EnqueueJob(job.Job{
 		Dir: modHandle,
 		Func: func(ctx context.Context) error {
 			return module.LoadModuleMetadata(idx.modStore, modHandle.Path())
 		},
-		Type: op.OpTypeLoadModuleMetadata.String(),
-		Defer: func(ctx context.Context, jobErr error) (job.IDs, error) {
-			ids := make(job.IDs, 0)
-			id, err := idx.jobStore.EnqueueJob(job.Job{
-				Dir: modHandle,
-				Func: func(ctx context.Context) error {
-					return module.DecodeReferenceTargets(ctx, idx.modStore, idx.schemaStore, modHandle.Path())
-				},
-				Type: op.OpTypeDecodeReferenceTargets.String(),
-			})
-			if err != nil {
-				return ids, err
-			}
-			ids = append(ids, id)
-
-			id, err = idx.jobStore.EnqueueJob(job.Job{
-				Dir: modHandle,
-				Func: func(ctx context.Context) error {
-					return module.DecodeReferenceOrigins(ctx, idx.modStore, idx.schemaStore, modHandle.Path())
-				},
-				Type: op.OpTypeDecodeReferenceOrigins.String(),
-			})
-			if err != nil {
-				return ids, err
-			}
-			ids = append(ids, id)
-
-			id, err = idx.jobStore.EnqueueJob(job.Job{
-				Dir: modHandle,
-				Func: func(ctx context.Context) error {
-					return module.GetModuleDataFromRegistry(ctx, idx.registryClient,
-						idx.modStore, idx.registryModStore, modHandle.Path())
-				},
-				Priority: job.LowPriority,
-				Type:     op.OpTypeGetModuleDataFromRegistry.String(),
-			})
-			if err != nil {
-				return ids, err
-			}
-
-			ids = append(ids, id)
-			return ids, nil
-		},
+		Type:      op.OpTypeLoadModuleMetadata.String(),
+		DependsOn: dependsOn,
 	})
 	if err != nil {
 		return ids, err
 	}
-	ids = append(ids, id)
+	ids = append(ids, metaId)
+
+	refTargetsId, err := idx.jobStore.EnqueueJob(job.Job{
+		Dir: modHandle,
+		Func: func(ctx context.Context) error {
+			return module.DecodeReferenceTargets(ctx, idx.modStore, idx.schemaStore, modHandle.Path())
+		},
+		Type:      op.OpTypeDecodeReferenceTargets.String(),
+		DependsOn: job.IDs{metaId},
+	})
+	if err != nil {
+		return ids, err
+	}
+	ids = append(ids, refTargetsId)
+
+	refOriginsId, err := idx.jobStore.EnqueueJob(job.Job{
+		Dir: modHandle,
+		Func: func(ctx context.Context) error {
+			return module.DecodeReferenceOrigins(ctx, idx.modStore, idx.schemaStore, modHandle.Path())
+		},
+		Type:      op.OpTypeDecodeReferenceOrigins.String(),
+		DependsOn: job.IDs{metaId},
+	})
+	if err != nil {
+		return ids, err
+	}
+	ids = append(ids, refOriginsId)
+
+	registryId, err := idx.jobStore.EnqueueJob(job.Job{
+		Dir: modHandle,
+		Func: func(ctx context.Context) error {
+			return module.GetModuleDataFromRegistry(ctx, idx.registryClient,
+				idx.modStore, idx.registryModStore, modHandle.Path())
+		},
+		Priority: job.LowPriority,
+		Type:     op.OpTypeGetModuleDataFromRegistry.String(),
+	})
+	if err != nil {
+		return ids, err
+	}
+
+	ids = append(ids, registryId)
 
 	return ids, nil
 }

--- a/internal/indexer/module_calls.go
+++ b/internal/indexer/module_calls.go
@@ -105,7 +105,6 @@ func (idx *Indexer) decodeInstalledModuleCalls(modHandle document.DirHandle) (jo
 			})
 			if err != nil {
 				multierror.Append(errs, err)
-				continue
 			} else {
 				jobIds = append(jobIds, varsRefId)
 			}

--- a/internal/job/job.go
+++ b/internal/job/job.go
@@ -27,6 +27,11 @@ type Job struct {
 	// and before the job is marked as done (StateDone).
 	// This can be used to schedule jobs dependent on the main job.
 	Defer DeferFunc
+
+	// DependsOn represents any other job IDs this job depends on.
+	// This will be taken into account when scheduling, so that only
+	// jobs with no dependencies are dispatched at any time.
+	DependsOn IDs
 }
 
 // DeferFunc represents a deferred function scheduling more jobs
@@ -36,11 +41,12 @@ type DeferFunc func(ctx context.Context, jobErr error) (IDs, error)
 
 func (job Job) Copy() Job {
 	return Job{
-		Func:     job.Func,
-		Dir:      job.Dir,
-		Type:     job.Type,
-		Priority: job.Priority,
-		Defer:    job.Defer,
+		Func:      job.Func,
+		Dir:       job.Dir,
+		Type:      job.Type,
+		Priority:  job.Priority,
+		Defer:     job.Defer,
+		DependsOn: job.DependsOn.Copy(),
 	}
 }
 

--- a/internal/state/job_id_slice_index.go
+++ b/internal/state/job_id_slice_index.go
@@ -1,0 +1,35 @@
+package state
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-memdb"
+	"github.com/hashicorp/terraform-ls/internal/job"
+)
+
+type JobIdSliceIndex struct {
+	Field string
+}
+
+func (s *JobIdSliceIndex) FromObject(obj interface{}) (bool, [][]byte, error) {
+	idx := &memdb.StringSliceFieldIndex{Field: s.Field}
+	return idx.FromObject(obj)
+}
+
+func (s *JobIdSliceIndex) FromArgs(args ...interface{}) ([]byte, error) {
+	if len(args) != 1 {
+		return nil, fmt.Errorf("must provide only a single argument")
+	}
+	arg, ok := args[0].(job.ID)
+	if !ok {
+		return nil, fmt.Errorf("argument must be a job.ID: %#v", args[0])
+	}
+	// Add the null character as a terminator
+	arg += "\x00"
+	return []byte(arg), nil
+}
+
+func (s *JobIdSliceIndex) PrefixFromArgs(args ...interface{}) ([]byte, error) {
+	idx := &memdb.StringSliceFieldIndex{Field: s.Field}
+	return idx.PrefixFromArgs(args...)
+}

--- a/internal/state/jobs.go
+++ b/internal/state/jobs.go
@@ -447,7 +447,7 @@ func (js *JobStore) removeJobFromDependsOn(txn *memdb.Txn, id job.ID) error {
 			jobCopy.DependsOn = jobCopy.DependsOn[:len(jobCopy.DependsOn)-1]
 
 			// re-insert updated data
-			_, err := txn.DeleteAll(js.tableName, "id", id)
+			_, err := txn.DeleteAll(js.tableName, "id", jobCopy.ID)
 			if err != nil {
 				return err
 			}

--- a/internal/state/slice_length_index.go
+++ b/internal/state/slice_length_index.go
@@ -1,0 +1,57 @@
+package state
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/hashicorp/go-memdb"
+)
+
+type SliceLengthIndex struct {
+	Field string
+}
+
+func (s *SliceLengthIndex) FromObject(obj interface{}) (bool, []byte, error) {
+	v := reflect.ValueOf(obj)
+	v = reflect.Indirect(v) // Dereference the pointer if any
+
+	fv := v.FieldByName(s.Field)
+	if !fv.IsValid() {
+		return false, nil,
+			fmt.Errorf("field '%s' for %#v is invalid", s.Field, obj)
+	}
+
+	// Check the type
+	k := fv.Kind()
+	if k != reflect.Slice {
+		return false, nil, fmt.Errorf("field %q is of type %v; want a slice", s.Field, k)
+	}
+
+	// Get the slice length and encode it
+	val := fv.Len()
+	buf := encodeInt(int64(val), 8)
+
+	return true, buf, nil
+}
+
+func (s *SliceLengthIndex) FromArgs(args ...interface{}) ([]byte, error) {
+	if len(args) != 1 {
+		return nil, fmt.Errorf("must provide only a single argument")
+	}
+
+	v := reflect.ValueOf(args[0])
+	if !v.IsValid() {
+		return nil, fmt.Errorf("%#v is invalid", args[0])
+	}
+
+	k := v.Kind()
+	_, ok := memdb.IsIntType(k)
+	if !ok {
+		return nil, fmt.Errorf("arg is of type %v; want an int", k)
+	}
+
+	val := v.Int()
+	buf := encodeInt(val, 8)
+
+	return buf, nil
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -55,14 +55,15 @@ var dbSchema = &memdb.DBSchema{
 					Unique:  true,
 					Indexer: &StringerFieldIndexer{Field: "ID"},
 				},
-				"priority_state": {
-					Name: "priority_state",
+				"priority_dependecies_state": {
+					Name: "priority_dependecies_state",
 					Indexer: &memdb.CompoundIndex{
 						Indexes: []memdb.Indexer{
 							&JobPriorityIndex{
 								PriorityIntField:   "Priority",
 								IsDirOpenBoolField: "IsDirOpen",
 							},
+							&SliceLengthIndex{Field: "DependsOn"},
 							&memdb.UintFieldIndex{Field: "State"},
 						},
 					},
@@ -102,6 +103,13 @@ var dbSchema = &memdb.DBSchema{
 							&memdb.UintFieldIndex{Field: "State"},
 						},
 					},
+				},
+				"depends_on": {
+					Name: "depends_on",
+					Indexer: &JobIdSliceIndex{
+						Field: "DependsOn",
+					},
+					AllowMissing: true,
 				},
 			},
 		},


### PR DESCRIPTION
## Background

Prior to this PR, the only way we could chain jobs was via `Defer`. This had one unfortunate limit, which is that a job can only depend on exactly one other job, i.e. there was just 1-to-1 dependency.

As part of introducing a new job type for parsing provider versions in https://github.com/hashicorp/terraform-ls/pull/1014 it became clear that the new job will need to rely on 2+ other jobs:

 - parsed files
 - decoded metadata (via earlydecoder) - so that we have `required_providers`
 - parsed module manifest (+ any/all modules decoded) - so that we have `required_providers` of any submodules

I originally attempted to solve it in a hacky way by introducing `WaitForJobs()` inside `Defer`, but that created a few other problems - need to run at least two go routines, so that one can be blocked (waiting) and the other one can be dispatching + I ran into some race conditions, so I binned that hacky approach.

A nice side-effect demonstrated in the 2nd commit is that using `DependsOn` instead of `Defer` makes the code (IMHO) clearer and more readable, as there's less nesting and with the right variable names for job IDs it makes it much more obvious what the relationships are.

There is unfortunately still a few remaining (valid) use cases for `Defer` though - specifically because we cannot schedule any jobs for module paths parsed from a module manifest, until that manifest is parsed - so those few lines of code to do the scheduling still need to run as part of `Defer`.

The only downside of `DependsOn` compared to `Defer` is that the job which we depend on may be long gone/finished by the time the dependent one is dispatched, which means that we don't have direct access to its error/outcome. However I plan to address that problem more holistically as part of https://github.com/hashicorp/terraform-ls/pull/1006 - TL;DR we can still run the jobs and return early if we find out that the data which we were expecting the previous job to provide aren't there.