### PR TITLE
ci: Bump `windows-2019` to `windows-latest`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - windows-2019 # temporary pin to avoid timeouts on windows-2022
+          - windows-latest
           - macos-latest
     steps:
       -


### PR DESCRIPTION
[The issue](https://github.com/actions/runner-images/issues/4856), why we pinned the windows version to 2019 should be resolve by now. Let's bump this to latest.