### PR TITLE
deps: bump terraform-schema to `62b1929`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/hashicorp/terraform-exec v0.17.3
 	github.com/hashicorp/terraform-json v0.15.0
 	github.com/hashicorp/terraform-registry-address v0.0.0-20220623143253-7d51757b572c
-	github.com/hashicorp/terraform-schema v0.0.0-20230208190913-43c2dec4c86f
+	github.com/hashicorp/terraform-schema v0.0.0-20230215154105-62b19298872f
 	github.com/mh-cbon/go-fmt-fail v0.0.0-20160815164508-67765b3fbcb5
 	github.com/mitchellh/cli v1.1.5
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -221,8 +221,8 @@ github.com/hashicorp/terraform-json v0.15.0 h1:/gIyNtR6SFw6h5yzlbDbACyGvIhKtQi8m
 github.com/hashicorp/terraform-json v0.15.0/go.mod h1:+L1RNzjDU5leLFZkHTFTbJXaoqUC6TqXlFgDoOXrtvk=
 github.com/hashicorp/terraform-registry-address v0.0.0-20220623143253-7d51757b572c h1:D8aRO6+mTqHfLsK/BC3j5OAoogv1WLRWzY1AaTo3rBg=
 github.com/hashicorp/terraform-registry-address v0.0.0-20220623143253-7d51757b572c/go.mod h1:Wn3Na71knbXc1G8Lh+yu/dQWWJeFQEpDeJMtWMtlmNI=
-github.com/hashicorp/terraform-schema v0.0.0-20230208190913-43c2dec4c86f h1:UEyawCSXF/4SvecNeKtKsVg8lrZEcQT2S2Sb5W4Pjgg=
-github.com/hashicorp/terraform-schema v0.0.0-20230208190913-43c2dec4c86f/go.mod h1:QZlFIRRPE58J4/WhwGFWbL6Figujvbv3kDSQiezMvmw=
+github.com/hashicorp/terraform-schema v0.0.0-20230215154105-62b19298872f h1:QpboEFKLwIvvp0D6UWWzAx4/j1nCj1snfTRh3PgRq4A=
+github.com/hashicorp/terraform-schema v0.0.0-20230215154105-62b19298872f/go.mod h1:JSXoOylwIc+IbKDP+QLygHz5yBEgK1B/zKTp6YGSSyg=
 github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734 h1:HKLsbzeOsfXmKNpr3GiT18XAblV0BjCbzL8KQAMZGa0=
 github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734/go.mod h1:kNDNcF7sN4DocDLBkQYz73HGKwN1ANB1blq4lIYLYvg=
 github.com/hexops/autogold v1.3.1 h1:YgxF9OHWbEIUjhDbpnLhgVsjUDsiHDTyDfy2lrfdlzo=


### PR DESCRIPTION
This is to bring in https://github.com/hashicorp/terraform-schema/pull/184 which in turn enables correct parsing of default values in optional object attributes, such as in the following sample config:

```hcl
variable "example" {
  type = object({
    foo = optional(string, "toot") # HERE
    bar = number
  })
}
```

This is a minor enhancement in the sense that we're catching up behind Terraform 1.3 which introduced defaults, as per https://github.com/hashicorp/terraform-ls/issues/917 (https://github.com/hashicorp/terraform/pull/31154).