### PR TITLE
fix: Add missing provider schema versions

### DIFF
--- a/internal/langserver/handlers/execute_command_terraform_version_test.go
+++ b/internal/langserver/handlers/execute_command_terraform_version_test.go
@@ -46,7 +46,7 @@ func TestLangServer_workspaceExecuteCommand_terraformVersion_basic(t *testing.T)
 		t.Fatal(err)
 	}
 
-	err = s.Modules.UpdateTerraformVersion(modDir, ver, map[tfaddr.Provider]*version.Version{}, nil)
+	err = s.Modules.UpdateTerraformAndProviderVersions(modDir, ver, map[tfaddr.Provider]*version.Version{}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/state/module.go
+++ b/internal/state/module.go
@@ -738,7 +738,7 @@ func (s *ModuleStore) FinishProviderSchemaLoading(path string, psErr error) erro
 	return nil
 }
 
-func (s *ModuleStore) UpdateTerraformVersion(modPath string, tfVer *version.Version, pv map[tfaddr.Provider]*version.Version, vErr error) error {
+func (s *ModuleStore) UpdateTerraformAndProviderVersions(modPath string, tfVer *version.Version, pv map[tfaddr.Provider]*version.Version, vErr error) error {
 	txn := s.db.Txn(true)
 	txn.Defer(func() {
 		s.SetTerraformVersionState(modPath, op.OpStateLoaded)

--- a/internal/state/module.go
+++ b/internal/state/module.go
@@ -576,6 +576,11 @@ func (s *ModuleStore) UpdateInstalledProviders(path string, pvs map[tfaddr.Provi
 		return err
 	}
 
+	err = updateProviderVersions(txn, path, pvs)
+	if err != nil {
+		return err
+	}
+
 	txn.Commit()
 	return nil
 }

--- a/internal/state/module_changes_test.go
+++ b/internal/state/module_changes_test.go
@@ -138,7 +138,7 @@ func TestModuleChanges_AwaitNextChangeBatch_multipleChanges(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = ss.Modules.UpdateTerraformVersion(modPath, testVersion(t, "1.0.0"), map[tfaddr.Provider]*version.Version{}, nil)
+	err = ss.Modules.UpdateTerraformAndProviderVersions(modPath, testVersion(t, "1.0.0"), map[tfaddr.Provider]*version.Version{}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/state/module_test.go
+++ b/internal/state/module_test.go
@@ -60,7 +60,7 @@ func TestModuleStore_ModuleByPath(t *testing.T) {
 	}
 
 	tfVersion := version.Must(version.NewVersion("1.0.0"))
-	err = s.Modules.UpdateTerraformVersion(modPath, tfVersion, nil, nil)
+	err = s.Modules.UpdateTerraformAndProviderVersions(modPath, tfVersion, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -287,7 +287,7 @@ func TestModuleStore_UpdateMetadata(t *testing.T) {
 	}
 }
 
-func TestModuleStore_UpdateTerraformVersion(t *testing.T) {
+func TestModuleStore_UpdateTerraformAndProviderVersions(t *testing.T) {
 	s, err := NewStateStore()
 	if err != nil {
 		t.Fatal(err)
@@ -301,7 +301,7 @@ func TestModuleStore_UpdateTerraformVersion(t *testing.T) {
 
 	vErr := customErr{}
 
-	err = s.Modules.UpdateTerraformVersion(tmpDir, testVersion(t, "0.12.4"), nil, vErr)
+	err = s.Modules.UpdateTerraformAndProviderVersions(tmpDir, testVersion(t, "0.12.4"), nil, vErr)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/state/provider_schema.go
+++ b/internal/state/provider_schema.go
@@ -219,10 +219,19 @@ func (s *ProviderSchemaStore) schemaExists(addr tfaddr.Provider, pCons version.C
 		if !ok {
 			continue
 		}
-		if ps.Schema == nil || ps.Version == nil {
-			// Incomplete entries may result from the provider version being
-			// sourced earlier where the schema is yet to be sourced,
-			// or vice versa, or sourcing failed.
+		if ps.Schema == nil {
+			// Incomplete entry may be a result of provider version being
+			// sourced earlier where schema is yet to be sourced or sourcing failed.
+			continue
+		}
+		if ps.Version == nil {
+			// Obtaining schema is always done *after* getting the version.
+			// Therefore, this can only happen in a rare case when getting
+			// provider versions fails but getting schema was successful.
+			// e.g. custom plugin cache location in combination with 0.12
+			// (where lock files didn't exist) [1], or user-triggered race
+			// condition when the lock file is deleted/created.
+			// [1] See https://github.com/hashicorp/terraform-ls/issues/24
 			continue
 		}
 

--- a/internal/state/provider_schema.go
+++ b/internal/state/provider_schema.go
@@ -382,11 +382,12 @@ func (ss sortableSchemas) Len() int {
 func (ss sortableSchemas) Less(i, j int) bool {
 	var leftRank, rightRank int
 
-	// TODO: Rank by version constraints match
+	leftRank += ss.rankByVersionMatch(ss.schemas[i].Version)
+	rightRank += ss.rankByVersionMatch(ss.schemas[j].Version)
 
 	// TODO: Rank by hierarchy proximity
 
-	// TODO: Rank by version
+	// TODO: Rank by version (higher wins)
 
 	leftRank += ss.rankBySource(ss.schemas[i].Source)
 	rightRank += ss.rankBySource(ss.schemas[j].Source)
@@ -408,6 +409,14 @@ func (ss sortableSchemas) rankBySource(src SchemaSource) int {
 			mod.ModManifest.ContainsLocalModule(ss.requiredModPath) {
 			return 1
 		}
+	}
+
+	return 0
+}
+
+func (ss sortableSchemas) rankByVersionMatch(v *version.Version) int {
+	if v != nil && ss.requiredVersion.Check(v) {
+		return 2
 	}
 
 	return 0

--- a/internal/state/provider_schema_test.go
+++ b/internal/state/provider_schema_test.go
@@ -71,7 +71,7 @@ func TestStateStore_IncompleteSchema_legacyLookup(t *testing.T) {
 	// obtaining versions typically takes less time than schema itself
 	// so we test that "incomplete" state is handled correctly too
 
-	err = s.Modules.UpdateTerraformVersion(modPath, testVersion(t, "0.13.0"), pvs, nil)
+	err = s.Modules.UpdateTerraformAndProviderVersions(modPath, testVersion(t, "0.13.0"), pvs, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -173,7 +173,7 @@ func TestStateStore_AddLocalSchema_duplicateWithVersion(t *testing.T) {
 	pv := map[tfaddr.Provider]*version.Version{
 		addr: testVersion(t, "1.2.0"),
 	}
-	err = s.Modules.UpdateTerraformVersion(modPath, testVersion(t, "0.12.0"), pv, nil)
+	err = s.Modules.UpdateTerraformAndProviderVersions(modPath, testVersion(t, "0.12.0"), pv, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -233,7 +233,7 @@ func TestStateStore_AddLocalSchema_duplicateWithVersion(t *testing.T) {
 	pv = map[tfaddr.Provider]*version.Version{
 		addr: testVersion(t, "1.5.0"),
 	}
-	err = s.Modules.UpdateTerraformVersion(modPath, testVersion(t, "0.12.0"), pv, nil)
+	err = s.Modules.UpdateTerraformAndProviderVersions(modPath, testVersion(t, "0.12.0"), pv, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -281,7 +281,7 @@ func TestStateStore_AddLocalSchema_versionFirst(t *testing.T) {
 	pv := map[tfaddr.Provider]*version.Version{
 		addr: testVersion(t, "1.2.0"),
 	}
-	err = s.Modules.UpdateTerraformVersion(modPath, testVersion(t, "0.12.0"), pv, nil)
+	err = s.Modules.UpdateTerraformAndProviderVersions(modPath, testVersion(t, "0.12.0"), pv, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1009,7 +1009,7 @@ func addAnySchema(t testOrBench, ss *ProviderSchemaStore, ms *ModuleStore, ps *P
 		pVersions := map[tfaddr.Provider]*version.Version{
 			ps.Address: ps.Version,
 		}
-		err = ms.UpdateTerraformVersion(s.ModulePath, testVersion(t, "0.14.0"), pVersions, nil)
+		err = ms.UpdateTerraformAndProviderVersions(s.ModulePath, testVersion(t, "0.14.0"), pVersions, nil)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/terraform/module/module_ops.go
+++ b/internal/terraform/module/module_ops.go
@@ -73,7 +73,7 @@ func GetTerraformVersion(ctx context.Context, modStore *state.ModuleStore, modPa
 
 	tfExec, err := TerraformExecutorForModule(ctx, mod.Path)
 	if err != nil {
-		sErr := modStore.UpdateTerraformVersion(modPath, nil, nil, err)
+		sErr := modStore.UpdateTerraformAndProviderVersions(modPath, nil, nil, err)
 		if err != nil {
 			return sErr
 		}
@@ -81,9 +81,16 @@ func GetTerraformVersion(ctx context.Context, modStore *state.ModuleStore, modPa
 	}
 
 	v, pv, err := tfExec.Version(ctx)
+
+	// TODO: Remove and rely purely on ParseProviderVersions
+	// In most cases we get the provider version from the datadir/lockfile
+	// but there is an edge case with custom plugin location
+	// when this may not be available, so leveraging versions
+	// from "terraform version" accounts for this.
+	// See https://github.com/hashicorp/terraform-ls/issues/24
 	pVersions := providerVersionsFromTfVersion(pv)
 
-	sErr := modStore.UpdateTerraformVersion(modPath, v, pVersions, err)
+	sErr := modStore.UpdateTerraformAndProviderVersions(modPath, v, pVersions, err)
 	if sErr != nil {
 		return sErr
 	}

--- a/internal/terraform/module/module_ops_test.go
+++ b/internal/terraform/module/module_ops_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -14,12 +15,15 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/hcl-lang/lang"
+	tfjson "github.com/hashicorp/terraform-json"
 	"github.com/hashicorp/terraform-ls/internal/filesystem"
 	"github.com/hashicorp/terraform-ls/internal/registry"
 	"github.com/hashicorp/terraform-ls/internal/state"
+	"github.com/hashicorp/terraform-ls/internal/terraform/exec"
 	"github.com/hashicorp/terraform-ls/internal/terraform/module/operation"
 	tfaddr "github.com/hashicorp/terraform-registry-address"
 	tfregistry "github.com/hashicorp/terraform-schema/registry"
+	"github.com/stretchr/testify/mock"
 	"github.com/zclconf/go-cty-debug/ctydebug"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -387,5 +391,228 @@ func TestParseProviderVersions(t *testing.T) {
 	}
 	if diff := cmp.Diff(expectedInstalledProviders, mod.InstalledProviders); diff != "" {
 		t.Fatalf("unexpected providers: %s", diff)
+	}
+}
+
+func TestParseProviderVersions_multipleVersions(t *testing.T) {
+	modPathFirst := "first"
+	modPathSecond := "second"
+
+	fs := fstest.MapFS{
+		modPathFirst: &fstest.MapFile{Mode: fs.ModeDir},
+		filepath.Join(modPathFirst, ".terraform.lock.hcl"): &fstest.MapFile{
+			Data: []byte(`provider "registry.terraform.io/hashicorp/aws" {
+  version = "4.23.0"
+  hashes = [
+    "h1:j6RGCfnoLBpzQVOKUbGyxf4EJtRvQClKplO+WdXL5O0=",
+    "zh:17adbedc9a80afc571a8de7b9bfccbe2359e2b3ce1fffd02b456d92248ec9294",
+    "zh:23d8956b031d78466de82a3d2bbe8c76cc58482c931af311580b8eaef4e6a38f",
+    "zh:343fe19e9a9f3021e26f4af68ff7f4828582070f986b6e5e5b23d89df5514643",
+    "zh:6b8ff83d884b161939b90a18a4da43dd464c4b984f54b5f537b2870ce6bd94bc",
+    "zh:7777d614d5e9d589ad5508eecf4c6d8f47d50fcbaf5d40fa7921064240a6b440",
+    "zh:82f4578861a6fd0cde9a04a1926920bd72d993d524e5b34d7738d4eff3634c44",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a08fefc153bbe0586389e814979cf7185c50fcddbb2082725991ed02742e7d1e",
+    "zh:ae789c0e7cb777d98934387f8888090ccb2d8973ef10e5ece541e8b624e1fb00",
+    "zh:b4608aab78b4dbb32c629595797107fc5a84d1b8f0682f183793d13837f0ecf0",
+    "zh:ed2c791c2354764b565f9ba4be7fc845c619c1a32cefadd3154a5665b312ab00",
+    "zh:f94ac0072a8545eebabf417bc0acbdc77c31c006ad8760834ee8ee5cdb64e743",
+  ]
+}
+`),
+		},
+		// These are somewhat awkward two entries
+		// to account for io/fs and our own path separator differences
+		// See https://github.com/hashicorp/terraform-ls/issues/1025
+		modPathFirst + "/main.tf": &fstest.MapFile{
+			Data: []byte{},
+		},
+		filepath.Join(modPathFirst, "main.tf"): &fstest.MapFile{
+			Data: []byte(`terraform {
+	required_providers {
+		aws = {
+			source  = "hashicorp/aws"
+			version = "4.23.0"
+		}
+	}
+}
+`),
+		},
+
+		modPathSecond: &fstest.MapFile{Mode: fs.ModeDir},
+		filepath.Join(modPathSecond, ".terraform.lock.hcl"): &fstest.MapFile{
+			Data: []byte(`provider "registry.terraform.io/hashicorp/aws" {
+  version = "4.25.0"
+  hashes = [
+    "h1:j6RGCfnoLBpzQVOKUbGyxf4EJtRvQClKplO+WdXL5O0=",
+    "zh:17adbedc9a80afc571a8de7b9bfccbe2359e2b3ce1fffd02b456d92248ec9294",
+    "zh:23d8956b031d78466de82a3d2bbe8c76cc58482c931af311580b8eaef4e6a38f",
+    "zh:343fe19e9a9f3021e26f4af68ff7f4828582070f986b6e5e5b23d89df5514643",
+    "zh:6b8ff83d884b161939b90a18a4da43dd464c4b984f54b5f537b2870ce6bd94bc",
+    "zh:7777d614d5e9d589ad5508eecf4c6d8f47d50fcbaf5d40fa7921064240a6b440",
+    "zh:82f4578861a6fd0cde9a04a1926920bd72d993d524e5b34d7738d4eff3634c44",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a08fefc153bbe0586389e814979cf7185c50fcddbb2082725991ed02742e7d1e",
+    "zh:ae789c0e7cb777d98934387f8888090ccb2d8973ef10e5ece541e8b624e1fb00",
+    "zh:b4608aab78b4dbb32c629595797107fc5a84d1b8f0682f183793d13837f0ecf0",
+    "zh:ed2c791c2354764b565f9ba4be7fc845c619c1a32cefadd3154a5665b312ab00",
+    "zh:f94ac0072a8545eebabf417bc0acbdc77c31c006ad8760834ee8ee5cdb64e743",
+  ]
+}
+`),
+		},
+		// These are somewhat awkward two entries
+		// to account for io/fs and our own path separator differences
+		// See https://github.com/hashicorp/terraform-ls/issues/1025
+		modPathSecond + "/main.tf": &fstest.MapFile{
+			Data: []byte{},
+		},
+		filepath.Join(modPathSecond, "main.tf"): &fstest.MapFile{
+			Data: []byte(`terraform {
+	required_providers {
+		aws = {
+			source = "hashicorp/aws"
+			version = "4.25.0"
+		}
+	}
+}
+`),
+		},
+	}
+
+	ss, err := state.NewStateStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ss.SetLogger(log.Default())
+
+	ctx := context.Background()
+
+	err = ss.Modules.Add(modPathFirst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = ParseModuleConfiguration(ctx, fs, ss.Modules, modPathFirst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// parse requirements first to enable schema obtaining later
+	err = LoadModuleMetadata(ctx, ss.Modules, modPathFirst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = ParseProviderVersions(ctx, fs, ss.Modules, modPathFirst)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = ss.Modules.Add(modPathSecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = ParseModuleConfiguration(ctx, fs, ss.Modules, modPathSecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// parse requirements first to enable schema obtaining later
+	err = LoadModuleMetadata(ctx, ss.Modules, modPathSecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = ParseProviderVersions(ctx, fs, ss.Modules, modPathSecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx = exec.WithExecutorOpts(ctx, &exec.ExecutorOpts{
+		ExecPath: "mock",
+	})
+	ctx = exec.WithExecutorFactory(ctx, exec.NewMockExecutor(&exec.TerraformMockCalls{
+		PerWorkDir: map[string][]*mock.Call{
+			"first": {
+				{
+					Method:        "ProviderSchemas",
+					Repeatability: 2,
+					Arguments: []interface{}{
+						mock.AnythingOfType(""),
+					},
+					ReturnArguments: []interface{}{
+						&tfjson.ProviderSchemas{
+							FormatVersion: "1.0",
+							Schemas: map[string]*tfjson.ProviderSchema{
+								"registry.terraform.io/hashicorp/aws": {
+									ConfigSchema: &tfjson.Schema{
+										Block: &tfjson.SchemaBlock{
+											Attributes: map[string]*tfjson.SchemaAttribute{
+												"first": {
+													AttributeType: cty.String,
+													Optional:      true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						nil,
+					},
+				},
+			},
+			"second": {
+				{
+					Method:        "ProviderSchemas",
+					Repeatability: 2,
+					Arguments: []interface{}{
+						mock.AnythingOfType(""),
+					},
+					ReturnArguments: []interface{}{
+						&tfjson.ProviderSchemas{
+							FormatVersion: "1.0",
+							Schemas: map[string]*tfjson.ProviderSchema{
+								"registry.terraform.io/hashicorp/aws": {
+									ConfigSchema: &tfjson.Schema{
+										Block: &tfjson.SchemaBlock{
+											Attributes: map[string]*tfjson.SchemaAttribute{
+												"second": {
+													AttributeType: cty.String,
+													Optional:      true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						nil,
+					},
+				},
+			},
+		},
+	}))
+
+	err = ObtainSchema(ctx, ss.Modules, ss.ProviderSchemas, modPathFirst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = ObtainSchema(ctx, ss.Modules, ss.ProviderSchemas, modPathSecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pAddr := tfaddr.MustParseProviderSource("hashicorp/aws")
+	vc := version.MustConstraints(version.NewConstraint(">= 4.25.0"))
+
+	// ask for schema for an unrelated module to avoid path-based matching
+	s, err := ss.ProviderSchemas.ProviderSchema("third", pAddr, vc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s == nil {
+		t.Fatalf("expected non-nil schema for %s %s", pAddr, vc)
+	}
+
+	_, ok := s.Provider.Attributes["second"]
+	if !ok {
+		t.Fatalf("expected attribute from second provider schema, not found")
 	}
 }


### PR DESCRIPTION
This is a follow-up to a recent bug fix - https://github.com/hashicorp/terraform-ls/pull/1048

The linked PR addressed the fact that we may sometimes get provider schemas with `nil` versions. This PR additionally ensures that versions are in fact stored as they should be and clarifies some related edge cases in attached comments.

The temporary lack of versions for schemas is not as easily noticeable thanks to the loose/optimistic matching of schemas we perform, where even if we don't match the version, we always match based on the address, or even just provider name alone.

The only difference it makes is when there are two schemas for the same provider address of different versions - so that inaccuracy is being addressed.

https://github.com/hashicorp/terraform-ls/blob/0f745e191e738796628db49b1e962ec881eb6982/internal/state/provider_schema.go#L264-L333

Additionally - to make testing easier, I also added ranking of schemas based on version constraint match, further making schema matching more accurate.
