### PR TITLE
Fix panic on obtaining provider schemas

### DIFF
--- a/internal/state/provider_schema.go
+++ b/internal/state/provider_schema.go
@@ -216,12 +216,14 @@ func (s *ProviderSchemaStore) schemaExists(addr tfaddr.Provider, pCons version.C
 
 	for item := it.Next(); item != nil; item = it.Next() {
 		ps, ok := item.(*ProviderSchema)
-		if ok {
-			if ps.Schema == nil {
-				// Incomplete entry may be a result of provider version being
-				// sourced earlier where schema is yet to be sourced or sourcing failed.
-				continue
-			}
+		if !ok {
+			continue
+		}
+		if ps.Schema == nil || ps.Version == nil {
+			// Incomplete entries may result from the provider version being
+			// sourced earlier where the schema is yet to be sourced,
+			// or vice versa, or sourcing failed.
+			continue
 		}
 
 		if providerAddrEquals(ps.Address, addr) && pCons.Check(ps.Version) {

--- a/internal/state/provider_schema_test.go
+++ b/internal/state/provider_schema_test.go
@@ -877,6 +877,17 @@ func TestAllSchemasExist(t *testing.T) {
 			ExpectedMatch: true,
 			ExpectedErr:   false,
 		},
+		{
+			Name: "missing provider version in schema store",
+			Requirements: map[tfaddr.Provider]version.Constraints{
+				tfaddr.MustParseProviderSource("hashicorp/test"): version.MustConstraints(version.NewConstraint(">=1.0.0")),
+			},
+			InstalledProviders: InstalledProviders{
+				tfaddr.MustParseProviderSource("hashicorp/test"): nil,
+			},
+			ExpectedMatch: false,
+			ExpectedErr:   false,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
This PR fixes the LS panic reported in https://github.com/hashicorp/vscode-terraform/issues/1213.

<details><summary>Stack trace:</summary>

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x13c4898]

goroutine 38 [running]:
github.com/hashicorp/go-version.prereleaseCheck(0xc09a8067e0, 0x3)
github.com/hashicorp/go-version@v1.6.0/constraint.go:198 +0x18
github.com/hashicorp/go-version.constraintGreaterThanEqual(0xc09a8067e8, 0xc0aa07f858)
github.com/hashicorp/go-version@v1.6.0/constraint.go:250 +0x25
github.com/hashicorp/go-version.(*Constraint).Check(...)
github.com/hashicorp/go-version@v1.6.0/constraint.go:163
github.com/hashicorp/go-version.Constraints.Check({0xc0cb192370, 0x1, 0xc}, 0x170c841)
github.com/hashicorp/go-version@v1.6.0/constraint.go:93 +0x5e
github.com/hashicorp/terraform-ls/internal/state.(*ProviderSchemaStore).schemaExists(0xc0007ed6c0, {{0xc0c90cacfa, 0x6}, {0xc0c90cacf0, 0x9}, {0x1714198, 0x15}}, {0xc0cb192370, 0x1, 0x1})
github.com/hashicorp/terraform-ls/internal/state/provider_schema.go:227 +0x9c9
github.com/hashicorp/terraform-ls/internal/state.(*ProviderSchemaStore).AllSchemasExist(0xc0008924c0, 0xc0604fc2a7)
github.com/hashicorp/terraform-ls/internal/state/provider_schema.go:197 +0xef
github.com/hashicorp/terraform-ls/internal/terraform/module.ObtainSchema({0x1d64de0, 0xc053b1f980}, 0x163d6a0, 0xc0bbe71c60, {0xc0604fc2a7, 0x64})
github.com/hashicorp/terraform-ls/internal/terraform/module/module_ops.go:128 +0xea
github.com/hashicorp/terraform-ls/internal/indexer.(*Indexer).WalkedModule.func8({0x1d64de0, 0xc053b1f950})
github.com/hashicorp/terraform-ls/internal/indexer/walker.go:135 +0xc5
github.com/hashicorp/terraform-ls/internal/scheduler.(*Scheduler).eval(0xc00088d5c0, {0x1d64d38, 0xc000892500})
github.com/hashicorp/terraform-ls/internal/scheduler/scheduler.go:70 +0x184
created by github.com/hashicorp/terraform-ls/internal/scheduler.(*Scheduler).Start
github.com/hashicorp/terraform-ls/internal/scheduler/scheduler.go:48 +0x69
```
</details>

## Background
We have two jobs, one to obtain the provider schema via `terraform providers schema -json` and one to get the Terraform and provider versions via `terraform version -json`. We track provider schemas in a memdb table, and both jobs add their results to a schema entry in this table. Only the results of both jobs combined produce a usable schema.

Since we delayed the execution of Terraform version in [terraform-ls #1014](https://github.com/hashicorp/terraform-ls/pull/1014), we can end up with a schema without a version in the table. The check whether a schema version matches the constrains panics in certain conditions. It panics for constraints like `>= 1.0.0`, but not `1.0.0`.

The introduction of `dependsOn` for jobs should avoid getting into a situation like this in the first place. The job for obtaining the schema, depends on the job for parsing the provider versions:

https://github.com/hashicorp/terraform-ls/blob/8a410a02c3947b39eb3cf17faf3abb60d25d5b57/internal/indexer/walker.go#L131-L139