### PR TITLE
OTEL: Instrument `PreloadEmbeddedSchema` job

### DIFF
--- a/internal/terraform/module/module_ops.go
+++ b/internal/terraform/module/module_ops.go
@@ -35,7 +35,13 @@ import (
 	tfschema "github.com/hashicorp/terraform-schema/schema"
 	"github.com/zclconf/go-cty/cty"
 	ctyjson "github.com/zclconf/go-cty/cty/json"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 )
+
+const tracerName = "github.com/hashicorp/terraform-ls/internal/terraform/module"
 
 type DeferFunc func(opError error)
 
@@ -223,72 +229,124 @@ func PreloadEmbeddedSchema(ctx context.Context, logger *log.Logger, fs fs.ReadDi
 	}
 
 	for pAddr := range missingReqs {
-		startTime := time.Now()
-
-		if pAddr.IsLegacy() && pAddr.Type == "terraform" {
-			// The terraform provider is built into Terraform 0.11+
-			// and while it's possible, users typically don't declare
-			// entry in required_providers block for it.
-			pAddr = tfaddr.NewProvider(tfaddr.BuiltInProviderHost, tfaddr.BuiltInProviderNamespace, "terraform")
-		} else if pAddr.IsLegacy() {
-			// Since we use recent version of Terraform to generate
-			// embedded schemas, these will never contain legacy
-			// addresses.
-			//
-			// A legacy namespace may come from missing
-			// required_providers entry & implied requirement
-			// from the provider block or 0.12-style entry,
-			// such as { grafana = "1.0" }.
-			//
-			// Implying "hashicorp" namespace here mimics behaviour
-			// of all recent (0.14+) Terraform versions.
-			originalAddr := pAddr
-			pAddr.Namespace = "hashicorp"
-			logger.Printf("preloading schema for %s (implying %s)",
-				originalAddr.ForDisplay(), pAddr.ForDisplay())
-		}
-
-		pSchemaFile, err := schemas.FindProviderSchemaFile(fs, pAddr)
-		if err != nil {
-			if errors.Is(err, schemas.SchemaNotAvailable{Addr: pAddr}) {
-				logger.Printf("preloaded schema not available for %s", pAddr)
-				continue
-			}
-			return err
-		}
-
-		b, err := io.ReadAll(pSchemaFile.File)
+		err := preloadSchemaForProviderAddr(ctx, pAddr, fs, schemaStore, logger)
 		if err != nil {
 			return err
 		}
-
-		jsonSchemas := tfjson.ProviderSchemas{}
-		err = json.Unmarshal(b, &jsonSchemas)
-		if err != nil {
-			return err
-		}
-		ps, ok := jsonSchemas.Schemas[pAddr.String()]
-		if !ok {
-			return fmt.Errorf("%q: no schema found in file", pAddr)
-		}
-
-		pSchema := tfschema.ProviderSchemaFromJson(ps, pAddr)
-		pSchema.SetProviderVersion(pAddr, pSchemaFile.Version)
-		err = schemaStore.AddPreloadedSchema(pAddr, pSchemaFile.Version, pSchema)
-		if err != nil {
-			existsError := &state.AlreadyExistsError{}
-			if errors.As(err, &existsError) {
-				// This accounts for a possible race condition
-				// where we may be preloading the same schema
-				// for different providers at the same time
-				logger.Printf("schema for %s is already loaded", pAddr)
-				continue
-			}
-			return err
-		}
-		elapsedTime := time.Now().Sub(startTime)
-		logger.Printf("preloaded schema for %s %s in %s", pAddr, pSchemaFile.Version, elapsedTime)
 	}
+
+	return nil
+}
+
+func preloadSchemaForProviderAddr(ctx context.Context, pAddr tfaddr.Provider, fs fs.ReadDirFS,
+	schemaStore *state.ProviderSchemaStore, logger *log.Logger) error {
+
+	startTime := time.Now()
+
+	if pAddr.IsLegacy() && pAddr.Type == "terraform" {
+		// The terraform provider is built into Terraform 0.11+
+		// and while it's possible, users typically don't declare
+		// entry in required_providers block for it.
+		pAddr = tfaddr.NewProvider(tfaddr.BuiltInProviderHost, tfaddr.BuiltInProviderNamespace, "terraform")
+	} else if pAddr.IsLegacy() {
+		// Since we use recent version of Terraform to generate
+		// embedded schemas, these will never contain legacy
+		// addresses.
+		//
+		// A legacy namespace may come from missing
+		// required_providers entry & implied requirement
+		// from the provider block or 0.12-style entry,
+		// such as { grafana = "1.0" }.
+		//
+		// Implying "hashicorp" namespace here mimics behaviour
+		// of all recent (0.14+) Terraform versions.
+		originalAddr := pAddr
+		pAddr.Namespace = "hashicorp"
+		logger.Printf("preloading schema for %s (implying %s)",
+			originalAddr.ForDisplay(), pAddr.ForDisplay())
+	}
+
+	ctx, rootSpan := otel.Tracer(tracerName).Start(ctx, "preloadProviderSchema",
+		trace.WithAttributes(attribute.KeyValue{
+			Key:   attribute.Key("ProviderAddress"),
+			Value: attribute.StringValue(pAddr.String()),
+		}))
+	defer rootSpan.End()
+
+	pSchemaFile, err := schemas.FindProviderSchemaFile(fs, pAddr)
+	if err != nil {
+		rootSpan.RecordError(err)
+		rootSpan.SetStatus(codes.Error, "schema file not found")
+		if errors.Is(err, schemas.SchemaNotAvailable{Addr: pAddr}) {
+			logger.Printf("preloaded schema not available for %s", pAddr)
+			return nil
+		}
+		return err
+	}
+
+	_, span := otel.Tracer(tracerName).Start(ctx, "readProviderSchemaFile",
+		trace.WithAttributes(attribute.KeyValue{
+			Key:   attribute.Key("ProviderAddress"),
+			Value: attribute.StringValue(pAddr.String()),
+		}))
+	b, err := io.ReadAll(pSchemaFile.File)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "schema file not readable")
+		return err
+	}
+	span.SetStatus(codes.Ok, "schema file read successfully")
+	span.End()
+
+	_, span = otel.Tracer(tracerName).Start(ctx, "decodeProviderSchemaData",
+		trace.WithAttributes(attribute.KeyValue{
+			Key:   attribute.Key("ProviderAddress"),
+			Value: attribute.StringValue(pAddr.String()),
+		}))
+	jsonSchemas := tfjson.ProviderSchemas{}
+	err = json.Unmarshal(b, &jsonSchemas)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "schema file not decodable")
+		return err
+	}
+	span.SetStatus(codes.Ok, "schema data decoded successfully")
+	span.End()
+
+	ps, ok := jsonSchemas.Schemas[pAddr.String()]
+	if !ok {
+		return fmt.Errorf("%q: no schema found in file", pAddr)
+	}
+
+	pSchema := tfschema.ProviderSchemaFromJson(ps, pAddr)
+	pSchema.SetProviderVersion(pAddr, pSchemaFile.Version)
+
+	_, span = otel.Tracer(tracerName).Start(ctx, "loadProviderSchemaDataIntoMemDb",
+		trace.WithAttributes(attribute.KeyValue{
+			Key:   attribute.Key("ProviderAddress"),
+			Value: attribute.StringValue(pAddr.String()),
+		}))
+	err = schemaStore.AddPreloadedSchema(pAddr, pSchemaFile.Version, pSchema)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "loading schema into mem-db failed")
+		span.End()
+		existsError := &state.AlreadyExistsError{}
+		if errors.As(err, &existsError) {
+			// This accounts for a possible race condition
+			// where we may be preloading the same schema
+			// for different providers at the same time
+			logger.Printf("schema for %s is already loaded", pAddr)
+			return nil
+		}
+		return err
+	}
+	span.SetStatus(codes.Ok, "schema loaded successfully")
+	span.End()
+
+	elapsedTime := time.Now().Sub(startTime)
+	logger.Printf("preloaded schema for %s %s in %s", pAddr, pSchemaFile.Version, elapsedTime)
+	rootSpan.SetStatus(codes.Ok, "schema loaded successfully")
 
 	return nil
 }


### PR DESCRIPTION
Follow-up from https://github.com/hashicorp/terraform-ls/pull/1327

Related to https://github.com/hashicorp/terraform-ls/issues/1056

One area identified as consuming significant time when working through some data is the `PreloadEmbeddedSchema` job. While this isn't necessarily an indication of a bottleneck in itself, this PR adds some further instrumentation to help gain further visibility into that job.

**Example dataset:**

<img width="878" alt="Screenshot 2023-07-28 at 16 31 40" src="https://github.com/hashicorp/terraform-ls/assets/287584/122d3303-ab4e-4553-b111-79d297094a1b">
