### PR TITLE
fix: Add missing context argument to a test

### DIFF
--- a/internal/scheduler/scheduler_long_test.go
+++ b/internal/scheduler/scheduler_long_test.go
@@ -51,7 +51,7 @@ func TestScheduler_millionJobsQueued(t *testing.T) {
 			for j := 0; j < 10000; j++ {
 				dirPath := filepath.Join(tmpDir, fmt.Sprintf("folder-%d", j))
 
-				newId, err := ss.JobStore.EnqueueJob(job.Job{
+				newId, err := ss.JobStore.EnqueueJob(ctx, job.Job{
 					Func: func(c context.Context) error {
 						return nil
 					},


### PR DESCRIPTION
This was discovered as part of (failing) nightly runs https://github.com/hashicorp/terraform-ls/actions/runs/5703957126/job/15457105405 ever since we merged https://github.com/hashicorp/terraform-ls/pull/1327 which changed some interfaces.

Because the test only runs/compiles with a specific build tag, this wasn't discovered as part of the original PR or through regular PR-based CI jobs.

Here is a test run from the branch: https://github.com/hashicorp/terraform-ls/actions/runs/5712124794/job/15474997813