### PR TITLE
docs: Add link to post explaining vim plugin installation

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -123,7 +123,7 @@ inoremap <silent><expr> <c-space> coc#refresh()
 
 ### vim-lsp
 
- - Install the following plugins:
+ - [Install](https://opensource.com/article/20/2/how-install-vim-plugins) the following plugins:
    * [async.vim plugin](https://github.com/prabirshrestha/async.vim)
    * [vim-lsp plugin](https://github.com/prabirshrestha/vim-lsp)
    * [asyncomplete.vim plugin](https://github.com/prabirshrestha/asyncomplete.vim)


### PR DESCRIPTION
Not every reader may be familiar with the vim plugin system and I _think_ the linked post explains it quite well, in fact better than the [official manual](https://github.com/vim/vim/blob/03c3bd9fd094c1aede2e8fe3ad8fd25b9f033053/runtime/doc/repeat.txt#L515), but I may be biased as a non-seasoned vim user. 🤷🏻‍♂️ 