### PR TITLE
Set codelensReferenceCount to experimental

### DIFF
--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -14,8 +14,9 @@ import (
 )
 
 type ExperimentalFeatures struct {
-	ValidateOnSave        bool `mapstructure:"validateOnSave"`
-	PrefillRequiredFields bool `mapstructure:"prefillRequiredFields"`
+	CodelensReferenceCount bool `mapstructure:"codelensReferenceCount"`
+	ValidateOnSave         bool `mapstructure:"validateOnSave"`
+	PrefillRequiredFields  bool `mapstructure:"prefillRequiredFields"`
 }
 
 type Indexing struct {


### PR DESCRIPTION
This moves the `terraform.codelens.referenceCount` setting to `terraform.experimentalFeatures.codelensReferenceCount` to properly reflect the experimental nature of this setting.

While `terraform.codelens.referenceCount` was set to false and declared to be experimental in the README, it was not marked as experimental in the name of the setting. We have been seeing reports of usage where it has been affecting performance and want to ensure that users are opting in with intent to test usage of this feature.

When this feature moves to stable, the previous setting name can return.

Needs https://github.com/hashicorp/vscode-terraform/pull/1545