### PR TITLE
Handle Invalid WSL URIs

### DIFF
--- a/internal/langserver/handlers/initialize.go
+++ b/internal/langserver/handlers/initialize.go
@@ -134,6 +134,18 @@ func (svc *service) Initialize(ctx context.Context, params lsp.InitializeParams)
 		rootURI := string(params.RootURI)
 		if !uri.IsURIValid(rootURI) {
 			properties["root_uri"] = "invalid"
+
+			if uri.IsURLEncodedPath(rootURI) {
+				uri, err := uri.UnEncodeURI(rootURI)
+				if err == nil {
+					if uri.Scheme == "file" && uri.Host == "wsl$" {
+						// panic("foo")
+						return serverCaps, fmt.Errorf("Unsupported WSLPATH: %q "+
+							"This is most likely bug, please report it.", rootURI)
+					}
+				}
+			}
+
 			return serverCaps, fmt.Errorf("Unsupported or invalid URI: %q "+
 				"This is most likely bug, please report it.", rootURI)
 		}

--- a/internal/langserver/handlers/initialize_test.go
+++ b/internal/langserver/handlers/initialize_test.go
@@ -113,7 +113,7 @@ func TestInitialize_withInvalidRootURI(t *testing.T) {
 	    "capabilities": {},
 	    "processId": 12345,
 	    "rootUri": "meh"
-	}`}, code.SystemError.Err())
+	}`}, code.InvalidParams.Err())
 }
 
 func TestInitialize_multipleFolders(t *testing.T) {

--- a/internal/uri/uri.go
+++ b/internal/uri/uri.go
@@ -69,6 +69,32 @@ func IsURIValid(uri string) bool {
 	return true
 }
 
+// IsURIValid checks whether uri is a valid URI per RFC 8089
+func IsURLEncodedPath(uri string) bool {
+	unescapedPath, err := url.PathUnescape(uri)
+	if err != nil {
+		return false
+	}
+
+	_, err = url.ParseRequestURI(unescapedPath)
+	return err == nil
+}
+
+// IsURIValid checks whether uri is a valid URI per RFC 8089
+func UnEncodeURI(uri string) (*url.URL, error) {
+	unescapedPath, err := url.PathUnescape(uri)
+	if err != nil {
+		return nil, err
+	}
+
+	parsed, err := url.ParseRequestURI(unescapedPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return parsed, nil
+}
+
 // PathFromURI extracts OS-specific path from an RFC 8089 "file" URI Scheme
 func PathFromURI(rawUri string) (string, error) {
 	uri, err := parseUri(rawUri)

--- a/internal/uri/uri.go
+++ b/internal/uri/uri.go
@@ -69,32 +69,6 @@ func IsURIValid(uri string) bool {
 	return true
 }
 
-// IsURIValid checks whether uri is a valid URI per RFC 8089
-func IsURLEncodedPath(uri string) bool {
-	unescapedPath, err := url.PathUnescape(uri)
-	if err != nil {
-		return false
-	}
-
-	_, err = url.ParseRequestURI(unescapedPath)
-	return err == nil
-}
-
-// IsURIValid checks whether uri is a valid URI per RFC 8089
-func UnEncodeURI(uri string) (*url.URL, error) {
-	unescapedPath, err := url.PathUnescape(uri)
-	if err != nil {
-		return nil, err
-	}
-
-	parsed, err := url.ParseRequestURI(unescapedPath)
-	if err != nil {
-		return nil, err
-	}
-
-	return parsed, nil
-}
-
 // PathFromURI extracts OS-specific path from an RFC 8089 "file" URI Scheme
 func PathFromURI(rawUri string) (string, error) {
 	uri, err := parseUri(rawUri)
@@ -210,4 +184,24 @@ func isLikelyWindowsDriveURIPath(uriPath string) bool {
 		return false
 	}
 	return uriPath[0] == '/' && unicode.IsLetter(rune(uriPath[1])) && uriPath[2] == ':'
+}
+
+// IsWSLURI checks whether URI represents a WSL (Windows Subsystem for Linux)
+// UNC path on Windows, such as \\wsl$\Ubuntu\path.
+//
+// Such a URI represents a common user error since the LS is generally
+// expected to run in the same environment where files are located
+// (i.e. within the Linux subsystem with Linux paths such as /Ubuntu/path).
+func IsWSLURI(uri string) bool {
+	unescapedPath, err := url.PathUnescape(uri)
+	if err != nil {
+		return false
+	}
+
+	u, err := url.ParseRequestURI(unescapedPath)
+	if err != nil {
+		return false
+	}
+
+	return u.Scheme == "file" && u.Host == "wsl$"
 }

--- a/internal/uri/uri_test.go
+++ b/internal/uri/uri_test.go
@@ -178,3 +178,36 @@ func TestMustParseURI(t *testing.T) {
 		})
 	}
 }
+
+func TestIsWSLURI(t *testing.T) {
+	type args struct {
+		uri string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "UNC WSL Path should return true",
+			args: args{
+				uri: `file://wsl%24/Ubuntu/home/james/some/path`,
+			},
+			want: true,
+		},
+		{
+			name: "Regular file path should return false",
+			args: args{
+				uri: `file://C:/foo/james/foo`,
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsWSLURI(tt.args.uri); got != tt.want {
+				t.Errorf("IsWSLURI() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/uri/uri_test.go
+++ b/internal/uri/uri_test.go
@@ -180,32 +180,25 @@ func TestMustParseURI(t *testing.T) {
 }
 
 func TestIsWSLURI(t *testing.T) {
-	type args struct {
-		uri string
-	}
 	tests := []struct {
 		name string
-		args args
+		uri  string
 		want bool
 	}{
 		{
 			name: "UNC WSL Path should return true",
-			args: args{
-				uri: `file://wsl%24/Ubuntu/home/james/some/path`,
-			},
+			uri:  `file://wsl%24/Ubuntu/home/james/some/path`,
 			want: true,
 		},
 		{
 			name: "Regular file path should return false",
-			args: args{
-				uri: `file://C:/foo/james/foo`,
-			},
+			uri:  `file://C:/foo/james/foo`,
 			want: false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := IsWSLURI(tt.args.uri); got != tt.want {
+			if got := IsWSLURI(tt.uri); got != tt.want {
 				t.Errorf("IsWSLURI() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
This adds another piece of logic to attempt to detect UNC WSL Uri as the workspace to open, and return a more informative error so the client can handle prompting the user.

The UNC WSL Uri being passed is in the form of `\\wsl$\Ubuntu\home\james\some\path`. If the user wants to edit files in the WSL instance, they should be opening the workspace in the Remote WSL extension.

When the VS Code sends the path to terraform-ls, it is urlencoded as `\\wsl%24\Ubuntu\home\james\some\path`. This fails `uri.IsURIValid`, which is incorrect because it is a valid path that needs to be decoded. Even if it is decoded, further on in the `uri` package we make assumptions about file paths that ignore the server portion of a UNC path, resulting in terraform-ls attempting to use `Ubuntu\home\james\some\path`. A future PR can address that.

Works with, but not required, https://github.com/hashicorp/vscode-terraform/pull/1219

Closes #656 