### PR TITLE
Introduce a new setting for early validation

### DIFF
--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -18,6 +18,10 @@ type ExperimentalFeatures struct {
 	PrefillRequiredFields bool `mapstructure:"prefillRequiredFields"`
 }
 
+type ValidationOptions struct {
+	EarlyValidation bool `mapstructure:"earlyValidation"`
+}
+
 type Indexing struct {
 	IgnoreDirectoryNames []string `mapstructure:"ignoreDirectoryNames"`
 	IgnorePaths          []string `mapstructure:"ignorePaths"`
@@ -35,6 +39,8 @@ type Options struct {
 
 	// ExperimentalFeatures encapsulates experimental features users can opt into.
 	ExperimentalFeatures ExperimentalFeatures `mapstructure:"experimentalFeatures"`
+
+	Validation ValidationOptions `mapstructure:"validation"`
 
 	IgnoreSingleFileWarning bool `mapstructure:"ignoreSingleFileWarning"`
 


### PR DESCRIPTION
Adds `validation.earlyValidation` as a new setting.

I chose to use `validation` as a primary key as we expect to add future settings for this feature.
