### PR TITLE
ci: Bump `aws-actions/configure-aws-credentials` to `v1-node16`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,7 +90,7 @@ jobs:
           hc-releases-source_env_key: ${{ secrets.HC_RELEASES_KEY_STAGING }}
       -
         name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.TERRAFORM_PROD_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.TERRAFORM_PROD_AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
This PR updates the action version to the Node 16 based one. It will get rid of two pipeline warnings.

<img width="519" alt="CleanShot 2022-11-25 at 16 42 34@2x" src="https://user-images.githubusercontent.com/45985/204019033-175714c7-85c9-43bf-aef8-d3a79721677f.png">

[More information](https://github.com/aws-actions/configure-aws-credentials/issues/521)