### PR TITLE
schemas: Treat legacy providers as hashicorp or builtin

### DIFF
--- a/internal/indexer/document_change.go
+++ b/internal/indexer/document_change.go
@@ -82,7 +82,7 @@ func (idx *Indexer) decodeModule(modHandle document.DirHandle, dependsOn job.IDs
 	eSchemaId, err := idx.jobStore.EnqueueJob(job.Job{
 		Dir: modHandle,
 		Func: func(ctx context.Context) error {
-			return module.PreloadEmbeddedSchema(ctx, schemas.FS, idx.modStore, idx.schemaStore, modHandle.Path())
+			return module.PreloadEmbeddedSchema(ctx, idx.logger, schemas.FS, idx.modStore, idx.schemaStore, modHandle.Path())
 		},
 		DependsOn:   job.IDs{metaId},
 		Type:        op.OpTypePreloadEmbeddedSchema.String(),

--- a/internal/indexer/module_calls.go
+++ b/internal/indexer/module_calls.go
@@ -77,7 +77,7 @@ func (idx *Indexer) decodeInstalledModuleCalls(modHandle document.DirHandle, ign
 			eSchemaId, err := idx.jobStore.EnqueueJob(job.Job{
 				Dir: mcHandle,
 				Func: func(ctx context.Context) error {
-					return module.PreloadEmbeddedSchema(ctx, schemas.FS, idx.modStore, idx.schemaStore, mcPath)
+					return module.PreloadEmbeddedSchema(ctx, idx.logger, schemas.FS, idx.modStore, idx.schemaStore, mcPath)
 				},
 				Type:        op.OpTypePreloadEmbeddedSchema.String(),
 				DependsOn:   job.IDs{metaId},

--- a/internal/indexer/walker.go
+++ b/internal/indexer/walker.go
@@ -149,7 +149,7 @@ func (idx *Indexer) WalkedModule(ctx context.Context, modHandle document.DirHand
 	eSchemaId, err := idx.jobStore.EnqueueJob(job.Job{
 		Dir: modHandle,
 		Func: func(ctx context.Context) error {
-			return module.PreloadEmbeddedSchema(ctx, schemas.FS, idx.modStore, idx.schemaStore, modHandle.Path())
+			return module.PreloadEmbeddedSchema(ctx, idx.logger, schemas.FS, idx.modStore, idx.schemaStore, modHandle.Path())
 		},
 		// This could theoretically also depend on ObtainSchema to avoid
 		// attempt to preload the same schema twice but we avoid that dependency

--- a/internal/schemas/schemas.go
+++ b/internal/schemas/schemas.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"log"
 	"path"
 
 	"github.com/hashicorp/go-version"
@@ -62,7 +61,6 @@ func FindProviderSchemaFile(filesystem fs.ReadDirFS, pAddr tfaddr.Provider) (*Pr
 	if err != nil {
 		return nil, err
 	}
-	log.Printf("unzipped file at %s", filePath)
 
 	return &ProviderSchema{
 		File:    gzipReader,

--- a/internal/terraform/module/module_ops.go
+++ b/internal/terraform/module/module_ops.go
@@ -188,7 +188,7 @@ func ObtainSchema(ctx context.Context, modStore *state.ModuleStore, schemaStore 
 	return nil
 }
 
-func PreloadEmbeddedSchema(ctx context.Context, fs fs.ReadDirFS, modStore *state.ModuleStore, schemaStore *state.ProviderSchemaStore, modPath string) error {
+func PreloadEmbeddedSchema(ctx context.Context, logger *log.Logger, fs fs.ReadDirFS, modStore *state.ModuleStore, schemaStore *state.ProviderSchemaStore, modPath string) error {
 	mod, err := modStore.ModuleByPath(modPath)
 	if err != nil {
 		return err
@@ -236,14 +236,14 @@ func PreloadEmbeddedSchema(ctx context.Context, fs fs.ReadDirFS, modStore *state
 			// of all recent (0.14+) Terraform versions.
 			originalAddr := pAddr
 			pAddr.Namespace = "hashicorp"
-			log.Printf("preloading schema for %s (implying %s)",
+			logger.Printf("preloading schema for %s (implying %s)",
 				originalAddr.ForDisplay(), pAddr.ForDisplay())
 		}
 
 		pSchemaFile, err := schemas.FindProviderSchemaFile(fs, pAddr)
 		if err != nil {
 			if errors.Is(err, schemas.SchemaNotAvailable{Addr: pAddr}) {
-				log.Printf("preloaded schema not available for %s", pAddr)
+				logger.Printf("preloaded schema not available for %s", pAddr)
 				continue
 			}
 			return err
@@ -273,13 +273,13 @@ func PreloadEmbeddedSchema(ctx context.Context, fs fs.ReadDirFS, modStore *state
 				// This accounts for a possible race condition
 				// where we may be preloading the same schema
 				// for different providers at the same time
-				log.Printf("schema for %s is already loaded", pAddr)
+				logger.Printf("schema for %s is already loaded", pAddr)
 				continue
 			}
 			return err
 		}
 		elapsedTime := time.Now().Sub(startTime)
-		log.Printf("preloaded schema for %s %s in %s", pAddr, pSchemaFile.Version, elapsedTime)
+		logger.Printf("preloaded schema for %s %s in %s", pAddr, pSchemaFile.Version, elapsedTime)
 	}
 
 	return nil

--- a/internal/terraform/module/module_ops.go
+++ b/internal/terraform/module/module_ops.go
@@ -222,7 +222,12 @@ func PreloadEmbeddedSchema(ctx context.Context, logger *log.Logger, fs fs.ReadDi
 	for pAddr := range missingReqs {
 		startTime := time.Now()
 
-		if pAddr.IsLegacy() {
+		if pAddr.IsLegacy() && pAddr.Type == "terraform" {
+			// The terraform provider is built into Terraform 0.11+
+			// and while it's possible, users typically don't declare
+			// entry in required_providers block for it.
+			pAddr = tfaddr.NewProvider(tfaddr.BuiltInProviderHost, tfaddr.BuiltInProviderNamespace, "terraform")
+		} else if pAddr.IsLegacy() {
 			// Since we use recent version of Terraform to generate
 			// embedded schemas, these will never contain legacy
 			// addresses.

--- a/internal/terraform/module/module_ops_test.go
+++ b/internal/terraform/module/module_ops_test.go
@@ -676,7 +676,7 @@ func TestPreloadEmbeddedSchema_basic(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = PreloadEmbeddedSchema(ctx, schemasFS, ss.Modules, ss.ProviderSchemas, modPath)
+	err = PreloadEmbeddedSchema(ctx, log.Default(), schemasFS, ss.Modules, ss.ProviderSchemas, modPath)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -746,7 +746,7 @@ func TestPreloadEmbeddedSchema_unknownProviderOnly(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = PreloadEmbeddedSchema(ctx, schemasFS, ss.Modules, ss.ProviderSchemas, modPath)
+	err = PreloadEmbeddedSchema(ctx, log.Default(), schemasFS, ss.Modules, ss.ProviderSchemas, modPath)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -810,13 +810,13 @@ func TestPreloadEmbeddedSchema_idempotency(t *testing.T) {
 	}
 
 	// first
-	err = PreloadEmbeddedSchema(ctx, schemasFS, ss.Modules, ss.ProviderSchemas, modPath)
+	err = PreloadEmbeddedSchema(ctx, log.Default(), schemasFS, ss.Modules, ss.ProviderSchemas, modPath)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// second - testing module state
-	err = PreloadEmbeddedSchema(ctx, schemasFS, ss.Modules, ss.ProviderSchemas, modPath)
+	err = PreloadEmbeddedSchema(ctx, log.Default(), schemasFS, ss.Modules, ss.ProviderSchemas, modPath)
 	if err != nil {
 		if !errors.Is(err, job.StateNotChangedErr{Dir: document.DirHandleFromPath(modPath)}) {
 			t.Fatal(err)
@@ -825,7 +825,7 @@ func TestPreloadEmbeddedSchema_idempotency(t *testing.T) {
 
 	ctx = job.WithIgnoreState(ctx, true)
 	// third - testing requirement matching
-	err = PreloadEmbeddedSchema(ctx, schemasFS, ss.Modules, ss.ProviderSchemas, modPath)
+	err = PreloadEmbeddedSchema(ctx, log.Default(), schemasFS, ss.Modules, ss.ProviderSchemas, modPath)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -892,14 +892,14 @@ func TestPreloadEmbeddedSchema_raceCondition(t *testing.T) {
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
-		err := PreloadEmbeddedSchema(ctx, schemasFS, ss.Modules, ss.ProviderSchemas, modPath)
+		err := PreloadEmbeddedSchema(ctx, log.Default(), schemasFS, ss.Modules, ss.ProviderSchemas, modPath)
 		if err != nil && !errors.Is(err, job.StateNotChangedErr{Dir: document.DirHandleFromPath(modPath)}) {
 			t.Error(err)
 		}
 	}()
 	go func() {
 		defer wg.Done()
-		err := PreloadEmbeddedSchema(ctx, schemasFS, ss.Modules, ss.ProviderSchemas, modPath)
+		err := PreloadEmbeddedSchema(ctx, log.Default(), schemasFS, ss.Modules, ss.ProviderSchemas, modPath)
 		if err != nil && !errors.Is(err, job.StateNotChangedErr{Dir: document.DirHandleFromPath(modPath)}) {
 			t.Error(err)
 		}


### PR DESCRIPTION
This was discovered as part of recent failing benchmarks, although it isn't direct root cause of the fail:

https://github.com/hashicorp/terraform-ls/actions/runs/3187102652/jobs/5198346112

## Before

![2022-10-05 10 58 57](https://user-images.githubusercontent.com/287584/194034398-cdf54c23-ce76-4cfb-9ce8-d715a2ed04c7.gif)

![2022-10-05 11 22 06](https://user-images.githubusercontent.com/287584/194038692-7b1b64ef-aba9-4b6a-a08c-0e7cecec08ae.gif)

## After

![2022-10-05 10 58 21](https://user-images.githubusercontent.com/287584/194034377-87883f0e-e192-42c9-8753-87969bbc5fed.gif)

![2022-10-05 11 22 28](https://user-images.githubusercontent.com/287584/194038723-d876ad80-8366-460d-9c78-29347eb46af9.gif)
