### PR TITLE
Change nvim_create_autocmd callback to a lambda

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -175,7 +175,9 @@ autocmd BufWritePre *.tf lua vim.lsp.buf.format()
 require'lspconfig'.terraformls.setup{}
 vim.api.nvim_create_autocmd({"BufWritePre"}, {
   pattern = {"*.tf", "*.tfvars"},
-  callback = vim.lsp.buf.format(),
+  callback = function()
+    vim.lsp.buf.format()
+  end,
 })
 ```
 


### PR DESCRIPTION
Related to #1140 

`callback` in `vim.api.nvim_create_autocmd()` seems to require a lambda.

I didn't test it for VimScript or Neovim v0.5.0+ so I didn't change it for these.