### PR TITLE
Continue parsing module files on error

### DIFF
--- a/internal/terraform/parser/module.go
+++ b/internal/terraform/parser/module.go
@@ -32,7 +32,9 @@ func ParseModuleFiles(fs FS, modPath string) (ast.ModFiles, ast.ModDiags, error)
 
 		src, err := fs.ReadFile(fullPath)
 		if err != nil {
-			return nil, nil, err
+			// If a file isn't accessible, continue with reading the
+			// remaining module files
+			continue
 		}
 
 		filename := ast.ModFilename(name)

--- a/internal/terraform/parser/module_test.go
+++ b/internal/terraform/parser/module_test.go
@@ -83,6 +83,15 @@ func TestParseModuleFiles(t *testing.T) {
 				},
 			},
 		},
+		{
+			"invalid-links",
+			map[string]struct{}{
+				"resources.tf": {},
+			},
+			map[string]hcl.Diagnostics{
+				"resources.tf": nil,
+			},
+		},
 	}
 
 	fs := osFs{}

--- a/internal/terraform/parser/testdata/invalid-links/invalid.tf
+++ b/internal/terraform/parser/testdata/invalid-links/invalid.tf
@@ -1,0 +1,1 @@
+non-existent-file

--- a/internal/terraform/parser/testdata/invalid-links/resources.tf
+++ b/internal/terraform/parser/testdata/invalid-links/resources.tf
@@ -1,0 +1,9 @@
+resource "aws_instance" "web" {
+  ami                    = "ami-a0cfeed8"
+  instance_type          = "t2.micro"
+  user_data              = file("init-script.sh")
+
+  tags = {
+    Name = random_pet.name.id
+  }
+}


### PR DESCRIPTION
This PR changes the parsing of module files so that if we encounter an inaccessible file, we continue parsing all the other module files instead of aborting with an error.

That should improve the experience for emacs users, relying on magic symlinks to keep track of open files.

Fixes https://github.com/hashicorp/terraform-ls/issues/1067

## UX

**Before**
![CleanShot 2023-02-13 at 11 55 20@2x](https://user-images.githubusercontent.com/45985/218439860-8a66e80f-acbd-4850-a3b1-facc95ea22fe.png)
No features available within the module


**After**
![CleanShot 2023-02-13 at 11 56 03@2x](https://user-images.githubusercontent.com/45985/218439854-79614568-85ba-4907-bec6-f8b37babc23a.png)
