### PR TITLE
Update github.com/creachadair/jrpc2 to v0.46.0.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/algolia/algoliasearch-client-go/v3 v3.26.4
 	github.com/apparentlymart/go-textseg v1.0.0
-	github.com/creachadair/jrpc2 v0.45.0
+	github.com/creachadair/jrpc2 v0.46.0
 	github.com/google/go-cmp v0.5.9
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-memdb v1.3.4

--- a/go.sum
+++ b/go.sum
@@ -79,8 +79,8 @@ github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnht
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/coreos/go-systemd/v22 v22.3.3-0.20220203105225-a9a7ef127534/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
-github.com/creachadair/jrpc2 v0.45.0 h1:61Cdy1IbyB3So5+znIQ4eki4P1/j/FiNIy0SS9j3kJY=
-github.com/creachadair/jrpc2 v0.45.0/go.mod h1:O7R/rmcUivGXUkfmbuWevcLv6f1xbKVSoMvmhW4/fr8=
+github.com/creachadair/jrpc2 v0.46.0 h1:ahMNQN8Q6oJDC6Zn/TPK1YRAP5alFQ5hk2h5tzBVifE=
+github.com/creachadair/jrpc2 v0.46.0/go.mod h1:O7R/rmcUivGXUkfmbuWevcLv6f1xbKVSoMvmhW4/fr8=
 github.com/creachadair/mds v0.0.0-20230313153906-9788b6f60568 h1:LzMDPh2FLXEHnQNTjGJT+vInPSDVOUTuzqE4GskHTNg=
 github.com/creachadair/mds v0.0.0-20230313153906-9788b6f60568/go.mod h1:caBACU+n1Q/rZ252FTzfnG0/H+ZUi+UnIQtEOraMv/g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/internal/langserver/handlers/command/init.go
+++ b/internal/langserver/handlers/command/init.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/creachadair/jrpc2/code"
+	"github.com/creachadair/jrpc2"
 	"github.com/hashicorp/terraform-ls/internal/document"
 	"github.com/hashicorp/terraform-ls/internal/langserver/cmd"
 	"github.com/hashicorp/terraform-ls/internal/langserver/errors"
@@ -17,7 +17,7 @@ import (
 func (h *CmdHandler) TerraformInitHandler(ctx context.Context, args cmd.CommandArgs) (interface{}, error) {
 	dirUri, ok := args.GetString("uri")
 	if !ok || dirUri == "" {
-		return nil, fmt.Errorf("%w: expected module uri argument to be set", code.InvalidParams.Err())
+		return nil, fmt.Errorf("%w: expected module uri argument to be set", jrpc2.InvalidParams.Err())
 	}
 
 	if !uri.IsURIValid(dirUri) {

--- a/internal/langserver/handlers/command/module_callers.go
+++ b/internal/langserver/handlers/command/module_callers.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/creachadair/jrpc2/code"
+	"github.com/creachadair/jrpc2"
 	"github.com/hashicorp/terraform-ls/internal/langserver/cmd"
 	"github.com/hashicorp/terraform-ls/internal/uri"
 )
@@ -24,7 +24,7 @@ type moduleCaller struct {
 func (h *CmdHandler) ModuleCallersHandler(ctx context.Context, args cmd.CommandArgs) (interface{}, error) {
 	modUri, ok := args.GetString("uri")
 	if !ok || modUri == "" {
-		return nil, fmt.Errorf("%w: expected module uri argument to be set", code.InvalidParams.Err())
+		return nil, fmt.Errorf("%w: expected module uri argument to be set", jrpc2.InvalidParams.Err())
 	}
 
 	if !uri.IsURIValid(modUri) {

--- a/internal/langserver/handlers/command/module_calls.go
+++ b/internal/langserver/handlers/command/module_calls.go
@@ -6,7 +6,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/creachadair/jrpc2/code"
+	"github.com/creachadair/jrpc2"
 	"github.com/hashicorp/terraform-ls/internal/langserver/cmd"
 	"github.com/hashicorp/terraform-ls/internal/uri"
 	tfaddr "github.com/hashicorp/terraform-registry-address"
@@ -48,7 +48,7 @@ func (h *CmdHandler) ModuleCallsHandler(ctx context.Context, args cmd.CommandArg
 
 	modUri, ok := args.GetString("uri")
 	if !ok || modUri == "" {
-		return response, fmt.Errorf("%w: expected module uri argument to be set", code.InvalidParams.Err())
+		return response, fmt.Errorf("%w: expected module uri argument to be set", jrpc2.InvalidParams.Err())
 	}
 
 	if !uri.IsURIValid(modUri) {

--- a/internal/langserver/handlers/command/module_providers.go
+++ b/internal/langserver/handlers/command/module_providers.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/creachadair/jrpc2/code"
+	"github.com/creachadair/jrpc2"
 	"github.com/hashicorp/terraform-ls/internal/langserver/cmd"
 	"github.com/hashicorp/terraform-ls/internal/uri"
 	tfaddr "github.com/hashicorp/terraform-registry-address"
@@ -33,7 +33,7 @@ func (h *CmdHandler) ModuleProvidersHandler(ctx context.Context, args cmd.Comman
 
 	modUri, ok := args.GetString("uri")
 	if !ok || modUri == "" {
-		return response, fmt.Errorf("%w: expected module uri argument to be set", code.InvalidParams.Err())
+		return response, fmt.Errorf("%w: expected module uri argument to be set", jrpc2.InvalidParams.Err())
 	}
 
 	if !uri.IsURIValid(modUri) {

--- a/internal/langserver/handlers/command/terraform.go
+++ b/internal/langserver/handlers/command/terraform.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/creachadair/jrpc2/code"
+	"github.com/creachadair/jrpc2"
 	"github.com/hashicorp/terraform-ls/internal/langserver/cmd"
 	"github.com/hashicorp/terraform-ls/internal/langserver/progress"
 	"github.com/hashicorp/terraform-ls/internal/uri"
@@ -31,7 +31,7 @@ func (h *CmdHandler) TerraformVersionRequestHandler(ctx context.Context, args cm
 	progress.Report(ctx, "Finding current module info ...")
 	modUri, ok := args.GetString("uri")
 	if !ok || modUri == "" {
-		return response, fmt.Errorf("%w: expected module uri argument to be set", code.InvalidParams.Err())
+		return response, fmt.Errorf("%w: expected module uri argument to be set", jrpc2.InvalidParams.Err())
 	}
 
 	if !uri.IsURIValid(modUri) {

--- a/internal/langserver/handlers/command/validate.go
+++ b/internal/langserver/handlers/command/validate.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/creachadair/jrpc2/code"
+	"github.com/creachadair/jrpc2"
 	lsctx "github.com/hashicorp/terraform-ls/internal/context"
 	"github.com/hashicorp/terraform-ls/internal/document"
 	"github.com/hashicorp/terraform-ls/internal/langserver/cmd"
@@ -19,7 +19,7 @@ import (
 func (h *CmdHandler) TerraformValidateHandler(ctx context.Context, args cmd.CommandArgs) (interface{}, error) {
 	dirUri, ok := args.GetString("uri")
 	if !ok || dirUri == "" {
-		return nil, fmt.Errorf("%w: expected module uri argument to be set", code.InvalidParams.Err())
+		return nil, fmt.Errorf("%w: expected module uri argument to be set", jrpc2.InvalidParams.Err())
 	}
 
 	if !uri.IsURIValid(dirUri) {

--- a/internal/langserver/handlers/execute_command.go
+++ b/internal/langserver/handlers/execute_command.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/creachadair/jrpc2"
-	"github.com/creachadair/jrpc2/code"
 	lsctx "github.com/hashicorp/terraform-ls/internal/context"
 	"github.com/hashicorp/terraform-ls/internal/langserver/cmd"
 	"github.com/hashicorp/terraform-ls/internal/langserver/handlers/command"
@@ -39,7 +38,7 @@ func (svc *service) WorkspaceExecuteCommand(ctx context.Context, params lsp.Exec
 	commandPrefix, _ := lsctx.CommandPrefix(ctx)
 	handler, ok := cmdHandlers(svc).Get(params.Command, commandPrefix)
 	if !ok {
-		return nil, fmt.Errorf("%w: command handler not found for %q", code.MethodNotFound.Err(), params.Command)
+		return nil, fmt.Errorf("%w: command handler not found for %q", jrpc2.MethodNotFound.Err(), params.Command)
 	}
 
 	pt, ok := params.WorkDoneToken.(lsp.ProgressToken)
@@ -52,6 +51,6 @@ func (svc *service) WorkspaceExecuteCommand(ctx context.Context, params lsp.Exec
 
 func removedHandler(errorMessage string) cmd.Handler {
 	return func(context.Context, cmd.CommandArgs) (interface{}, error) {
-		return nil, jrpc2.Errorf(code.MethodNotFound, "REMOVED: %s", errorMessage)
+		return nil, jrpc2.Errorf(jrpc2.MethodNotFound, "REMOVED: %s", errorMessage)
 	}
 }

--- a/internal/langserver/handlers/execute_command_init_test.go
+++ b/internal/langserver/handlers/execute_command_init_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/creachadair/jrpc2/code"
+	"github.com/creachadair/jrpc2"
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-ls/internal/langserver"
 	"github.com/hashicorp/terraform-ls/internal/langserver/cmd"
@@ -66,7 +66,7 @@ func TestLangServer_workspaceExecuteCommand_init_argumentError(t *testing.T) {
 		Method: "workspace/executeCommand",
 		ReqParams: fmt.Sprintf(`{
 		"command": %q
-	}`, cmd.Name("terraform.init"))}, code.InvalidParams.Err())
+	}`, cmd.Name("terraform.init"))}, jrpc2.InvalidParams.Err())
 }
 
 func TestLangServer_workspaceExecuteCommand_init_basic(t *testing.T) {
@@ -242,5 +242,5 @@ func TestLangServer_workspaceExecuteCommand_init_error(t *testing.T) {
 		ReqParams: fmt.Sprintf(`{
 		"command": %q,
 		"arguments": ["uri=%s"]
-	}`, cmd.Name("terraform.init"), testFileURI)}, code.SystemError.Err())
+	}`, cmd.Name("terraform.init"), testFileURI)}, jrpc2.SystemError.Err())
 }

--- a/internal/langserver/handlers/execute_command_module_callers_test.go
+++ b/internal/langserver/handlers/execute_command_module_callers_test.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/creachadair/jrpc2/code"
+	"github.com/creachadair/jrpc2"
 	"github.com/hashicorp/terraform-ls/internal/document"
 	"github.com/hashicorp/terraform-ls/internal/langserver"
 	"github.com/hashicorp/terraform-ls/internal/langserver/cmd"
@@ -67,7 +67,7 @@ func TestLangServer_workspaceExecuteCommand_moduleCallers_argumentError(t *testi
 		Method: "workspace/executeCommand",
 		ReqParams: fmt.Sprintf(`{
 		"command": %q
-	}`, cmd.Name("module.callers"))}, code.InvalidParams.Err())
+	}`, cmd.Name("module.callers"))}, jrpc2.InvalidParams.Err())
 }
 
 func TestLangServer_workspaceExecuteCommand_moduleCallers_basic(t *testing.T) {

--- a/internal/langserver/handlers/execute_command_module_providers_test.go
+++ b/internal/langserver/handlers/execute_command_module_providers_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/creachadair/jrpc2/code"
+	"github.com/creachadair/jrpc2"
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-ls/internal/document"
 	"github.com/hashicorp/terraform-ls/internal/langserver"
@@ -67,7 +67,7 @@ func TestLangServer_workspaceExecuteCommand_moduleProviders_argumentError(t *tes
 		Method: "workspace/executeCommand",
 		ReqParams: fmt.Sprintf(`{
 		"command": %q
-	}`, cmd.Name("module.providers"))}, code.InvalidParams.Err())
+	}`, cmd.Name("module.providers"))}, jrpc2.InvalidParams.Err())
 }
 
 func TestLangServer_workspaceExecuteCommand_moduleProviders_basic(t *testing.T) {

--- a/internal/langserver/handlers/execute_command_modules_test.go
+++ b/internal/langserver/handlers/execute_command_modules_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/creachadair/jrpc2"
-	"github.com/creachadair/jrpc2/code"
 	"github.com/hashicorp/terraform-ls/internal/langserver"
 	"github.com/hashicorp/terraform-ls/internal/langserver/cmd"
 	"github.com/hashicorp/terraform-ls/internal/state"
@@ -66,5 +65,5 @@ func TestLangServer_workspaceExecuteCommand_modules_basic(t *testing.T) {
 		ReqParams: fmt.Sprintf(`{
 		"command": %q,
 		"arguments": ["uri=%s"] 
-	}`, cmd.Name("rootmodules"), testFileURI)}, jrpc2.Errorf(code.MethodNotFound, "REMOVED: use module.callers instead"))
+	}`, cmd.Name("rootmodules"), testFileURI)}, jrpc2.Errorf(jrpc2.MethodNotFound, "REMOVED: use module.callers instead"))
 }

--- a/internal/langserver/handlers/execute_command_test.go
+++ b/internal/langserver/handlers/execute_command_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/creachadair/jrpc2/code"
+	"github.com/creachadair/jrpc2"
 	"github.com/hashicorp/terraform-ls/internal/langserver"
 	"github.com/hashicorp/terraform-ls/internal/state"
 	"github.com/hashicorp/terraform-ls/internal/terraform/exec"
@@ -65,5 +65,5 @@ func TestLangServer_workspaceExecuteCommand_noCommandHandlerError(t *testing.T) 
 		Method: "workspace/executeCommand",
 		ReqParams: `{
 		"command": "notfound"
-	}`}, code.MethodNotFound.Err())
+	}`}, jrpc2.MethodNotFound.Err())
 }

--- a/internal/langserver/handlers/execute_command_validate_test.go
+++ b/internal/langserver/handlers/execute_command_validate_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/creachadair/jrpc2/code"
+	"github.com/creachadair/jrpc2"
 	"github.com/hashicorp/terraform-ls/internal/langserver"
 	"github.com/hashicorp/terraform-ls/internal/langserver/cmd"
 	"github.com/hashicorp/terraform-ls/internal/state"
@@ -63,5 +63,5 @@ func TestLangServer_workspaceExecuteCommand_validate_argumentError(t *testing.T)
 		Method: "workspace/executeCommand",
 		ReqParams: fmt.Sprintf(`{
 		"command": %q
-	}`, cmd.Name("terraform.validate"))}, code.InvalidParams.Err())
+	}`, cmd.Name("terraform.validate"))}, jrpc2.InvalidParams.Err())
 }

--- a/internal/langserver/handlers/formatting_test.go
+++ b/internal/langserver/handlers/formatting_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/creachadair/jrpc2/code"
+	"github.com/creachadair/jrpc2"
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-ls/internal/langserver"
 	"github.com/hashicorp/terraform-ls/internal/langserver/session"
@@ -214,7 +214,7 @@ func TestLangServer_formatting_oldVersion(t *testing.T) {
 			"textDocument": {
 				"uri": "%s/main.tf"
 			}
-		}`, tmpDir.URI)}, code.SystemError.Err())
+		}`, tmpDir.URI)}, jrpc2.SystemError.Err())
 }
 
 func TestLangServer_formatting_variables(t *testing.T) {

--- a/internal/langserver/handlers/initialize.go
+++ b/internal/langserver/handlers/initialize.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/creachadair/jrpc2"
-	"github.com/creachadair/jrpc2/code"
 	lsctx "github.com/hashicorp/terraform-ls/internal/context"
 	"github.com/hashicorp/terraform-ls/internal/document"
 	ilsp "github.com/hashicorp/terraform-ls/internal/lsp"
@@ -134,7 +133,7 @@ func (svc *service) Initialize(ctx context.Context, params lsp.InitializeParams)
 	} else {
 		rootURI := string(params.RootURI)
 
-		invalidUriErr := jrpc2.Errorf(code.InvalidParams,
+		invalidUriErr := jrpc2.Errorf(jrpc2.InvalidParams,
 			"Unsupported or invalid URI: %q "+
 				"This is most likely client bug, please report it.", rootURI)
 

--- a/internal/langserver/handlers/initialize_test.go
+++ b/internal/langserver/handlers/initialize_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/creachadair/jrpc2/code"
+	"github.com/creachadair/jrpc2"
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-ls/internal/langserver"
 	"github.com/hashicorp/terraform-ls/internal/state"
@@ -49,7 +49,7 @@ func TestInitialize_twice(t *testing.T) {
 	    "capabilities": {},
 	    "rootUri": %q,
 	    "processId": 12345
-	}`, tmpDir.URI)}, code.SystemError.Err())
+	}`, tmpDir.URI)}, jrpc2.SystemError.Err())
 }
 
 func TestInitialize_withIncompatibleTerraformVersion(t *testing.T) {
@@ -113,7 +113,7 @@ func TestInitialize_withInvalidRootURI(t *testing.T) {
 	    "capabilities": {},
 	    "processId": 12345,
 	    "rootUri": "meh"
-	}`}, code.InvalidParams.Err())
+	}`}, jrpc2.InvalidParams.Err())
 }
 
 func TestInitialize_multipleFolders(t *testing.T) {

--- a/internal/langserver/handlers/semantic_tokens.go
+++ b/internal/langserver/handlers/semantic_tokens.go
@@ -3,7 +3,7 @@ package handlers
 import (
 	"context"
 
-	"github.com/creachadair/jrpc2/code"
+	"github.com/creachadair/jrpc2"
 	ilsp "github.com/hashicorp/terraform-ls/internal/lsp"
 	lsp "github.com/hashicorp/terraform-ls/internal/protocol"
 )
@@ -24,7 +24,7 @@ func (svc *service) TextDocumentSemanticTokensFull(ctx context.Context, params l
 		// it didn't claim to support, so we just strictly follow
 		// the protocol here and avoid serving buggy clients.
 		svc.logger.Printf("semantic tokens full request support not announced by client")
-		return tks, code.MethodNotFound.Err()
+		return tks, jrpc2.MethodNotFound.Err()
 	}
 
 	dh := ilsp.HandleFromDocumentURI(params.TextDocument.URI)

--- a/internal/langserver/handlers/service.go
+++ b/internal/langserver/handlers/service.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/creachadair/jrpc2"
-	"github.com/creachadair/jrpc2/code"
 	rpch "github.com/creachadair/jrpc2/handler"
 	"github.com/hashicorp/hcl-lang/decoder"
 	"github.com/hashicorp/hcl-lang/lang"
@@ -581,7 +580,7 @@ func convertMap(m map[string]rpch.Func) rpch.Map {
 	return hm
 }
 
-const requestCancelled code.Code = -32800
+const requestCancelled jrpc2.Code = -32800
 
 // handle calls a jrpc2.Func compatible function
 func handle(ctx context.Context, req *jrpc2.Request, fn interface{}) (interface{}, error) {

--- a/internal/langserver/handlers/shutdown_test.go
+++ b/internal/langserver/handlers/shutdown_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/creachadair/jrpc2/code"
+	"github.com/creachadair/jrpc2"
 	"github.com/hashicorp/terraform-ls/internal/langserver"
 	"github.com/hashicorp/terraform-ls/internal/terraform/exec"
 	"github.com/stretchr/testify/mock"
@@ -34,5 +34,5 @@ func TestShutdown_twice(t *testing.T) {
 
 	ls.CallAndExpectError(t, &langserver.CallRequest{
 		Method: "shutdown", ReqParams: `{}`},
-		code.InvalidRequest.Err())
+		jrpc2.InvalidRequest.Err())
 }

--- a/internal/langserver/session/errors.go
+++ b/internal/langserver/session/errors.go
@@ -3,10 +3,10 @@ package session
 import (
 	"fmt"
 
-	"github.com/creachadair/jrpc2/code"
+	"github.com/creachadair/jrpc2"
 )
 
-const SessionNotInitialized code.Code = -32002
+const SessionNotInitialized jrpc2.Code = -32002
 
 type unexpectedSessionState struct {
 	ExpectedState sessionState
@@ -27,7 +27,7 @@ func SessionNotInitializedErr(state sessionState) error {
 		return fmt.Errorf("%w: %s", SessionNotInitialized.Err(), uss)
 	}
 	if state == stateDown {
-		return fmt.Errorf("%w: %s", code.InvalidRequest.Err(), uss)
+		return fmt.Errorf("%w: %s", jrpc2.InvalidRequest.Err(), uss)
 	}
 
 	return uss
@@ -35,12 +35,12 @@ func SessionNotInitializedErr(state sessionState) error {
 
 func SessionAlreadyInitializedErr(reqID string) error {
 	return fmt.Errorf("%w: session was already initialized via request ID %s",
-		code.SystemError.Err(), reqID)
+		jrpc2.SystemError.Err(), reqID)
 }
 
 func SessionAlreadyDownErr(reqID string) error {
 	return fmt.Errorf("%w: session was already shut down via request %s",
-		code.InvalidRequest.Err(), reqID)
+		jrpc2.InvalidRequest.Err(), reqID)
 }
 
 type InvalidURIErr struct {


### PR DESCRIPTION
In preparation for tagging a v1 for this module, this release contains some API changes, specifically a package rename. This PR updates the terraform-ls usage. The changes have no semantic effect.

I'm sending this in advance since Dependabot won't be able to handle it automatically, but feel free to take it over if you'd prefer to make the change some other way, skip the update, etc.

(For background see https://github.com/creachadair/jrpc2/issues/46).