### PR TITLE
deps: Bump terraform-schema to 8234469

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/hashicorp/terraform-exec v0.18.1
 	github.com/hashicorp/terraform-json v0.17.1
 	github.com/hashicorp/terraform-registry-address v0.2.1
-	github.com/hashicorp/terraform-schema v0.0.0-20230620150221-29a5273da5f1
+	github.com/hashicorp/terraform-schema v0.0.0-20230801050013-8234469eab81
 	github.com/mh-cbon/go-fmt-fail v0.0.0-20160815164508-67765b3fbcb5
 	github.com/mitchellh/cli v1.1.5
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -216,8 +216,8 @@ github.com/hashicorp/terraform-json v0.17.1 h1:eMfvh/uWggKmY7Pmb3T85u86E2EQg6EQH
 github.com/hashicorp/terraform-json v0.17.1/go.mod h1:Huy6zt6euxaY9knPAFKjUITn8QxUFIe9VuSzb4zn/0o=
 github.com/hashicorp/terraform-registry-address v0.2.1 h1:QuTf6oJ1+WSflJw6WYOHhLgwUiQ0FrROpHPYFtwTYWM=
 github.com/hashicorp/terraform-registry-address v0.2.1/go.mod h1:BSE9fIFzp0qWsJUUyGquo4ldV9k2n+psif6NYkBRS3Y=
-github.com/hashicorp/terraform-schema v0.0.0-20230620150221-29a5273da5f1 h1:MmN3soz6kM7YG2H0bV1CnMugCYR0BmHmy7poMOWr30A=
-github.com/hashicorp/terraform-schema v0.0.0-20230620150221-29a5273da5f1/go.mod h1:c3vz3dnCBFmFnqYKdZhsn6yJ0Tn8dWErPz7tOmMX8e4=
+github.com/hashicorp/terraform-schema v0.0.0-20230801050013-8234469eab81 h1:M4Vj4ETh3KGjW3j/DErxEWReYGvmptYW/hontgSQoOQ=
+github.com/hashicorp/terraform-schema v0.0.0-20230801050013-8234469eab81/go.mod h1:sjr8eFDzy3aBLwOXC8+jLm/MatUH+SFFiY2XDDReKA0=
 github.com/hashicorp/terraform-svchost v0.1.1 h1:EZZimZ1GxdqFRinZ1tpJwVxxt49xc/S52uzrw4x0jKQ=
 github.com/hashicorp/terraform-svchost v0.1.1/go.mod h1:mNsjQfZyf/Jhz35v6/0LWcv26+X7JPS+buii2c9/ctc=
 github.com/hexops/autogold v1.3.1 h1:YgxF9OHWbEIUjhDbpnLhgVsjUDsiHDTyDfy2lrfdlzo=


### PR DESCRIPTION
This is to bring in https://github.com/hashicorp/terraform-schema/pull/238 and reduce the noise in OTEL data.