### PR TITLE
Update doc: call NeoVim lsp format API with `async = true`

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -181,15 +181,17 @@ vim.api.nvim_create_autocmd({"BufWritePre"}, {
 lua <<EOF
   require'lspconfig'.terraformls.setup{}
 EOF
-autocmd BufWritePre *.tfvars lua vim.lsp.buf.format()
-autocmd BufWritePre *.tf lua vim.lsp.buf.format()
+autocmd BufWritePre *.tfvars lua vim.lsp.buf.format({ async = true })
+autocmd BufWritePre *.tf lua vim.lsp.buf.format({ async = true })
 ```
  - If you are using `init.lua`:
 ```lua
 require'lspconfig'.terraformls.setup{}
 vim.api.nvim_create_autocmd({"BufWritePre"}, {
   pattern = {"*.tf", "*.tfvars"},
-  callback = vim.lsp.buf.format(),
+  callback = function()
+    vim.lsp.buf.format({ async = true })
+  end
 })
 ```
 


### PR DESCRIPTION
After following the setup guide for Neovim `v0.8.0+`, the auto formatting did
not work on `BufWritePre`.
Following the git history and the docs was updated in #1126. As it said in the
PR:
```
- vim.lsp.buf.formatting()              Use vim.lsp.buf.format() with
                                        {async = true} instead.
```
So I tried to add `async = true` and it works as expected.

The example config is incorrect anyway because the parameter `callback` takes
a function, not the invocation.

I know very little about NeoVim's API. Therefore I am not sure if this should
be the common setup. Also I only use/tested the pure lua config version.
