### PR TITLE
fix: flaky exit handler test

### DIFF
--- a/internal/langserver/handlers/exit_test.go
+++ b/internal/langserver/handlers/exit_test.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-ls/internal/langserver"
 )
@@ -15,6 +16,8 @@ func TestExit(t *testing.T) {
 	ls.Notify(t, &langserver.CallRequest{
 		Method:    "exit",
 		ReqParams: `{}`})
+
+	time.Sleep(10 * time.Millisecond)
 
 	if !ms.StopFuncCalled() {
 		t.Fatal("Expected service stop function to be called")


### PR DESCRIPTION
This PR fixes the flaky exit handler test. The sleep makes sure that we account for the asynchronous nature of LS notifications.

I think using `time.Sleep` isn't the best, but a very pragmatic solution here. 

### Before
```
$ go test -timeout 30s -run '^TestExit$' github.com/hashicorp/terraform-ls/internal/langserver/handlers -count=1000
--- FAIL: TestExit (0.00s)
    exit_test.go:20: Expected service stop function to be called
--- FAIL: TestExit (0.00s)
    exit_test.go:20: Expected service stop function to be called
FAIL
FAIL    github.com/hashicorp/terraform-ls/internal/langserver/handlers  1.807s
FAIL
```

### After
```
$ go test -timeout 30s -run '^TestExit$' github.com/hashicorp/terraform-ls/internal/langserver/handlers -count=1000
ok      github.com/hashicorp/terraform-ls/internal/langserver/handlers  13.512s
```

Closes https://github.com/hashicorp/terraform-ls/issues/445
