### PR TITLE
schemas: remove log statements

### DIFF
--- a/internal/schemas/schemas.go
+++ b/internal/schemas/schemas.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"log"
 	"path"
 
 	"github.com/hashicorp/go-version"
@@ -33,11 +32,9 @@ func (e SchemaNotAvailable) Error() string {
 func FindProviderSchemaFile(filesystem fs.ReadDirFS, pAddr tfaddr.Provider) (*ProviderSchema, error) {
 	providerPath := path.Join("data", pAddr.Hostname.String(), pAddr.Namespace, pAddr.Type)
 
-	log.Printf("looking for dir at %q", providerPath)
 	entries, err := fs.ReadDir(filesystem, providerPath)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
-			log.Printf("dir not exist: %#v", err)
 			return nil, SchemaNotAvailable{Addr: pAddr}
 		}
 		return nil, err


### PR DESCRIPTION
This is to avoid benchmark failures due to inability to parse the output:
https://github.com/hashicorp/terraform-ls/actions/runs/3286664100/jobs/5415008036#step:6:1
