### PR TITLE
Don't query the TF registry for module sources starting with "."

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ internal/schemas/schemas_gen.go
 internal/schemas/data/
 terraform-ls
 terraform-ls.exe
+go.work*

--- a/internal/hooks/module_source_registry.go
+++ b/internal/hooks/module_source_registry.go
@@ -45,8 +45,9 @@ func (h *Hooks) RegistryModuleSources(ctx context.Context, value cty.Value) ([]d
 	candidates := make([]decoder.Candidate, 0)
 	prefix := value.AsString()
 
-	if isModuleSourceLocal(prefix) {
-		// We're dealing with a local module source here, no need to search the registry
+	if strings.HasPrefix(prefix, ".") {
+		// We're likely dealing with a local module source here; no need to search the registry
+		// A search for "." will not return any results
 		return candidates, nil
 	}
 
@@ -70,20 +71,4 @@ func (h *Hooks) RegistryModuleSources(ctx context.Context, value cty.Value) ([]d
 	}
 
 	return candidates, nil
-}
-
-var moduleSourceLocalPrefixes = []string{
-	"./",
-	"../",
-	".\\",
-	"..\\",
-}
-
-func isModuleSourceLocal(raw string) bool {
-	for _, prefix := range moduleSourceLocalPrefixes {
-		if strings.HasPrefix(raw, prefix) {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/hooks/module_source_registry_test.go
+++ b/internal/hooks/module_source_registry_test.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -105,7 +104,7 @@ func TestHooks_RegistryModuleSources(t *testing.T) {
 	h := &Hooks{
 		ModStore:      s.Modules,
 		AlgoliaClient: searchClient,
-		Logger:        log.New(ioutil.Discard, "", 0),
+		Logger:        log.New(io.Discard, "", 0),
 	}
 
 	tests := []struct {
@@ -183,7 +182,7 @@ func TestHooks_RegistryModuleSourcesCtxCancel(t *testing.T) {
 	h := &Hooks{
 		ModStore:      s.Modules,
 		AlgoliaClient: searchClient,
-		Logger:        log.New(ioutil.Discard, "", 0),
+		Logger:        log.New(io.Discard, "", 0),
 	}
 
 	_, err = h.RegistryModuleSources(ctx, cty.StringVal("aws"))
@@ -212,7 +211,7 @@ func TestHooks_RegistryModuleSourcesIgnore(t *testing.T) {
 	h := &Hooks{
 		ModStore:      s.Modules,
 		AlgoliaClient: searchClient,
-		Logger:        log.New(ioutil.Discard, "", 0),
+		Logger:        log.New(io.Discard, "", 0),
 	}
 
 	tests := []struct {


### PR DESCRIPTION
This PR updates the check for local module prefixes from `../` to `.` to stop sending search requests for `.` and `..` to the TF registry.

Closes https://github.com/hashicorp/terraform-ls/issues/1053