### PR TITLE
Update `setup-go` to obtain version via `go-version-file`

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -17,19 +17,10 @@ jobs:
         name: Unshallow
         run: git fetch --prune --unshallow
       -
-        name: Read go version
-        id: go-version
-        shell: bash
-        run: |
-          content=`cat ./.go-version`
-          echo "::set-output name=content::$content"
-      -
         name: Set up Go
         uses: actions/setup-go@v3
         with:
-          # TODO: Replace with go-version-from-file when it is supported
-          # https://github.com/actions/setup-go/pull/62
-          go-version: ${{ steps.go-version.outputs.content }}
+          go-version-file: ".go-version"
       -
         name: Go mod download
         run: go mod download -x

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -5,6 +5,9 @@ on:
     - cron:  '0 3 * * *'
   workflow_dispatch:
 
+env:
+  GOPROXY: https://proxy.golang.org/
+
 jobs:
   benchmarks:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,6 @@ jobs:
       -
         name: Set up Go
         uses: actions/setup-go@v3
-        env:
-          GOPROXY: https://proxy.golang.org/
         with:
           go-version-file: ".go-version"
       -

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,20 +23,12 @@ jobs:
         name: Unshallow
         run: git fetch --prune --unshallow
       -
-        name: Read go version
-        id: go-version
-        run: |
-          content=`cat ./.go-version`
-          echo "::set-output name=content::$content"
-      -
         name: Set up Go
         uses: actions/setup-go@v3
         env:
           GOPROXY: https://proxy.golang.org/
         with:
-          # TODO: Replace with go-version-from-file when it is supported
-          # https://github.com/actions/setup-go/pull/62
-          go-version: ${{ steps.go-version.outputs.content }}
+          go-version-file: ".go-version"
       -
         name: Generate provider schemas
         run: |
@@ -67,26 +59,10 @@ jobs:
         name: Unshallow
         run: git fetch --prune --unshallow
       -
-        name: Read go version (Unix)
-        if: ${{ runner.os != 'Windows' }}
-        id: go-version-unix
-        run: |
-          content=`cat ./.go-version`
-          echo "::set-output name=content::$content"
-      -
-        name: Read go version (Windows)
-        if: ${{ runner.os == 'Windows' }}
-        id: go-version-win
-        run: |
-          $content = Get-Content .\.go-version -Raw
-          echo "::set-output name=content::$content"
-      -
         name: Set up Go
         uses: actions/setup-go@v3
         with:
-          # TODO: Replace with go-version-from-file when it is supported
-          # https://github.com/actions/setup-go/pull/62
-          go-version: ${{ steps.go-version-unix.outputs.content || steps.go-version-win.outputs.content }}
+          go-version-file: ".go-version"
       -
         name: Go mod download
         run: go mod download -x

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,18 +24,10 @@ jobs:
         name: Unshallow
         run: git fetch --prune --unshallow
       -
-        name: Read go version
-        id: go-version
-        run: |
-          content=`cat ./.go-version`
-          echo "::set-output name=content::$content"
-      -
         name: Set up Go
         uses: actions/setup-go@v3
         with:
-          # TODO: Replace with go-version-from-file when it is supported
-          # https://github.com/actions/setup-go/pull/62
-          go-version: ${{ steps.go-version.outputs.content }}
+          go-version-file: ".go-version"
       -
         name: Generate provider schemas
         run: |


### PR DESCRIPTION
This PR updates our workflows to make `setup-go` obtain the Go version directly from the `.go-version` file.