### PR TITLE
clean/ci: avoid running tests via GoReleaser & remove GO111MODULE

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,10 +1,5 @@
 env:
-  - GO111MODULE=on
   - CGO_ENABLED=0
-
-before:
-  hooks:
-    - go test ./...
 
 builds:
   -


### PR DESCRIPTION
This is to avoid some CPU/time waste on running tests twice on every PR/push, which we generally always do as per our current GHA workflow setup.

https://github.com/hashicorp/terraform-ls/blob/4459e5ccae15ae64da61118cece2a1c1aa0cff10/.github/workflows/ci.yml#L3-L9

It does mean we'd no longer run tests as part of a release pipeline, but I'm not sure that was ever that much valuable anyway since we'd usually wait for the last `main` push CI workflow to turn green.

I'm also removing an old ENV variable `GO111MODULE` which is no longer relevant in the Go version we use.