### PR TITLE
Replace deprecated set-output with new `$GITHUB_OUTPUT` var

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           docker login docker.pkg.github.com -u docker -p '${{ secrets.CODESIGN_GITHUB_TOKEN }}' && \
           docker pull docker.pkg.github.com/hashicorp/hc-codesign/hc-codesign:$VERSION && \
-          echo "::set-output name=image::docker.pkg.github.com/hashicorp/hc-codesign/hc-codesign:$VERSION"
+          echo "image=docker.pkg.github.com/hashicorp/hc-codesign/hc-codesign:$VERSION" >> $GITHUB_OUTPUT
         id: codesign
         env:
           VERSION: v0


### PR DESCRIPTION
This should get rid of the warning in the [`Install hc-codesign` step](https://github.com/hashicorp/terraform-ls/actions/runs/3542571029/jobs/5948212728#step:6:32).
> Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/