### PR TITLE
state: avoid infinite recursion in JobStore

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -1,4 +1,4 @@
-name: ci
+name: Nightly Tests
 
 on:
   schedule:

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -1,0 +1,34 @@
+name: ci
+
+on:
+  schedule:
+    - cron:  '0 3 * * *'
+  workflow_dispatch:
+
+env:
+  GOPROXY: https://proxy.golang.org/
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Unshallow
+        run: git fetch --prune --unshallow
+      -
+        name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: ".go-version"
+      -
+        name: Go mod download
+        run: go mod download -x
+      -
+        name: Run long tests
+        run: go test -timeout=30m -tags=longtest ./...

--- a/internal/scheduler/scheduler_long_test.go
+++ b/internal/scheduler/scheduler_long_test.go
@@ -1,0 +1,83 @@
+//go:build longtest
+
+package scheduler
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/hashicorp/terraform-ls/internal/document"
+	"github.com/hashicorp/terraform-ls/internal/job"
+	"github.com/hashicorp/terraform-ls/internal/state"
+)
+
+// See https://github.com/hashicorp/terraform-ls/issues/1065
+// This test can be very expensive to run in terms of CPU, memory and time.
+// It takes about 3-4 minutes to finish on M1 Pro.
+func TestScheduler_millionJobsQueued(t *testing.T) {
+	ss, err := state.NewStateStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ss.SetLogger(testLogger())
+
+	tmpDir := t.TempDir()
+	ctx, cancelFunc := context.WithCancel(context.Background())
+
+	lowPrioSched := NewScheduler(ss.JobStore, 1, job.LowPriority)
+	lowPrioSched.Start(ctx)
+	t.Cleanup(func() {
+		lowPrioSched.Stop()
+		cancelFunc()
+	})
+
+	highPrioSched := NewScheduler(ss.JobStore, 100, job.HighPriority)
+
+	// slightly over ~1M jobs seems sufficient to exceed the goroutine stack limit
+	idBatches := make([]job.IDs, 106, 106)
+	var wg sync.WaitGroup
+	for i := 0; i <= 105; i++ {
+		wg.Add(1)
+		i := i
+		go func(i int) {
+			defer wg.Done()
+			idBatches[i] = make(job.IDs, 0)
+			for j := 0; j < 10000; j++ {
+				dirPath := filepath.Join(tmpDir, fmt.Sprintf("folder-%d", j))
+
+				newId, err := ss.JobStore.EnqueueJob(job.Job{
+					Func: func(c context.Context) error {
+						return nil
+					},
+					Dir:      document.DirHandleFromPath(dirPath),
+					Type:     "test",
+					Priority: job.HighPriority,
+				})
+				if err != nil {
+					t.Error(err)
+				}
+				idBatches[i] = append(idBatches[i], newId)
+			}
+			t.Logf("scheduled %d high priority jobs in batch %d", len(idBatches[i]), i)
+		}(i)
+	}
+	wg.Wait()
+
+	highPrioSched.Start(ctx)
+	t.Log("high priority scheduler started")
+
+	t.Cleanup(func() {
+		highPrioSched.Stop()
+		cancelFunc()
+	})
+
+	for _, batch := range idBatches {
+		err = ss.JobStore.WaitForJobs(ctx, batch...)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #1065

I couldn't come up with a more light-weight test which would reproduce the bug. As mentioned in the comment, it (scheduling over 1 million jobs) takes about 3-4 minutes to finish on M1 Pro and consumes decent chunk of almost all cores + ~5-6GB of memory at peak.

The Windows GHA environment runs out of memory before the test can even finish. 🙊 

There are a few options to consider:

1. remove the test entirely (some risk that we re-introduce the bug)
2. gate the test on ENV variable, such as `LONG_TESTS=1`
3. gate the test on build tags, such as `-tags=longtests`

We could also consider not running the test on non-empty `CI` ENV variable (which most CI systems set, incl. GitHub Actions), but I'd argue that it's probably not as valuable to run that test locally for most of the time either.