### PR TITLE
github: Pin external GitHub Actions to hashes

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -21,7 +21,7 @@ jobs:
         run: git fetch --prune --unshallow
       -
         name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@d0a58c1c4d2b25278816e339b944508c875f3613 # https://github.com/actions/setup-go/releases/tag/v3.4.0
         with:
           go-version-file: ".go-version"
       -

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # https://github.com/actions/checkout/releases/tag/v3.2.0
       -
         name: Unshallow
         run: git fetch --prune --unshallow

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -67,14 +67,14 @@ jobs:
       -
         name: Upload benchmark data as artifact
         if: ${{ always() && !cancelled() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # https://github.com/actions/upload-artifact/releases/tag/v3.1.1
         with:
           name: benchdata-${{ github.ref_name }}-${{ github.sha }}-${{ github.run_id }}.json
           path: "${{ runner.temp }}/benchdata.json"
       -
         name: Send failures to Slack
         if: ${{ failure() && !cancelled() }}
-        uses: slackapi/slack-github-action@v1.23.0
+        uses: slackapi/slack-github-action@007b2c3c751a190b6f0f040e47ed024deaa72844 # https://github.com/slackapi/slack-github-action/releases/tag/v1.23.0
         with:
           payload: |
             {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
           du -h -s ./internal/schemas/data
       -
         name: Snapshot build (cross-platform)
-        uses: goreleaser/goreleaser-action@v3
+        uses: goreleaser/goreleaser-action@b508e2e3ef3b19d4e4146d4f8fb3ba9db644a757 # https://github.com/goreleaser/goreleaser-action/releases/tag/v3.2.0
         with:
           version: latest
           args: build --snapshot --skip-post-hooks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # https://github.com/actions/checkout/releases/tag/v3.2.0
       -
         name: Unshallow
         run: git fetch --prune --unshallow
@@ -52,7 +52,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # https://github.com/actions/checkout/releases/tag/v3.2.0
       -
         name: Unshallow
         run: git fetch --prune --unshallow

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         run: git fetch --prune --unshallow
       -
         name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@d0a58c1c4d2b25278816e339b944508c875f3613 # https://github.com/actions/setup-go/releases/tag/v3.4.0
         with:
           go-version-file: ".go-version"
       -
@@ -58,7 +58,7 @@ jobs:
         run: git fetch --prune --unshallow
       -
         name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@d0a58c1c4d2b25278816e339b944508c875f3613 # https://github.com/actions/setup-go/releases/tag/v3.4.0
         with:
           go-version-file: ".go-version"
       -

--- a/.github/workflows/issue-comment-created.yml
+++ b/.github/workflows/issue-comment-created.yml
@@ -12,7 +12,7 @@ jobs:
   issue_comment_triage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # https://github.com/actions/checkout/releases/tag/v3.2.0
       - uses: actions-ecosystem/action-remove-labels@v1
         with:
           labels: |

--- a/.github/workflows/issue-comment-created.yml
+++ b/.github/workflows/issue-comment-created.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # https://github.com/actions/checkout/releases/tag/v3.2.0
-      - uses: actions-ecosystem/action-remove-labels@v1
+      - uses: actions-ecosystem/action-remove-labels@2ce5d41b4b6aa8503e285553f75ed56e0a40bae0 # https://github.com/actions-ecosystem/action-remove-labels/releases/tag/v1.3.0
         with:
           labels: |
             stale

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -12,7 +12,7 @@ jobs:
   lock:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@v4
+      - uses: dessant/lock-threads@c1b35aecc5cdb1a34539d14196df55838bb2f836 # https://github.com/dessant/lock-threads/releases/tag/v4.0.0
         with:
           issue-comment: >
             I'm going to lock this issue because it has been closed for _30 days_ ⏳. This helps our maintainers find and focus on the active issues.

--- a/.github/workflows/milestone-closed.yml
+++ b/.github/workflows/milestone-closed.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: bflad/action-milestone-comment@v1
+      - uses: bflad/action-milestone-comment@9d467f6d8032006cc343576e65a0810d07ef0614 # https://github.com/bflad/action-milestone-comment/releases/tag/v1.0.1
         with:
           body: |
             This functionality has been released in [${{ github.event.milestone.title }} of the language server](https://github.com/${{ github.repository }}/blob/${{ github.event.milestone.title }}/CHANGELOG.md).

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -23,7 +23,7 @@ jobs:
         run: git fetch --prune --unshallow
       -
         name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@d0a58c1c4d2b25278816e339b944508c875f3613 # https://github.com/actions/setup-go/releases/tag/v3.4.0
         with:
           go-version-file: ".go-version"
       -

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # https://github.com/actions/checkout/releases/tag/v3.2.0
       -
         name: Unshallow
         run: git fetch --prune --unshallow

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
         run: git fetch --prune --unshallow
       -
         name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@d0a58c1c4d2b25278816e339b944508c875f3613 # https://github.com/actions/setup-go/releases/tag/v3.4.0
         with:
           go-version-file: ".go-version"
       -

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
           github-token: ${{ secrets.CODESIGN_GITHUB_TOKEN }}
       -
         name: Release
-        uses: goreleaser/goreleaser-action@v3
+        uses: goreleaser/goreleaser-action@b508e2e3ef3b19d4e4146d4f8fb3ba9db644a757 # https://github.com/goreleaser/goreleaser-action/releases/tag/v3.2.0
         with:
           version: latest
           args: release
@@ -90,7 +90,7 @@ jobs:
           hc-releases-source_env_key: ${{ secrets.HC_RELEASES_KEY_STAGING }}
       -
         name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@95bc17402b232b5c8fbc16750c070a30575baf2e # https://github.com/aws-actions/configure-aws-credentials/tree/v1-node16
         with:
           aws-access-key-id: ${{ secrets.TERRAFORM_PROD_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.TERRAFORM_PROD_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # https://github.com/actions/checkout/releases/tag/v3.2.0
       -
         name: Unshallow
         run: git fetch --prune --unshallow

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,7 +12,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v6
+    - uses: actions/stale@5ebf00ea0e4c1561e9b43a292ed34424fb1d4578 # https://github.com/actions/stale/releases/tag/v6.0.1
       with:
         days-before-stale: '-1'
         days-before-close: '90'


### PR DESCRIPTION
The intention here is to reduce the security risk posed by the supply chain - i.e. externally maintained GitHub Actions.

The expectation is that dependabot will continue to update these hashes as and when new versions become available.