### PR TITLE
jobs: Don't wait for `GetModuleDataFromRegistry` job

### DIFF
--- a/internal/indexer/document_change.go
+++ b/internal/indexer/document_change.go
@@ -124,7 +124,9 @@ func (idx *Indexer) decodeModule(ctx context.Context, modHandle document.DirHand
 	}
 	ids = append(ids, refOriginsId)
 
-	registryId, err := idx.jobStore.EnqueueJob(ctx, job.Job{
+	// This job may make an HTTP request, and we schedule it in
+	// the low-priority queue, so we don't want to wait for it.
+	_, err = idx.jobStore.EnqueueJob(ctx, job.Job{
 		Dir: modHandle,
 		Func: func(ctx context.Context) error {
 			return module.GetModuleDataFromRegistry(ctx, idx.registryClient,
@@ -136,8 +138,6 @@ func (idx *Indexer) decodeModule(ctx context.Context, modHandle document.DirHand
 	if err != nil {
 		return ids, err
 	}
-
-	ids = append(ids, registryId)
 
 	return ids, nil
 }


### PR DESCRIPTION
This job may make an HTTP request and we schedule it in the low priority queue so we don't want to wait for it.

This can significantly reduce the request time for the `didOpen` and `didChange` calls.

**Before**
<img width="988" alt="CleanShot 2023-07-27 at 18 03 40@2x" src="https://github.com/hashicorp/terraform-ls/assets/45985/39d371c1-86a9-416e-8a85-84c4b4373291">

**After**
<img width="981" alt="CleanShot 2023-07-27 at 18 04 07@2x" src="https://github.com/hashicorp/terraform-ls/assets/45985/eb7bbfaf-4f28-4ae1-bde9-de02bc3ed68a">

Another improvement might be not to schedule this job if there are no external module calls in a file.