### PR TITLE
textDocument/formatting: log terraform fmt execution time

### DIFF
--- a/internal/langserver/handlers/code_action.go
+++ b/internal/langserver/handlers/code_action.go
@@ -57,9 +57,7 @@ func (svc *service) textDocumentCodeAction(ctx context.Context, params lsp.CodeA
 				return ca, errors.EnrichTfExecError(err)
 			}
 
-			svc.logger.Printf("Formatting document via %q", tfExec.GetExecPath())
-
-			edits, err := formatDocument(ctx, tfExec, doc.Text, dh)
+			edits, err := svc.formatDocument(ctx, tfExec, doc.Text, dh)
 			if err != nil {
 				return ca, err
 			}


### PR DESCRIPTION
From past experience this is a common source of bug reports, for various reasons - often due to https://github.com/tfutils/tfenv/issues/196 which was now resolved, but it seems reasonable to me to log the execution time as it's a commonly used feature, so it's effectively a hot path.

This allows us to rule out TF CLI as a cause, if/when people report performance related issues.