### PR TITLE
Pick core schema only based on `required_version` constraint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/hashicorp/terraform-exec v0.17.2
 	github.com/hashicorp/terraform-json v0.14.0
 	github.com/hashicorp/terraform-registry-address v0.0.0-20220623143253-7d51757b572c
-	github.com/hashicorp/terraform-schema v0.0.0-20220805102629-49cc6ae5bfa3
+	github.com/hashicorp/terraform-schema v0.0.0-20220805171904-86bd319381d4
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mh-cbon/go-fmt-fail v0.0.0-20160815164508-67765b3fbcb5
 	github.com/mitchellh/cli v1.1.4

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/hashicorp/terraform-exec v0.17.2
 	github.com/hashicorp/terraform-json v0.14.0
 	github.com/hashicorp/terraform-registry-address v0.0.0-20220623143253-7d51757b572c
-	github.com/hashicorp/terraform-schema v0.0.0-20220805171904-86bd319381d4
+	github.com/hashicorp/terraform-schema v0.0.0-20220809100530-1ef9558a761c
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mh-cbon/go-fmt-fail v0.0.0-20160815164508-67765b3fbcb5
 	github.com/mitchellh/cli v1.1.4

--- a/go.sum
+++ b/go.sum
@@ -338,8 +338,8 @@ github.com/hashicorp/terraform-json v0.14.0 h1:sh9iZ1Y8IFJLx+xQiKHGud6/TSUCM0N8e
 github.com/hashicorp/terraform-json v0.14.0/go.mod h1:5A9HIWPkk4e5aeeXIBbkcOvaZbIYnAIkEyqP2pNSckM=
 github.com/hashicorp/terraform-registry-address v0.0.0-20220623143253-7d51757b572c h1:D8aRO6+mTqHfLsK/BC3j5OAoogv1WLRWzY1AaTo3rBg=
 github.com/hashicorp/terraform-registry-address v0.0.0-20220623143253-7d51757b572c/go.mod h1:Wn3Na71knbXc1G8Lh+yu/dQWWJeFQEpDeJMtWMtlmNI=
-github.com/hashicorp/terraform-schema v0.0.0-20220805102629-49cc6ae5bfa3 h1:1MdlLPlGxrTKSrkIf8ehb8b9TQuiMwvZSZ0CPlGQRQk=
-github.com/hashicorp/terraform-schema v0.0.0-20220805102629-49cc6ae5bfa3/go.mod h1:YfAL2BROQ9jq7ei+c8HqGyx0C1lc3xenQ/2FTr4AtKI=
+github.com/hashicorp/terraform-schema v0.0.0-20220805171904-86bd319381d4 h1:Q7sxEVQKPqP42iyk7lHEylWik7dNPwagy+zuXn8WToE=
+github.com/hashicorp/terraform-schema v0.0.0-20220805171904-86bd319381d4/go.mod h1:vZFv3NuAOpCxkP8j4d08ofVXVeCEjIbeKy/fNxYFbhg=
 github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734 h1:HKLsbzeOsfXmKNpr3GiT18XAblV0BjCbzL8KQAMZGa0=
 github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734/go.mod h1:kNDNcF7sN4DocDLBkQYz73HGKwN1ANB1blq4lIYLYvg=
 github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=

--- a/go.sum
+++ b/go.sum
@@ -338,8 +338,8 @@ github.com/hashicorp/terraform-json v0.14.0 h1:sh9iZ1Y8IFJLx+xQiKHGud6/TSUCM0N8e
 github.com/hashicorp/terraform-json v0.14.0/go.mod h1:5A9HIWPkk4e5aeeXIBbkcOvaZbIYnAIkEyqP2pNSckM=
 github.com/hashicorp/terraform-registry-address v0.0.0-20220623143253-7d51757b572c h1:D8aRO6+mTqHfLsK/BC3j5OAoogv1WLRWzY1AaTo3rBg=
 github.com/hashicorp/terraform-registry-address v0.0.0-20220623143253-7d51757b572c/go.mod h1:Wn3Na71knbXc1G8Lh+yu/dQWWJeFQEpDeJMtWMtlmNI=
-github.com/hashicorp/terraform-schema v0.0.0-20220805171904-86bd319381d4 h1:Q7sxEVQKPqP42iyk7lHEylWik7dNPwagy+zuXn8WToE=
-github.com/hashicorp/terraform-schema v0.0.0-20220805171904-86bd319381d4/go.mod h1:vZFv3NuAOpCxkP8j4d08ofVXVeCEjIbeKy/fNxYFbhg=
+github.com/hashicorp/terraform-schema v0.0.0-20220809100530-1ef9558a761c h1:NlNpLN/GHk2ycoeGcfGbVFt0nMIC+c0WLvYPu8s8faU=
+github.com/hashicorp/terraform-schema v0.0.0-20220809100530-1ef9558a761c/go.mod h1:vZFv3NuAOpCxkP8j4d08ofVXVeCEjIbeKy/fNxYFbhg=
 github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734 h1:HKLsbzeOsfXmKNpr3GiT18XAblV0BjCbzL8KQAMZGa0=
 github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734/go.mod h1:kNDNcF7sN4DocDLBkQYz73HGKwN1ANB1blq4lIYLYvg=
 github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=

--- a/internal/indexer/document_open.go
+++ b/internal/indexer/document_open.go
@@ -1,0 +1,87 @@
+package indexer
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-ls/internal/document"
+	"github.com/hashicorp/terraform-ls/internal/job"
+	"github.com/hashicorp/terraform-ls/internal/terraform/exec"
+	"github.com/hashicorp/terraform-ls/internal/terraform/module"
+	op "github.com/hashicorp/terraform-ls/internal/terraform/module/operation"
+)
+
+func (idx *Indexer) DocumentOpened(modHandle document.DirHandle) (job.IDs, error) {
+	mod, err := idx.modStore.ModuleByPath(modHandle.Path())
+	if err != nil {
+		return nil, err
+	}
+
+	ids := make(job.IDs, 0)
+	var errs *multierror.Error
+
+	if mod.TerraformVersionState == op.OpStateUnknown {
+		_, err := idx.jobStore.EnqueueJob(job.Job{
+			Dir: modHandle,
+			Func: func(ctx context.Context) error {
+				ctx = exec.WithExecutorFactory(ctx, idx.tfExecFactory)
+				return module.GetTerraformVersion(ctx, idx.modStore, modHandle.Path())
+			},
+			Type: op.OpTypeGetTerraformVersion.String(),
+		})
+		if err != nil {
+			errs = multierror.Append(errs, err)
+		}
+		// Given that getting version may take time and we only use it to
+		// enhance the UX, we ignore the outcome (job ID) here
+		// to avoid delays when documents of new modules are open.
+
+		// TODO: This affects some completion data, so we'll need to either
+		// update the tests or find some way of synchronizing this in tests
+	}
+
+	parseId, err := idx.jobStore.EnqueueJob(job.Job{
+		Dir: modHandle,
+		Func: func(ctx context.Context) error {
+			return module.ParseModuleConfiguration(idx.fs, idx.modStore, modHandle.Path())
+		},
+		Type: op.OpTypeParseModuleConfiguration.String(),
+	})
+	if err != nil {
+		return ids, err
+	}
+	ids = append(ids, parseId)
+
+	modIds, err := idx.decodeModule(modHandle, job.IDs{parseId})
+	if err != nil {
+		return ids, err
+	}
+	ids = append(ids, modIds...)
+
+	parseVarsId, err := idx.jobStore.EnqueueJob(job.Job{
+		Dir: modHandle,
+		Func: func(ctx context.Context) error {
+			return module.ParseVariables(idx.fs, idx.modStore, modHandle.Path())
+		},
+		Type: op.OpTypeParseVariables.String(),
+	})
+	if err != nil {
+		return ids, err
+	}
+	ids = append(ids, parseVarsId)
+
+	varsRefsId, err := idx.jobStore.EnqueueJob(job.Job{
+		Dir: modHandle,
+		Func: func(ctx context.Context) error {
+			return module.DecodeVarsReferences(ctx, idx.modStore, idx.schemaStore, modHandle.Path())
+		},
+		Type:      op.OpTypeDecodeVarsReferences.String(),
+		DependsOn: job.IDs{parseVarsId},
+	})
+	if err != nil {
+		return ids, err
+	}
+	ids = append(ids, varsRefsId)
+
+	return ids, errs.ErrorOrNil()
+}

--- a/internal/indexer/document_open.go
+++ b/internal/indexer/document_open.go
@@ -35,9 +35,6 @@ func (idx *Indexer) DocumentOpened(modHandle document.DirHandle) (job.IDs, error
 		// Given that getting version may take time and we only use it to
 		// enhance the UX, we ignore the outcome (job ID) here
 		// to avoid delays when documents of new modules are open.
-
-		// TODO: This affects some completion data, so we'll need to either
-		// update the tests or find some way of synchronizing this in tests
 	}
 
 	parseId, err := idx.jobStore.EnqueueJob(job.Job{

--- a/internal/indexer/walker.go
+++ b/internal/indexer/walker.go
@@ -83,21 +83,6 @@ func (idx *Indexer) WalkedModule(ctx context.Context, modHandle document.DirHand
 		}
 	}
 
-	tfVersionId, err := idx.jobStore.EnqueueJob(job.Job{
-		Dir: modHandle,
-		Func: func(ctx context.Context) error {
-			ctx = exec.WithExecutorFactory(ctx, idx.tfExecFactory)
-			return module.GetTerraformVersion(ctx, idx.modStore, modHandle.Path())
-		},
-		Type: op.OpTypeGetTerraformVersion.String(),
-	})
-	if err != nil {
-		errs = multierror.Append(errs, err)
-	} else {
-		ids = append(ids, tfVersionId)
-		refCollectionDeps = append(refCollectionDeps, tfVersionId)
-	}
-
 	dataDir := datadir.WalkDataDirOfModule(idx.fs, modHandle.Path())
 	idx.logger.Printf("parsed datadir: %#v", dataDir)
 

--- a/internal/indexer/watcher.go
+++ b/internal/indexer/watcher.go
@@ -83,23 +83,5 @@ func (idx *Indexer) PluginLockChanged(ctx context.Context, modHandle document.Di
 	}
 	ids = append(ids, id)
 
-	id, err = idx.jobStore.EnqueueJob(job.Job{
-		Dir: modHandle,
-		Func: func(ctx context.Context) error {
-			ctx = exec.WithExecutorFactory(ctx, idx.tfExecFactory)
-			eo, ok := exec.ExecutorOptsFromContext(ctx)
-			if ok {
-				ctx = exec.WithExecutorOpts(ctx, eo)
-			}
-
-			return module.GetTerraformVersion(ctx, idx.modStore, modHandle.Path())
-		},
-		Type: op.OpTypeGetTerraformVersion.String(),
-	})
-	if err != nil {
-		return ids, err
-	}
-	ids = append(ids, id)
-
 	return ids, nil
 }

--- a/internal/langserver/handlers/code_action_test.go
+++ b/internal/langserver/handlers/code_action_test.go
@@ -104,6 +104,8 @@ func TestLangServer_codeAction_basic(t *testing.T) {
 			"uri": "%s/main.tf"
 		}
 	}`, tmpDir.URI)})
+	waitForAllJobs(t, ss)
+
 	ls.CallAndExpectResponse(t, &langserver.CallRequest{
 		Method: "textDocument/codeAction",
 		ReqParams: fmt.Sprintf(`{
@@ -351,6 +353,7 @@ func TestLangServer_codeAction_no_code_action_requested(t *testing.T) {
 					"uri": "%s/main.tf"
 				}
 			}`, tmpDir.URI)})
+			waitForAllJobs(t, ss)
 
 			ls.CallAndExpectResponse(t, tt.request, tt.want)
 		})

--- a/internal/langserver/handlers/complete_test.go
+++ b/internal/langserver/handlers/complete_test.go
@@ -129,6 +129,7 @@ func TestModuleCompletion_withValidData_basic(t *testing.T) {
 			"uri": "%s/main.tf"
 		}
 	}`, tmpDir.URI)})
+	waitForAllJobs(t, ss)
 
 	ls.CallAndExpectResponse(t, &langserver.CallRequest{
 		Method: "textDocument/completion",
@@ -355,6 +356,7 @@ func TestModuleCompletion_withValidDataAndSnippets(t *testing.T) {
 			"uri": "%s/main.tf"
 		}
 	}`, tmpDir.URI)})
+	waitForAllJobs(t, ss)
 
 	ls.CallAndExpectResponse(t, &langserver.CallRequest{
 		Method: "textDocument/completion",
@@ -669,6 +671,7 @@ func TestVarsCompletion_withValidData(t *testing.T) {
 			"uri": "%s/terraform.tfvars"
 		}
 	}`, tmpDir.URI)})
+	waitForAllJobs(t, ss)
 
 	ls.CallAndExpectResponse(t, &langserver.CallRequest{
 		Method: "textDocument/completion",
@@ -821,6 +824,7 @@ output "test" {
 			"uri": "%s/main.tf"
 		}
 	}`, mainCfg, tmpDir.URI)})
+	waitForAllJobs(t, ss)
 
 	ls.CallAndExpectResponse(t, &langserver.CallRequest{
 		Method: "textDocument/completion",
@@ -1089,6 +1093,7 @@ output "test" {
 			"uri": "%s/main.tf"
 		}
 	}`, mainCfg, tmpDir.URI)})
+	waitForAllJobs(t, ss)
 
 	// first module
 	ls.CallAndExpectResponse(t, &langserver.CallRequest{
@@ -1429,6 +1434,8 @@ variable "ccc" {}
 			"uri": "%s/outputs.tf"
 		}
 	}`, tmpDir.URI)})
+	waitForAllJobs(t, ss)
+
 	ls.CallAndExpectResponse(t, &langserver.CallRequest{
 		Method: "textDocument/completion",
 		ReqParams: fmt.Sprintf(`{

--- a/internal/langserver/handlers/did_change_test.go
+++ b/internal/langserver/handlers/did_change_test.go
@@ -72,6 +72,8 @@ module "app" {
         "text": %q
     }
 }`, TempDir(t).URI, originalText)})
+	waitForAllJobs(t, ss)
+
 	ls.Call(t, &langserver.CallRequest{
 		Method: "textDocument/didChange",
 		ReqParams: fmt.Sprintf(`{

--- a/internal/langserver/handlers/did_open_test.go
+++ b/internal/langserver/handlers/did_open_test.go
@@ -80,6 +80,8 @@ func TestLangServer_didOpenLanguageIdStored(t *testing.T) {
         "text": %q
     }
 }`, TempDir(t).URI, originalText)})
+	waitForAllJobs(t, ss)
+
 	path := filepath.Join(TempDir(t).Path(), "main.tf")
 	dh := document.HandleFromPath(path)
 	doc, err := ss.DocumentStore.GetDocument(dh)

--- a/internal/langserver/handlers/document_link_test.go
+++ b/internal/langserver/handlers/document_link_test.go
@@ -101,6 +101,7 @@ func TestDocumentLink_withValidData(t *testing.T) {
 			"uri": "%s/main.tf"
 		}
 	}`, tmpDir.URI)})
+	waitForAllJobs(t, ss)
 
 	ls.CallAndExpectResponse(t, &langserver.CallRequest{
 		Method: "textDocument/documentLink",

--- a/internal/langserver/handlers/execute_command_module_callers_test.go
+++ b/internal/langserver/handlers/execute_command_module_callers_test.go
@@ -18,15 +18,22 @@ import (
 )
 
 func TestLangServer_workspaceExecuteCommand_moduleCallers_argumentError(t *testing.T) {
-	rootDir := t.TempDir()
-	rootUri := uri.FromPath(rootDir)
+	rootDir := document.DirHandleFromPath(t.TempDir())
+
+	ss, err := state.NewStateStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	wc := walker.NewWalkerCollector()
 
 	ls := langserver.NewLangServerMock(t, NewMockSession(&MockSessionInput{
 		TerraformCalls: &exec.TerraformMockCalls{
 			PerWorkDir: map[string][]*mock.Call{
-				rootDir: validTfMockCalls(),
+				rootDir.Path(): validTfMockCalls(),
 			},
 		},
+		StateStore:      ss,
+		WalkerCollector: wc,
 	}))
 	stop := ls.Start(t)
 	defer stop()
@@ -37,7 +44,9 @@ func TestLangServer_workspaceExecuteCommand_moduleCallers_argumentError(t *testi
 	    "capabilities": {},
 	    "rootUri": %q,
 		"processId": 12345
-	}`, rootUri)})
+	}`, rootDir.URI)})
+	waitForWalkerPath(t, ss, wc, rootDir)
+
 	ls.Notify(t, &langserver.CallRequest{
 		Method:    "initialized",
 		ReqParams: "{}",
@@ -51,7 +60,8 @@ func TestLangServer_workspaceExecuteCommand_moduleCallers_argumentError(t *testi
 			"text": "provider \"github\" {}",
 			"uri": %q
 		}
-	}`, fmt.Sprintf("%s/main.tf", rootUri))})
+	}`, fmt.Sprintf("%s/main.tf", rootDir.URI))})
+	waitForAllJobs(t, ss)
 
 	ls.CallAndExpectError(t, &langserver.CallRequest{
 		Method: "workspace/executeCommand",
@@ -109,6 +119,7 @@ func TestLangServer_workspaceExecuteCommand_moduleCallers_basic(t *testing.T) {
 			"uri": %q
 		}
 	}`, fmt.Sprintf("%s/main.tf", baseDirUri))})
+	waitForAllJobs(t, ss)
 
 	ls.CallAndExpectResponse(t, &langserver.CallRequest{
 		Method: "workspace/executeCommand",

--- a/internal/langserver/handlers/execute_command_modules_test.go
+++ b/internal/langserver/handlers/execute_command_modules_test.go
@@ -59,6 +59,7 @@ func TestLangServer_workspaceExecuteCommand_modules_basic(t *testing.T) {
 			"uri": %q
 		}
 	}`, testFileURI)})
+	waitForAllJobs(t, ss)
 
 	ls.CallAndExpectError(t, &langserver.CallRequest{
 		Method: "workspace/executeCommand",

--- a/internal/langserver/handlers/go_to_ref_target_test.go
+++ b/internal/langserver/handlers/go_to_ref_target_test.go
@@ -86,6 +86,8 @@ output "foo" {
 			"uri": "%s/main.tf"
 		}
 	}`, tmpDir.URI)})
+	waitForAllJobs(t, ss)
+
 	ls.CallAndExpectResponse(t, &langserver.CallRequest{
 		Method: "textDocument/definition",
 		ReqParams: fmt.Sprintf(`{
@@ -217,6 +219,8 @@ output "foo" {
 			"uri": "%s/main.tf"
 		}
 	}`, tmpDir.URI)})
+	waitForAllJobs(t, ss)
+
 	ls.CallAndExpectResponse(t, &langserver.CallRequest{
 		Method: "textDocument/definition",
 		ReqParams: fmt.Sprintf(`{
@@ -370,6 +374,7 @@ output "foo" {
 			"uri": "%s/main.tf"
 		}
 	}`, tmpDir.URI)})
+	waitForAllJobs(t, ss)
 
 	ls.CallAndExpectResponse(t, &langserver.CallRequest{
 		Method: "textDocument/definition",
@@ -476,6 +481,8 @@ func TestDefinition_moduleInputToVariable(t *testing.T) {
 			"uri": "%s/main.tf"
 		}
 	}`, modHandle.URI)})
+	waitForAllJobs(t, ss)
+
 	ls.CallAndExpectResponse(t, &langserver.CallRequest{
 		Method: "textDocument/definition",
 		ReqParams: fmt.Sprintf(`{
@@ -576,6 +583,8 @@ output "foo" {
 			"uri": "%s/main.tf"
 		}
 	}`, tmpDir.URI)})
+	waitForAllJobs(t, ss)
+
 	ls.CallAndExpectResponse(t, &langserver.CallRequest{
 		Method: "textDocument/declaration",
 		ReqParams: fmt.Sprintf(`{
@@ -707,6 +716,8 @@ output "foo" {
 			"uri": "%s/main.tf"
 		}
 	}`, tmpDir.URI)})
+	waitForAllJobs(t, ss)
+
 	ls.CallAndExpectResponse(t, &langserver.CallRequest{
 		Method: "textDocument/declaration",
 		ReqParams: fmt.Sprintf(`{

--- a/internal/langserver/handlers/handlers_test.go
+++ b/internal/langserver/handlers/handlers_test.go
@@ -103,6 +103,18 @@ func waitForWalkerPath(t testOrBench, ss *state.StateStore, wc *walker.WalkerCol
 	}
 }
 
+func waitForAllJobs(t testOrBench, ss *state.StateStore) {
+	ctx := context.Background()
+	ids, err := ss.JobStore.ListAllJobs()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = ss.JobStore.WaitForJobs(ctx, ids...)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 type testOrBench interface {
 	Fatal(args ...interface{})
 	Fatalf(format string, args ...interface{})

--- a/internal/langserver/handlers/hover_test.go
+++ b/internal/langserver/handlers/hover_test.go
@@ -114,6 +114,7 @@ func TestHover_withValidData(t *testing.T) {
 			"uri": "%s/main.tf"
 		}
 	}`, TempDir(t).URI)})
+	waitForAllJobs(t, ss)
 
 	ls.CallAndExpectResponse(t, &langserver.CallRequest{
 		Method: "textDocument/hover",
@@ -232,6 +233,7 @@ func TestVarsHover_withValidData(t *testing.T) {
 			"uri": "%s/terraform.tfvars"
 		}
 	}`, tmpDir.URI)})
+	waitForAllJobs(t, ss)
 
 	ls.CallAndExpectResponse(t, &langserver.CallRequest{
 		Method: "textDocument/hover",

--- a/internal/langserver/handlers/references_test.go
+++ b/internal/langserver/handlers/references_test.go
@@ -87,6 +87,8 @@ output "foo" {
 			"uri": "%s/main.tf"
 		}
 	}`, tmpDir.URI)})
+	waitForAllJobs(t, ss)
+
 	ls.CallAndExpectResponse(t, &langserver.CallRequest{
 		Method: "textDocument/references",
 		ReqParams: fmt.Sprintf(`{
@@ -198,6 +200,8 @@ variable "instances" {
 			"uri": "%s/main.tf"
 		}
 	}`, subHandle.URI)})
+	waitForAllJobs(t, ss)
+
 	ls.CallAndExpectResponse(t, &langserver.CallRequest{
 		Method: "textDocument/references",
 		ReqParams: fmt.Sprintf(`{

--- a/internal/langserver/handlers/semantic_tokens_test.go
+++ b/internal/langserver/handlers/semantic_tokens_test.go
@@ -113,6 +113,7 @@ func TestSemanticTokensFull(t *testing.T) {
 			"uri": "%s/main.tf"
 		}
 	}`, tmpDir.URI)})
+	waitForAllJobs(t, ss)
 
 	ls.CallAndExpectResponse(t, &langserver.CallRequest{
 		Method: "textDocument/semanticTokens/full",
@@ -233,6 +234,7 @@ func TestSemanticTokensFull_clientSupportsDelta(t *testing.T) {
 			"uri": "%s/main.tf"
 		}
 	}`, tmpDir.URI)})
+	waitForAllJobs(t, ss)
 
 	ls.CallAndExpectResponse(t, &langserver.CallRequest{
 		Method: "textDocument/semanticTokens/full",
@@ -360,6 +362,7 @@ func TestVarsSemanticTokensFull(t *testing.T) {
 				"uri": "%s/terraform.tfvars"
 			}
 	}`, tmpDir.URI)})
+	waitForAllJobs(t, ss)
 
 	ls.CallAndExpectResponse(t, &langserver.CallRequest{
 		Method: "textDocument/semanticTokens/full",

--- a/internal/langserver/handlers/service.go
+++ b/internal/langserver/handlers/service.go
@@ -43,6 +43,7 @@ type service struct {
 	sessCtx     context.Context
 	stopSession context.CancelFunc
 
+	// TODO: Rename to *scheduler to avoid confusion
 	lowPrioIndexer  *scheduler.Scheduler
 	highPrioIndexer *scheduler.Scheduler
 

--- a/internal/langserver/handlers/symbols_test.go
+++ b/internal/langserver/handlers/symbols_test.go
@@ -72,6 +72,7 @@ func TestLangServer_symbols_basic(t *testing.T) {
 			"uri": "%s/main.tf"
 		}
 	}`, tmpDir.URI)})
+	waitForAllJobs(t, ss)
 
 	ls.CallAndExpectResponse(t, &langserver.CallRequest{
 		Method: "textDocument/documentSymbol",

--- a/internal/langserver/handlers/workspace_symbol_test.go
+++ b/internal/langserver/handlers/workspace_symbol_test.go
@@ -90,6 +90,7 @@ func TestLangServer_workspace_symbol_basic(t *testing.T) {
 			"uri": "%s/blah/third.tf"
 		}
 	}`, tmpDir.URI)})
+	waitForAllJobs(t, ss)
 
 	ls.CallAndExpectResponse(t, &langserver.CallRequest{
 		Method: "workspace/symbol",

--- a/internal/state/jobs.go
+++ b/internal/state/jobs.go
@@ -540,6 +540,23 @@ func (js *JobStore) ListQueuedJobs() (job.IDs, error) {
 	return jobIDs, nil
 }
 
+func (js *JobStore) ListAllJobs() (job.IDs, error) {
+	txn := js.db.Txn(false)
+
+	it, err := txn.Get(js.tableName, "id")
+	if err != nil {
+		return nil, err
+	}
+
+	jobIDs := make(job.IDs, 0)
+	for obj := it.Next(); obj != nil; obj = it.Next() {
+		sj := obj.(*ScheduledJob)
+		jobIDs = append(jobIDs, sj.ID)
+	}
+
+	return jobIDs, nil
+}
+
 func (js *JobStore) allJobs() (job.IDs, error) {
 	txn := js.db.Txn(false)
 


### PR DESCRIPTION
Depends on https://github.com/hashicorp/terraform-schema/pull/129

Closes https://github.com/hashicorp/terraform-ls/issues/993

## UX Impact

While the primary motivation behind the change was performance, it brings a minor UX impact.

### IntelliSense with too _old_ version (e.g. 0.10)

**Before**: No IntelliSense available, most schema-dependent jobs providing data for IntelliSense fail, as per [errors in log](https://gist.github.com/radeksimko/0fb6825951bb316deef9ed4b43b306b5).

![Screenshot 2022-08-08 at 12 02 43](https://user-images.githubusercontent.com/287584/183403928-21c2380f-9e4b-4ee4-b502-296abbd2cf16.png)

**After**: 0.12-based IntelliSense provided, no errors in log.

![Screenshot 2022-08-08 at 12 18 26](https://user-images.githubusercontent.com/287584/183406393-9e292814-8359-40b2-af26-b367b2e4a175.png)

--- 

The UX for too new version (e.g. 1.5.0) and for when the version is not known (yet) remains practically the same, it is just hopefully more obvious from the changed code combined with the upstream tfschema changes.