### PR TITLE
version: trim spaces from raw `VERSION`

### DIFF
--- a/version.go
+++ b/version.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	_ "embed"
+	"strings"
 
 	goversion "github.com/hashicorp/go-version"
 )
@@ -16,7 +17,7 @@ var (
 	//go:embed version/VERSION
 	rawVersion string
 
-	version = goversion.Must(goversion.NewVersion(rawVersion))
+	version = goversion.Must(goversion.NewVersion(strings.TrimSpace(rawVersion)))
 )
 
 // VersionString returns the complete version string, including prerelease

--- a/version.go
+++ b/version.go
@@ -16,15 +16,10 @@ var (
 	//go:embed version/VERSION
 	rawVersion string
 
-	fullVersion = parseRawVersion(rawVersion)
+	version = goversion.Must(goversion.NewVersion(rawVersion))
 )
 
 // VersionString returns the complete version string, including prerelease
 func VersionString() string {
-	return fullVersion.String()
-}
-
-func parseRawVersion(rawVersion string) goversion.Version {
-	v := goversion.Must(goversion.NewVersion(rawVersion))
-	return *v
+	return version.String()
 }


### PR DESCRIPTION
This is useful e.g. when VERSION file is edited via GitHub UI, which automatically adds a trailing newline.
