### PR TITLE
Enable `for_each`, `count`, `self.*` and `dynamic` support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/hashicorp/terraform-exec v0.17.3
 	github.com/hashicorp/terraform-json v0.14.0
 	github.com/hashicorp/terraform-registry-address v0.0.0-20220623143253-7d51757b572c
-	github.com/hashicorp/terraform-schema v0.0.0-20221031152819-619c765a4245
+	github.com/hashicorp/terraform-schema v0.0.0-20221124161228-88812f3e8011
 	github.com/mh-cbon/go-fmt-fail v0.0.0-20160815164508-67765b3fbcb5
 	github.com/mitchellh/cli v1.1.5
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/hc-install v0.4.0
-	github.com/hashicorp/hcl-lang v0.0.0-20221031081328-b20d6288c7f3
+	github.com/hashicorp/hcl-lang v0.0.0-20221124153623-6addab33cf00
 	github.com/hashicorp/hcl/v2 v2.15.0
 	github.com/hashicorp/terraform-exec v0.17.3
 	github.com/hashicorp/terraform-json v0.14.0

--- a/go.sum
+++ b/go.sum
@@ -226,8 +226,8 @@ github.com/hashicorp/terraform-json v0.14.0 h1:sh9iZ1Y8IFJLx+xQiKHGud6/TSUCM0N8e
 github.com/hashicorp/terraform-json v0.14.0/go.mod h1:5A9HIWPkk4e5aeeXIBbkcOvaZbIYnAIkEyqP2pNSckM=
 github.com/hashicorp/terraform-registry-address v0.0.0-20220623143253-7d51757b572c h1:D8aRO6+mTqHfLsK/BC3j5OAoogv1WLRWzY1AaTo3rBg=
 github.com/hashicorp/terraform-registry-address v0.0.0-20220623143253-7d51757b572c/go.mod h1:Wn3Na71knbXc1G8Lh+yu/dQWWJeFQEpDeJMtWMtlmNI=
-github.com/hashicorp/terraform-schema v0.0.0-20221031152819-619c765a4245 h1:aM/2KRcXoS0GiK7PXMNqgDe9VxGwjdotB3tmTrQbXAo=
-github.com/hashicorp/terraform-schema v0.0.0-20221031152819-619c765a4245/go.mod h1:nbLCjxhC3CDEYkvTw+R9X9sKrqQLKHyzpFvi/dQtZUs=
+github.com/hashicorp/terraform-schema v0.0.0-20221124161228-88812f3e8011 h1:B39mc/093mi7V5M24vktnZ7GZ767EeuK4clY2Iw3WBI=
+github.com/hashicorp/terraform-schema v0.0.0-20221124161228-88812f3e8011/go.mod h1:z8Y7pQU438gSqsayiw072w7X2vMibDVK05Btwr5cZVA=
 github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734 h1:HKLsbzeOsfXmKNpr3GiT18XAblV0BjCbzL8KQAMZGa0=
 github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734/go.mod h1:kNDNcF7sN4DocDLBkQYz73HGKwN1ANB1blq4lIYLYvg=
 github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=

--- a/go.sum
+++ b/go.sum
@@ -216,8 +216,8 @@ github.com/hashicorp/hc-install v0.4.0 h1:cZkRFr1WVa0Ty6x5fTvL1TuO1flul231rWkGH9
 github.com/hashicorp/hc-install v0.4.0/go.mod h1:5d155H8EC5ewegao9A4PUTMNPZaq+TbOzkJJZ4vrXeI=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/hashicorp/hcl-lang v0.0.0-20221031081328-b20d6288c7f3 h1:vGYvIZ5vznlnvJp4lmTz0yvkE6P7by+myhKPXJhC61c=
-github.com/hashicorp/hcl-lang v0.0.0-20221031081328-b20d6288c7f3/go.mod h1:rn5V4b1/658M3g1o+MtdIUl/ZNoCVasB9T31j8XllMM=
+github.com/hashicorp/hcl-lang v0.0.0-20221124153623-6addab33cf00 h1:GbEoLr5aQ8aGVo6Bia6Nk+QRaWyFAUK+EddwH0nhB0I=
+github.com/hashicorp/hcl-lang v0.0.0-20221124153623-6addab33cf00/go.mod h1:it6xaAkaNpJd9WicHQmPMb88VKpp+S2PwB+5GPOuVYc=
 github.com/hashicorp/hcl/v2 v2.15.0 h1:CPDXO6+uORPjKflkWCCwoWc9uRp+zSIPcCQ+BrxV7m8=
 github.com/hashicorp/hcl/v2 v2.15.0/go.mod h1:JRmR89jycNkrrqnMmvPDMd56n1rQJ2Q6KocSLCMCXng=
 github.com/hashicorp/terraform-exec v0.17.3 h1:MX14Kvnka/oWGmIkyuyvL6POx25ZmKrjlaclkx3eErU=


### PR DESCRIPTION
This PR pulls in all the upstream changes to [hcl-lang](https://github.com/hashicorp/hcl-lang/) and [terraform-schema](https://github.com/hashicorp/terraform-schema/).

With the changes, we introduce:
* Support for `self.*` references: https://github.com/hashicorp/hcl-lang/pull/163
* `dynamic` block support, including label and content completion: https://github.com/hashicorp/hcl-lang/pull/154
* Support for `each.*` references: https://github.com/hashicorp/hcl-lang/pull/162
* Support for `count.index` references https://github.com/hashicorp/hcl-lang/pull/160

Closes https://github.com/hashicorp/terraform-ls/issues/1096
Closes https://github.com/hashicorp/terraform-ls/issues/859
Closes https://github.com/hashicorp/terraform-ls/issues/1095
Closes https://github.com/hashicorp/terraform-ls/issues/1093
Closes https://github.com/hashicorp/terraform-ls/issues/530