### PR TITLE
docs: remove deprecated function & change recommended function

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -160,15 +160,15 @@ let g:LanguageClient_serverCommands = {
 lua <<EOF
   require'lspconfig'.terraformls.setup{}
 EOF
-autocmd BufWritePre *.tfvars lua vim.lsp.buf.formatting_sync()
-autocmd BufWritePre *.tf lua vim.lsp.buf.formatting_sync()
+autocmd BufWritePre *.tfvars lua vim.lsp.buf.format()
+autocmd BufWritePre *.tf lua vim.lsp.buf.format()
 ```
  - If you are using `init.lua`:
 ```lua
 require'lspconfig'.terraformls.setup{}
 vim.api.nvim_create_autocmd({"BufWritePre"}, {
   pattern = {"*.tf", "*.tfvars"},
-  callback = vim.lsp.buf.formatting_sync,
+  callback = function() vim.lsp.buf.format() end,
 })
 ```
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -168,7 +168,7 @@ autocmd BufWritePre *.tf lua vim.lsp.buf.formatting_sync()
 require'lspconfig'.terraformls.setup{}
 vim.api.nvim_create_autocmd({"BufWritePre"}, {
   pattern = {"*.tf", "*.tfvars"},
-  callback = function() vim.lsp.buf.formatting_sync() end,
+  callback = vim.lsp.buf.formatting_sync(),
 })
 ```
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -160,6 +160,27 @@ let g:LanguageClient_serverCommands = {
 lua <<EOF
   require'lspconfig'.terraformls.setup{}
 EOF
+autocmd BufWritePre *.tfvars lua vim.lsp.buf.formatting_sync()
+autocmd BufWritePre *.tf lua vim.lsp.buf.formatting_sync()
+```
+ - If you are using `init.lua`:
+```lua
+require'lspconfig'.terraformls.setup{}
+vim.api.nvim_create_autocmd({"BufWritePre"}, {
+  pattern = {"*.tf", "*.tfvars"},
+  callback = function() vim.lsp.buf.formatting_sync() end,
+})
+```
+
+### Neovim v0.8.0+
+
+ - Install the [nvim-lspconfig plugin](https://github.com/neovim/nvim-lspconfig)
+ - Add the following to your `.vimrc` or `init.vim`:
+
+```vim
+lua <<EOF
+  require'lspconfig'.terraformls.setup{}
+EOF
 autocmd BufWritePre *.tfvars lua vim.lsp.buf.format()
 autocmd BufWritePre *.tf lua vim.lsp.buf.format()
 ```

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -189,7 +189,7 @@ autocmd BufWritePre *.tf lua vim.lsp.buf.format()
 require'lspconfig'.terraformls.setup{}
 vim.api.nvim_create_autocmd({"BufWritePre"}, {
   pattern = {"*.tf", "*.tfvars"},
-  callback = function() vim.lsp.buf.format() end,
+  callback = vim.lsp.buf.format(),
 })
 ```
 


### PR DESCRIPTION
This PR replaces the nvim's deprecated functions with new ones.

You can check for deprecated functions with `:h  deprecated` command on nvim.
```
- vim.lsp.buf.formatting()              Use vim.lsp.buf.format() with
                                        {async = true} instead.
```
nvim docs [here](https://neovim.io/doc/user/lsp.html#vim.lsp.buf.format()).