### PR TITLE
Cache registry module errors

### DIFF
--- a/internal/registry/module.go
+++ b/internal/registry/module.go
@@ -51,13 +51,13 @@ type ModuleVersion struct {
 	Version string `json:"version"`
 }
 
-type RegistryClientError struct {
-	Status int
-	Body   string
+type ClientError struct {
+	StatusCode int
+	Body       string
 }
 
-func (rce RegistryClientError) Error() string {
-	return fmt.Sprintf("%d: %s", rce.Status, rce.Body)
+func (rce ClientError) Error() string {
+	return fmt.Sprintf("%d: %s", rce.StatusCode, rce.Body)
 }
 
 func (c Client) GetModuleData(ctx context.Context, addr tfaddr.Module, cons version.Constraints) (*ModuleResponse, error) {
@@ -94,7 +94,7 @@ func (c Client) GetModuleData(ctx context.Context, addr tfaddr.Module, cons vers
 			return nil, err
 		}
 
-		return nil, RegistryClientError{Status: resp.StatusCode, Body: string(bodyBytes)}
+		return nil, ClientError{StatusCode: resp.StatusCode, Body: string(bodyBytes)}
 	}
 
 	err = json.NewDecoder(resp.Body).Decode(&response)
@@ -146,7 +146,7 @@ func (c Client) GetModuleVersions(ctx context.Context, addr tfaddr.Module) (vers
 			return nil, err
 		}
 
-		return nil, RegistryClientError{Status: resp.StatusCode, Body: string(bodyBytes)}
+		return nil, ClientError{StatusCode: resp.StatusCode, Body: string(bodyBytes)}
 	}
 
 	var response ModuleVersionsResponse

--- a/internal/state/module.go
+++ b/internal/state/module.go
@@ -528,6 +528,10 @@ func (s *ModuleStore) RegistryModuleMeta(addr tfaddr.Module, cons version.Constr
 	for item := it.Next(); item != nil; item = it.Next() {
 		mod := item.(*RegistryModuleData)
 
+		if mod.Error {
+			continue
+		}
+
 		if cons.Check(mod.Version) {
 			return &registry.ModuleData{
 				Version: mod.Version,

--- a/internal/state/registry_modules_test.go
+++ b/internal/state/registry_modules_test.go
@@ -118,3 +118,40 @@ func TestModule_DeclaredModuleMeta(t *testing.T) {
 		t.Fatalf("mismatch chached metadata: %s", diff)
 	}
 }
+
+func TestStateStore_cache_error(t *testing.T) {
+	s, err := NewStateStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	source, err := tfaddr.ParseModuleSource("terraform-aws-modules/eks/aws")
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := version.MustConstraints(version.NewConstraint(">= 3.0"))
+
+	// should be false
+	exists, err := s.RegistryModules.Exists(source, c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exists == true {
+		t.Fatal("should not exist")
+	}
+
+	// store an error for a moudle
+	err = s.RegistryModules.CacheError(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// should be true
+	exists, err = s.RegistryModules.Exists(source, c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exists != true {
+		t.Fatal("should exist")
+	}
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -154,6 +154,7 @@ var dbSchema = &memdb.DBSchema{
 							&StringerFieldIndexer{Field: "Source"},
 							&VersionFieldIndexer{Field: "Version"},
 						},
+						AllowMissing: true,
 					},
 				},
 				"source_addr": {

--- a/internal/terraform/module/module_ops.go
+++ b/internal/terraform/module/module_ops.go
@@ -639,8 +639,8 @@ func GetModuleDataFromRegistry(ctx context.Context, regClient registry.Client, m
 		if err != nil {
 			errs = multierror.Append(errs, err)
 
-			clientError := registry.RegistryClientError{}
-			if errors.As(err, &clientError) && clientError.Status == 404 {
+			clientError := registry.ClientError{}
+			if errors.As(err, &clientError) && clientError.StatusCode >= 400 && clientError.StatusCode < 429 {
 				// Still cache the module
 				err = modRegStore.CacheError(sourceAddr)
 				if err != nil {

--- a/internal/terraform/module/module_ops.go
+++ b/internal/terraform/module/module_ops.go
@@ -640,7 +640,9 @@ func GetModuleDataFromRegistry(ctx context.Context, regClient registry.Client, m
 			errs = multierror.Append(errs, err)
 
 			clientError := registry.ClientError{}
-			if errors.As(err, &clientError) && clientError.StatusCode >= 400 && clientError.StatusCode < 429 {
+			if errors.As(err, &clientError) &&
+				((clientError.StatusCode >= 400 && clientError.StatusCode < 408) ||
+					(clientError.StatusCode > 408 && clientError.StatusCode < 429)) {
 				// Still cache the module
 				err = modRegStore.CacheError(sourceAddr)
 				if err != nil {

--- a/internal/terraform/module/module_ops.go
+++ b/internal/terraform/module/module_ops.go
@@ -638,6 +638,16 @@ func GetModuleDataFromRegistry(ctx context.Context, regClient registry.Client, m
 		metaData, err := regClient.GetModuleData(ctx, sourceAddr, declaredModule.Version)
 		if err != nil {
 			errs = multierror.Append(errs, err)
+
+			clientError := registry.RegistryClientError{}
+			if errors.As(err, &clientError) && clientError.Status == 404 {
+				// Still cache the module
+				err = modRegStore.CacheError(sourceAddr)
+				if err != nil {
+					errs = multierror.Append(errs, err)
+				}
+			}
+
 			continue
 		}
 


### PR DESCRIPTION
This PR introduces caching for registry module HTTP request errors. We're currently only caching 404 errors, but it might also be sensible to cache other errors.

The change dramatically improves the performance when many jobs run in the background after a more significant text change.

## UX

**Before**
![2023-04-26 15 52 48](https://user-images.githubusercontent.com/45985/234597861-433edc1e-807d-4a9a-868b-0f4396c53af6.gif)


**After**
![2023-04-26 15 51 31](https://user-images.githubusercontent.com/45985/234597815-fb204e4e-9c81-4422-82a9-423cc327fd76.gif)