### PR TITLE
LSP Logging

### DIFF
--- a/internal/cmd/serve_command.go
+++ b/internal/cmd/serve_command.go
@@ -109,8 +109,11 @@ func (c *ServeCommand) Run(args []string) int {
 	}
 
 	srv := langserver.NewLangServer(ctx, handlers.NewSession)
-	srv.SetLogger(logger)
-
+	// TODO: Not sure about removing this here. We can't use window/LogMessage yet
+	// because we haven't started
+	// If we leave this here, some stuff still goes to stderr
+	// srv.SetLogger(logger)
+	
 	if c.port != 0 {
 		err := srv.StartTCP(fmt.Sprintf("localhost:%d", c.port))
 		if err != nil {

--- a/internal/langserver/handlers/initialize.go
+++ b/internal/langserver/handlers/initialize.go
@@ -12,6 +12,7 @@ import (
 	"github.com/creachadair/jrpc2"
 	lsctx "github.com/hashicorp/terraform-ls/internal/context"
 	"github.com/hashicorp/terraform-ls/internal/document"
+	"github.com/hashicorp/terraform-ls/internal/logging"
 	ilsp "github.com/hashicorp/terraform-ls/internal/lsp"
 	lsp "github.com/hashicorp/terraform-ls/internal/protocol"
 	"github.com/hashicorp/terraform-ls/internal/settings"
@@ -39,6 +40,9 @@ func (svc *service) Initialize(ctx context.Context, params lsp.InitializeParams)
 	expClientCaps := lsp.ExperimentalClientCapabilities(clientCaps.Experimental)
 
 	svc.server = jrpc2.ServerFromContext(ctx)
+	svc.logger = logging.NewLspLogger(&logging.LspLogger{
+		Context: ctx,
+	})
 
 	setupTelemetry(expClientCaps, svc, ctx, properties)
 	defer svc.telemetry.SendEvent(ctx, "initialize", properties)

--- a/internal/langserver/langserver.go
+++ b/internal/langserver/langserver.go
@@ -17,6 +17,7 @@ import (
 	"github.com/creachadair/jrpc2/channel"
 	"github.com/creachadair/jrpc2/server"
 	"github.com/hashicorp/terraform-ls/internal/langserver/session"
+	"github.com/hashicorp/terraform-ls/internal/logging"
 )
 
 type langServer struct {
@@ -85,7 +86,7 @@ func (ls *langServer) startServer(reader io.Reader, writer io.WriteCloser) (*sin
 		return nil, err
 	}
 	srv.Start(channel.LSP(reader, writer))
-
+	
 	return srv, nil
 }
 
@@ -104,6 +105,10 @@ func (ls *langServer) StartAndWait(reader io.Reader, writer io.WriteCloser) erro
 		srv.Wait()
 		cancelFunc()
 	}()
+
+	ls.SetLogger(logging.NewLspLogger(&logging.LspLogger{
+		Context: ctx,
+	}))
 
 	select {
 	case <-ctx.Done():

--- a/internal/logging/lsp.go
+++ b/internal/logging/lsp.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package logging
 
 import (

--- a/internal/logging/lsp.go
+++ b/internal/logging/lsp.go
@@ -1,0 +1,33 @@
+package logging
+
+import (
+	"context"
+	"log"
+	"strings"
+
+	"github.com/creachadair/jrpc2"
+	lsp "github.com/hashicorp/terraform-ls/internal/protocol"
+)
+
+func NewLspLogger(lspLog *LspLogger) *log.Logger {
+	return log.New(lspLog, "", log.Lshortfile)
+}
+
+type LspLogger struct {
+	Context context.Context
+}
+
+func (l LspLogger) Write(p []byte) (int, error) {
+	logMessage := string(p)
+	// there appears to be an extra newline that's helpful for stderr
+	// but not for outputchannel
+	logMessage = strings.TrimSuffix(logMessage, "\n")
+	
+	// TODO handle error here
+	jrpc2.ServerFromContext(l.Context).Notify(l.Context, "window/logMessage", &lsp.LogMessageParams{
+		Type: lsp.Log,
+		Message: logMessage,
+	})
+	
+	return 0, nil
+}


### PR DESCRIPTION
This uses the LSP window/logMessage notification to send terraform-ls logs to the client instead of to stderr. This has the benefit of not using stderr for clients that report that as errors as well as shipping logs for TCP connections.

How these logs are displayed varies by editor, with VS Code, SublimeText and neovim appearing to handle these fine.

This is currently a hackweek project that needs some work to get into a state that can be shipped
