### PR TITLE
goreleaser: Use correct ldflag (versionPrerelease) when compiling LS

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,7 +9,7 @@ builds:
       - -trimpath
       - -tags=preloadschema
     ldflags:
-      - '-s -w -X "main.version={{ .RawVersion }}" -X "main.prerelease={{ if .IsSnapshot }}snapshot.{{ .ShortCommit }}{{ else }}{{ .Prerelease }}{{ end }}"{{ if not .IsSnapshot }} -X "main.algoliaAppID={{ .Env.ALGOLIA_APP_ID }}" -X "main.algoliaAPIKey={{ .Env.ALGOLIA_API_KEY }}"{{ end }}'
+      - '-s -w -X "main.version={{ .RawVersion }}" -X "main.versionPrerelease={{ if .IsSnapshot }}snapshot.{{ .ShortCommit }}{{ else }}{{ .Prerelease }}{{ end }}"{{ if not .IsSnapshot }} -X "main.algoliaAppID={{ .Env.ALGOLIA_APP_ID }}" -X "main.algoliaAPIKey={{ .Env.ALGOLIA_API_KEY }}"{{ end }}'
     goarch:
       - '386'
       - amd64
@@ -35,7 +35,7 @@ builds:
       - -trimpath
       - -tags=preloadschema
     ldflags:
-      - '-s -w -X "main.version={{ .RawVersion }}" -X "main.prerelease={{ if .IsSnapshot }}snapshot.{{ .ShortCommit }}{{ else }}{{ .Prerelease }}{{ end }}"{{ if not .IsSnapshot }} -X "main.algoliaAppID={{ .Env.ALGOLIA_APP_ID }}" -X "main.algoliaAPIKey={{ .Env.ALGOLIA_API_KEY }}"{{ end }}'
+      - '-s -w -X "main.version={{ .RawVersion }}" -X "main.versionPrerelease={{ if .IsSnapshot }}snapshot.{{ .ShortCommit }}{{ else }}{{ .Prerelease }}{{ end }}"{{ if not .IsSnapshot }} -X "main.algoliaAppID={{ .Env.ALGOLIA_APP_ID }}" -X "main.algoliaAPIKey={{ .Env.ALGOLIA_API_KEY }}"{{ end }}'
     goarch:
       - '386'
       - amd64


### PR DESCRIPTION
I noticed as part of https://github.com/hashicorp/terraform-ls/issues/1041 that we released `0.29.0` (stable) as `0.29.0-dev`, which is because https://github.com/hashicorp/terraform-ls/pull/945 didn't follow a corresponding update of the GoReleaser config.

This PR fixes that.

## Before

```
goreleaser build --snapshot --skip-post-hooks --rm-dist
./dist/signable_darwin_arm64/terraform-ls version
0.29.0-dev
platform: darwin/arm64
go: go1.18.5
compiler: gc
```

## After

```
goreleaser build --snapshot --skip-post-hooks --rm-dist
./dist/signable_darwin_arm64/terraform-ls version
0.29.0-snapshot.dfd43fd
platform: darwin/arm64
go: go1.18.5
compiler: gc
```