### PR TITLE
Spelling: initalized -> initialized

### DIFF
--- a/internal/langserver/session/session.go
+++ b/internal/langserver/session/session.go
@@ -48,7 +48,7 @@ func (s *session) Initialize(req *jrpc2.Request) error {
 		if s.IsInitializedUnconfirmed() {
 			return SessionAlreadyInitializedErr(s.initializeReq.ID())
 		}
-		return fmt.Errorf("session is not ready to be initalized. State: %s",
+		return fmt.Errorf("session is not ready to be initialized. State: %s",
 			s.state)
 	}
 


### PR DESCRIPTION
Popped up in an error message I received in #1041, thought it worth a quick PR to fix.