### PR TITLE
schemas: log exec path to Terraform

### DIFF
--- a/internal/schemas/gen/gen.go
+++ b/internal/schemas/gen/gen.go
@@ -124,7 +124,7 @@ func gen() error {
 	if err != nil {
 		return err
 	}
-	log.Printf("using Terraform %s", coreVersion)
+	log.Printf("using Terraform %s (at %s)", coreVersion, execPath)
 
 	log.Println("running terraform init")
 


### PR DESCRIPTION
This is to help avoid any doubts as to where the Terraform installation comes from.

In our case we seem to rely on Terraform installed in GHA environment, for better or worse and this is to make that fact more obvious.