### PR TITLE
Improve TF registry client

### DIFF
--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -106,7 +106,7 @@ func (c Client) GetMatchingModuleVersion(addr tfaddr.Module, con version.Constra
 		}
 	}
 
-	sort.Sort(foundVersions)
+	sort.Sort(sort.Reverse(foundVersions))
 
 	for _, fv := range foundVersions {
 		if con.Check(fv) {

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -124,7 +124,7 @@ func TestGetMatchingModuleVersion(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	cons := version.MustConstraints(version.NewConstraint("0.0.8"))
+	cons := version.MustConstraints(version.NewConstraint(">=0.0.7"))
 	client := NewClient()
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -1,6 +1,7 @@
 package registry
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -12,6 +13,7 @@ import (
 )
 
 func TestGetModuleData(t *testing.T) {
+	ctx := context.Background()
 	addr, err := tfaddr.ParseModuleSource("puppetlabs/deployment/ec")
 	if err != nil {
 		t.Fatal(err)
@@ -35,7 +37,7 @@ func TestGetModuleData(t *testing.T) {
 	client.BaseURL = srv.URL
 	t.Cleanup(srv.Close)
 
-	data, err := client.GetModuleData(addr, cons)
+	data, err := client.GetModuleData(ctx, addr, cons)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -120,6 +122,7 @@ func TestGetModuleData(t *testing.T) {
 }
 
 func TestGetMatchingModuleVersion(t *testing.T) {
+	ctx := context.Background()
 	addr, err := tfaddr.ParseModuleSource("puppetlabs/deployment/ec")
 	if err != nil {
 		t.Fatal(err)
@@ -137,7 +140,7 @@ func TestGetMatchingModuleVersion(t *testing.T) {
 	client.BaseURL = srv.URL
 	t.Cleanup(srv.Close)
 
-	v, err := client.GetMatchingModuleVersion(addr, cons)
+	v, err := client.GetMatchingModuleVersion(ctx, addr, cons)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/terraform/module/module_ops.go
+++ b/internal/terraform/module/module_ops.go
@@ -390,7 +390,7 @@ func GetModuleDataFromRegistry(ctx context.Context, regClient registry.Client, m
 		}
 
 		// get module data from Terraform Registry
-		metaData, err := regClient.GetModuleData(sourceAddr, declaredModule.Version)
+		metaData, err := regClient.GetModuleData(ctx, sourceAddr, declaredModule.Version)
 		if err != nil {
 			errs = multierror.Append(errs, err)
 			continue


### PR DESCRIPTION
This PR fixes the sorting of registry module versions. Before we would return the oldest instead of the newest version.

And passes context to the registry client for cancellation purposes.