### PR TITLE
Disable cgo for builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,6 +115,7 @@ jobs:
           BASE_VERSION: ${{ needs.set-product-version.outputs.product-base-version }}
           PRERELEASE_VERSION: ${{ needs.set-product-version.outputs.product-prerelease-version}}
           METADATA_VERSION: ${{ env.METADATA }}
+          CGO_ENABLED: 0
         with:
           product_name: ${{ env.PKG_NAME }}
           product_version: ${{ needs.set-product-version.outputs.product-version }}


### PR DESCRIPTION
When migrating to CRT, I missed disabling cgo for native (Linux) builds. We had this set before in the [`.goreleaser.yml`](https://github.com/hashicorp/terraform-ls/blob/f3eb1948a92f9b308fc33f8a665f13cece024979/.goreleaser.yml#L1-L2)

The current binaries released for Linux are dynamically linked, as reported in https://github.com/hashicorp/vscode-terraform/issues/1346

