### PR TITLE
ci: Automate releasing via bob

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -208,4 +208,4 @@ Release process:
  1. Run the [Release workflow](https://github.com/hashicorp/terraform-ls/actions/workflows/release.yml) with the appropriate version (matching the one in `version/VERSION`) & SHA (long one).
  1. Wait for `staging` release [is finished](https://github.com/hashicorp/crt-workflows-common/actions/workflows/crt-promote-staging.yml).
  1. Wait for a message in the Slack channel saying that authorisation is needed to promote artifacts to production. Click on the link and approve.
- 1. Once notified that promotion is successful, go to https://github.com/hashicorp/crt-workflows-common/actions/workflows/promote-production-packaging.yml, locate the terraform-ls promote-production-packaging workflow, and approve.
+ 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -205,31 +205,7 @@ Release process:
 
  1. Update [`version/VERSION`](https://github.com/hashicorp/terraform-ls/blob/main/version/VERSION) to remove `-dev` suffix and set it to the intended version to be released
  1. Wait for [`build` workflow](https://github.com/hashicorp/terraform-ls/actions/workflows/build.yml) and dependent `prepare` workflow to finish
- 1. Ensure you have the appropriate GitHub PAT set in `BOB_GITHUB_TOKEN` variable
- 1. Set `SHA` to the corresponding (long) last commit SHA (after updating `VERSION` file) & `VERSION` to the same version
- 1. Use `bob` to promote artifacts to **staging**
- ```
-bob trigger-promotion \
-  --product-name=terraform-ls \
-  --environment=terraform-ls-oss \
-  --org=hashicorp \
-  --repo=terraform-ls \
-  --slack-channel=C02AGQXCAF5 \
-  --product-version="$VERSION" \
-  --sha="$SHA" \
-  --branch=main \
-  staging
- ```
- 1. Use `bob` to promote artifacts to **production**
- ```
-bob trigger-promotion \
-  --product-name=terraform-ls \
-  --environment=terraform-ls-oss \
-  --org=hashicorp \
-  --repo=terraform-ls \
-  --slack-channel=C02AGQXCAF5 \
-  --product-version="$VERSION" \
-  --sha="$SHA" \
-  --branch=main \
-  production
- ```
+ 1. Run the [Release workflow](https://github.com/hashicorp/terraform-ls/actions/workflows/release.yml) with the appropriate version (matching the one in `version/VERSION`) & SHA (long one).
+ 1. Wait for `staging` release [is finished](https://github.com/hashicorp/crt-workflows-common/actions/workflows/crt-promote-staging.yml).
+ 1. Wait for a message in the Slack channel saying that authorisation is needed to promote artifacts to production. Click on the link and approve.
+ 1. Once notified that promotion is successful, go to https://github.com/hashicorp/crt-workflows-common/actions/workflows/promote-production-packaging.yml, locate the terraform-ls promote-production-packaging workflow, and approve.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,73 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version'
+        required: true
+        type: string
+      sha:
+        description: 'SHA'
+        required: true
+        type: string
+      branch:
+        description: 'Branch'
+        type: string
+        default: main
+
+jobs:
+  staging:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup bob
+        uses: hashicorp/action-setup-bob@v1
+        with:
+          github-token:
+            ${{ secrets.BOB_GITHUB_TOKEN }}
+      - name: Promote to staging
+        env:
+          BOB_GITHUB_TOKEN: ${{ secrets.BOB_GITHUB_TOKEN }}
+          VERSION: ${{ github.event.inputs.version }}
+          SHA: ${{ github.event.inputs.sha }}
+          BRANCH: main
+          ENVIRONMENT: staging
+        run: |
+          bob trigger-promotion \
+            --product-name=terraform-ls \
+            --environment=terraform-ls-oss \
+            --org=hashicorp \
+            --repo=terraform-ls \
+            --slack-channel=C02AGQXCAF5 \
+            --product-version=$VERSION \
+            --sha=$SHA \
+            --branch=$BRANCH \
+            $ENVIRONMENT
+
+  production:
+    runs-on: ubuntu-latest
+    needs: staging
+    steps:
+      - name: Setup bob
+        uses: hashicorp/action-setup-bob@v1
+        with:
+          github-token:
+            ${{ secrets.BOB_GITHUB_TOKEN }}
+      - name: Promote to production
+        env:
+          BOB_GITHUB_TOKEN: ${{ secrets.BOB_GITHUB_TOKEN }}
+          VERSION: ${{ github.event.inputs.version }}
+          SHA: ${{ github.event.inputs.sha }}
+          BRANCH: main
+          ENVIRONMENT: production
+        run: |
+          bob trigger-promotion \
+            --product-name=terraform-ls \
+            --environment=terraform-ls-oss \
+            --org=hashicorp \
+            --repo=terraform-ls \
+            --slack-channel=C02AGQXCAF5 \
+            --product-version=$VERSION \
+            --sha=$SHA \
+            --branch=$BRANCH \
+            $ENVIRONMENT


### PR DESCRIPTION
## Context

Releasing currently requires a number of additional steps outside of GitHub. For a simple project with simple release pipeline such as this one, there is no strong benefit to do multi-staged releasing, as some other bigger projects do.

## Proposal

Simplify release process by moving promotion steps into a GHA workflow.

## TODO

 - [x] Create a dedicated GH bot account with appropriate access
 - [x] Grant access for `tf-editor-exp-ci-bot` to `bob` repo
 - [x] Generate new PAT within the GH bot account ^
 - [x] Set PAT as a new secret within this repo `BOB_GITHUB_TOKEN`
 - [x] Update release docs