### PR TITLE
Centralize diagnostics publishing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/hc-install v0.5.2
-	github.com/hashicorp/hcl-lang v0.0.0-20230823131918-b6a3f8271038
+	github.com/hashicorp/hcl-lang v0.0.0-20230825134805-29034e9d534d
 	github.com/hashicorp/hcl/v2 v2.17.0
 	github.com/hashicorp/terraform-exec v0.18.1
 	github.com/hashicorp/terraform-json v0.17.1
@@ -27,7 +27,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/stretchr/testify v1.8.4
 	github.com/vektra/mockery/v2 v2.32.4
-	github.com/zclconf/go-cty v1.13.2
+	github.com/zclconf/go-cty v1.13.3
 	github.com/zclconf/go-cty-debug v0.0.0-20191215020915-b22d67c1ba0b
 	go.bobheadxi.dev/gobenchdata v1.3.1
 	go.opentelemetry.io/otel/trace v1.16.0

--- a/go.sum
+++ b/go.sum
@@ -215,8 +215,8 @@ github.com/hashicorp/hc-install v0.5.2 h1:SfwMFnEXVVirpwkDuSF5kymUOhrUxrTq3udEse
 github.com/hashicorp/hc-install v0.5.2/go.mod h1:9QISwe6newMWIfEiXpzuu1k9HAGtQYgnSH8H9T8wmoI=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/hashicorp/hcl-lang v0.0.0-20230823131918-b6a3f8271038 h1:fhyfQoAyYFvt+AqIFlTHrstlC4OOT4KB/F/KatqJUfI=
-github.com/hashicorp/hcl-lang v0.0.0-20230823131918-b6a3f8271038/go.mod h1:xlYq00R/OYgpAmScjO1zkE9NCjl6zuMex1VVcUU0pjQ=
+github.com/hashicorp/hcl-lang v0.0.0-20230825134805-29034e9d534d h1:kr/f+fJGnFGe2al/H55/blLb1Ne5BAZWe4qY/BxA2D0=
+github.com/hashicorp/hcl-lang v0.0.0-20230825134805-29034e9d534d/go.mod h1:X9wA1+6Zr0nVspFxRvhVZnDhBMWhvb0uuAjp4bGujuc=
 github.com/hashicorp/hcl/v2 v2.17.0 h1:z1XvSUyXd1HP10U4lrLg5e0JMVz6CPaJvAgxM0KNZVY=
 github.com/hashicorp/hcl/v2 v2.17.0/go.mod h1:gJyW2PTShkJqQBKpAmPO3yxMxIuoXkOF2TpqXzrQyx4=
 github.com/hashicorp/terraform-exec v0.18.1 h1:LAbfDvNQU1l0NOQlTuudjczVhHj061fNX5H8XZxHlH4=
@@ -378,8 +378,8 @@ github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/zclconf/go-cty v1.2.0/go.mod h1:hOPWgoHbaTUnI5k4D2ld+GRpFJSCe6bCM7m1q/N4PQ8=
-github.com/zclconf/go-cty v1.13.2 h1:4GvrUxe/QUDYuJKAav4EYqdM47/kZa672LwmXFmEKT0=
-github.com/zclconf/go-cty v1.13.2/go.mod h1:YKQzy/7pZ7iq2jNFzy5go57xdxdWoLLpaEp4u238AE0=
+github.com/zclconf/go-cty v1.13.3 h1:m+b9q3YDbg6Bec5rr+KGy1MzEVzY/jC2X+YX4yqKtHI=
+github.com/zclconf/go-cty v1.13.3/go.mod h1:YKQzy/7pZ7iq2jNFzy5go57xdxdWoLLpaEp4u238AE0=
 github.com/zclconf/go-cty-debug v0.0.0-20191215020915-b22d67c1ba0b h1:FosyBZYxY34Wul7O/MSKey3txpPYyCqVO5ZyceuQJEI=
 github.com/zclconf/go-cty-debug v0.0.0-20191215020915-b22d67c1ba0b/go.mod h1:ZRKQfBXbGkpdV6QMzT3rU1kSTAnfu1dO8dPKjYprgj8=
 go.bobheadxi.dev/gobenchdata v1.3.1 h1:3Pts2nPUZdgFSU63nWzvfs2xRbK8WVSNeJ2H9e/Ypew=

--- a/internal/decoder/decoder.go
+++ b/internal/decoder/decoder.go
@@ -7,11 +7,9 @@ import (
 	"context"
 
 	"github.com/hashicorp/hcl-lang/decoder"
-	"github.com/hashicorp/hcl-lang/lang"
 	"github.com/hashicorp/hcl-lang/reference"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/terraform-ls/internal/codelens"
-	"github.com/hashicorp/terraform-ls/internal/decoder/validations"
 	ilsp "github.com/hashicorp/terraform-ls/internal/lsp"
 	lsp "github.com/hashicorp/terraform-ls/internal/protocol"
 	"github.com/hashicorp/terraform-ls/internal/state"
@@ -92,11 +90,6 @@ func DecoderContext(ctx context.Context) decoder.DecoderContext {
 			dCtx.CodeLenses = append(dCtx.CodeLenses, codelens.ReferenceCount(cmdId))
 		}
 	}
-
-	validations := []lang.ValidationFunc{
-		validations.UnreferencedOrigins,
-	}
-	dCtx.Validations = append(dCtx.Validations, validations...)
 
 	return dCtx
 }

--- a/internal/decoder/validations/unreferenced_origin.go
+++ b/internal/decoder/validations/unreferenced_origin.go
@@ -13,13 +13,8 @@ import (
 	"github.com/hashicorp/hcl/v2"
 )
 
-func UnreferencedOrigins(ctx context.Context) lang.DiagnosticsMap {
+func UnreferencedOrigins(ctx context.Context, pathCtx *decoder.PathContext) lang.DiagnosticsMap {
 	diagsMap := make(lang.DiagnosticsMap)
-
-	pathCtx, err := decoder.PathCtx(ctx)
-	if err != nil {
-		return diagsMap
-	}
 
 	for _, origin := range pathCtx.ReferenceOrigins {
 		matchableOrigin, ok := origin.(reference.MatchableOrigin)

--- a/internal/decoder/validations/unreferenced_origin_test.go
+++ b/internal/decoder/validations/unreferenced_origin_test.go
@@ -109,9 +109,7 @@ func TestUnreferencedOrigins(t *testing.T) {
 				ReferenceOrigins: tt.origins,
 			}
 
-			ctx = decoder.WithPathContext(ctx, pathCtx)
-
-			diags := UnreferencedOrigins(ctx)
+			diags := UnreferencedOrigins(ctx, pathCtx)
 			if diff := cmp.Diff(tt.want["test.tf"], diags["test.tf"]); diff != "" {
 				t.Fatalf("unexpected diagnostics: %s", diff)
 			}

--- a/internal/indexer/document_change.go
+++ b/internal/indexer/document_change.go
@@ -96,6 +96,19 @@ func (idx *Indexer) decodeModule(ctx context.Context, modHandle document.DirHand
 	}
 	ids = append(ids, eSchemaId)
 
+	earlyValidationId, err := idx.jobStore.EnqueueJob(ctx, job.Job{
+		Dir: modHandle,
+		Func: func(ctx context.Context) error {
+			return module.EarlyValidation(ctx, idx.modStore, idx.schemaStore, modHandle.Path())
+		},
+		Type:        op.OpTypeEarlyValidation.String(),
+		DependsOn:   job.IDs{eSchemaId},
+		IgnoreState: ignoreState,
+	})
+	if err != nil {
+		return ids, err
+	}
+
 	refTargetsId, err := idx.jobStore.EnqueueJob(ctx, job.Job{
 		Dir: modHandle,
 		Func: func(ctx context.Context) error {
@@ -127,10 +140,10 @@ func (idx *Indexer) decodeModule(ctx context.Context, modHandle document.DirHand
 	_, err = idx.jobStore.EnqueueJob(ctx, job.Job{
 		Dir: modHandle,
 		Func: func(ctx context.Context) error {
-			return module.EarlyValidation(ctx, idx.modStore, idx.schemaStore, modHandle.Path())
+			return module.ReferenceValidation(ctx, idx.modStore, idx.schemaStore, modHandle.Path())
 		},
-		Type:        op.OpTypeEarlyValidation.String(),
-		DependsOn:   job.IDs{eSchemaId, refTargetsId, refOriginsId},
+		Type:        op.OpTypeReferenceValidation.String(),
+		DependsOn:   job.IDs{earlyValidationId, refTargetsId, refOriginsId},
 		IgnoreState: ignoreState,
 	})
 	if err != nil {

--- a/internal/indexer/document_change.go
+++ b/internal/indexer/document_change.go
@@ -100,9 +100,9 @@ func (idx *Indexer) decodeModule(ctx context.Context, modHandle document.DirHand
 	_, err = idx.jobStore.EnqueueJob(ctx, job.Job{
 		Dir: modHandle,
 		Func: func(ctx context.Context) error {
-			return module.EarlyValidation(ctx, idx.modStore, idx.schemaStore, modHandle.Path())
+			return module.SchemaValidation(ctx, idx.modStore, idx.schemaStore, modHandle.Path())
 		},
-		Type:        op.OpTypeEarlyValidation.String(),
+		Type:        op.OpTypeSchemaValidation.String(),
 		DependsOn:   job.IDs{eSchemaId},
 		IgnoreState: ignoreState,
 	})

--- a/internal/indexer/document_change.go
+++ b/internal/indexer/document_change.go
@@ -96,7 +96,8 @@ func (idx *Indexer) decodeModule(ctx context.Context, modHandle document.DirHand
 	}
 	ids = append(ids, eSchemaId)
 
-	earlyValidationId, err := idx.jobStore.EnqueueJob(ctx, job.Job{
+	// TODO! check if early validation setting is enabled
+	_, err = idx.jobStore.EnqueueJob(ctx, job.Job{
 		Dir: modHandle,
 		Func: func(ctx context.Context) error {
 			return module.EarlyValidation(ctx, idx.modStore, idx.schemaStore, modHandle.Path())
@@ -137,13 +138,14 @@ func (idx *Indexer) decodeModule(ctx context.Context, modHandle document.DirHand
 	}
 	ids = append(ids, refOriginsId)
 
+	// TODO! check if early validation setting is enabled
 	_, err = idx.jobStore.EnqueueJob(ctx, job.Job{
 		Dir: modHandle,
 		Func: func(ctx context.Context) error {
 			return module.ReferenceValidation(ctx, idx.modStore, idx.schemaStore, modHandle.Path())
 		},
 		Type:        op.OpTypeReferenceValidation.String(),
-		DependsOn:   job.IDs{earlyValidationId, refTargetsId, refOriginsId},
+		DependsOn:   job.IDs{refTargetsId, refOriginsId},
 		IgnoreState: ignoreState,
 	})
 	if err != nil {

--- a/internal/langserver/diagnostics/diagnostics_test.go
+++ b/internal/langserver/diagnostics/diagnostics_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/terraform-ls/internal/terraform/ast"
 )
 
 var discardLogger = log.New(ioutil.Discard, "", 0)
@@ -19,8 +20,8 @@ func TestDiags_Closes(t *testing.T) {
 	n := NewNotifier(noopNotifier{}, discardLogger)
 
 	diags := NewDiagnostics()
-	diags.Append("test", map[string]hcl.Diagnostics{
-		"test": {
+	diags.Append(ast.HCLParsingSource, map[string]hcl.Diagnostics{
+		ast.HCLParsingSource.String(): {
 			{
 				Severity: hcl.DiagError,
 			},
@@ -46,8 +47,8 @@ func TestPublish_DoesNotSendAfterClose(t *testing.T) {
 	n := NewNotifier(noopNotifier{}, discardLogger)
 
 	diags := NewDiagnostics()
-	diags.Append("test", map[string]hcl.Diagnostics{
-		"test": {
+	diags.Append(ast.TerraformValidateSource, map[string]hcl.Diagnostics{
+		ast.TerraformValidateSource.String(): {
 			{
 				Severity: hcl.DiagError,
 			},
@@ -61,7 +62,7 @@ func TestPublish_DoesNotSendAfterClose(t *testing.T) {
 
 func TestDiagnostics_Append(t *testing.T) {
 	diags := NewDiagnostics()
-	diags.Append("foo", map[string]hcl.Diagnostics{
+	diags.Append(ast.HCLParsingSource, map[string]hcl.Diagnostics{
 		"first.tf": {
 			&hcl.Diagnostic{
 				Severity: hcl.DiagError,
@@ -79,7 +80,7 @@ func TestDiagnostics_Append(t *testing.T) {
 			},
 		},
 	})
-	diags.Append("bar", map[string]hcl.Diagnostics{
+	diags.Append(ast.SchemaValidationSource, map[string]hcl.Diagnostics{
 		"first.tf": {
 			&hcl.Diagnostic{
 				Severity: hcl.DiagError,
@@ -96,8 +97,8 @@ func TestDiagnostics_Append(t *testing.T) {
 	})
 
 	expectedDiags := Diagnostics{
-		"first.tf": map[DiagnosticSource]hcl.Diagnostics{
-			DiagnosticSource("foo"): {
+		"first.tf": map[ast.DiagnosticSource]hcl.Diagnostics{
+			ast.HCLParsingSource: {
 				&hcl.Diagnostic{
 					Severity: hcl.DiagError,
 					Summary:  "Something went wrong",
@@ -113,7 +114,7 @@ func TestDiagnostics_Append(t *testing.T) {
 					},
 				},
 			},
-			DiagnosticSource("bar"): {
+			ast.SchemaValidationSource: {
 				&hcl.Diagnostic{
 					Severity: hcl.DiagError,
 					Summary:  "Something else went wrong",
@@ -121,8 +122,8 @@ func TestDiagnostics_Append(t *testing.T) {
 				},
 			},
 		},
-		"second.tf": map[DiagnosticSource]hcl.Diagnostics{
-			DiagnosticSource("bar"): {
+		"second.tf": map[ast.DiagnosticSource]hcl.Diagnostics{
+			ast.SchemaValidationSource: {
 				&hcl.Diagnostic{
 					Severity: hcl.DiagWarning,
 					Summary:  "Beware",

--- a/internal/langserver/handlers/command/validate.go
+++ b/internal/langserver/handlers/command/validate.go
@@ -8,14 +8,11 @@ import (
 	"fmt"
 
 	"github.com/creachadair/jrpc2"
-	lsctx "github.com/hashicorp/terraform-ls/internal/context"
 	"github.com/hashicorp/terraform-ls/internal/document"
+	"github.com/hashicorp/terraform-ls/internal/job"
 	"github.com/hashicorp/terraform-ls/internal/langserver/cmd"
-	"github.com/hashicorp/terraform-ls/internal/langserver/diagnostics"
-	"github.com/hashicorp/terraform-ls/internal/langserver/errors"
-	"github.com/hashicorp/terraform-ls/internal/langserver/progress"
-	"github.com/hashicorp/terraform-ls/internal/state"
 	"github.com/hashicorp/terraform-ls/internal/terraform/module"
+	op "github.com/hashicorp/terraform-ls/internal/terraform/module/operation"
 	"github.com/hashicorp/terraform-ls/internal/uri"
 )
 
@@ -31,51 +28,17 @@ func (h *CmdHandler) TerraformValidateHandler(ctx context.Context, args cmd.Comm
 
 	dirHandle := document.DirHandleFromURI(dirUri)
 
-	mod, err := h.StateStore.Modules.ModuleByPath(dirHandle.Path())
-	if err != nil {
-		if state.IsModuleNotFound(err) {
-			err = h.StateStore.Modules.Add(dirHandle.Path())
-			if err != nil {
-				return nil, err
-			}
-			mod, err = h.StateStore.Modules.ModuleByPath(dirHandle.Path())
-			if err != nil {
-				return nil, err
-			}
-		} else {
-			return nil, err
-		}
-	}
-
-	tfExec, err := module.TerraformExecutorForModule(ctx, mod.Path)
-	if err != nil {
-		return nil, errors.EnrichTfExecError(err)
-	}
-
-	notifier, err := lsctx.DiagnosticsNotifier(ctx)
+	id, err := h.StateStore.JobStore.EnqueueJob(ctx, job.Job{
+		Dir: dirHandle,
+		Func: func(ctx context.Context) error {
+			return module.TerraformValidate(ctx, h.StateStore.Modules, dirHandle.Path())
+		},
+		Type:        op.OpTypeTerraformValidate.String(),
+		IgnoreState: true,
+	})
 	if err != nil {
 		return nil, err
 	}
 
-	progress.Begin(ctx, "Validating")
-	defer func() {
-		progress.End(ctx, "Finished")
-	}()
-	progress.Report(ctx, "Running terraform validate ...")
-	jsonDiags, err := tfExec.Validate(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	diags := diagnostics.NewDiagnostics()
-	validateDiags := diagnostics.HCLDiagsFromJSON(jsonDiags)
-	diags.EmptyRootDiagnostic()
-	diags.Append("terraform validate", validateDiags)
-	diags.Append("early validation", mod.ValidationDiagnostics)
-	diags.Append("HCL", mod.ModuleDiagnostics.AutoloadedOnly().AsMap())
-	diags.Append("HCL", mod.VarsDiagnostics.AutoloadedOnly().AsMap())
-
-	notifier.PublishHCLDiags(ctx, mod.Path, diags)
-
-	return nil, nil
+	return nil, h.StateStore.JobStore.WaitForJobs(ctx, id)
 }

--- a/internal/langserver/handlers/hooks_module.go
+++ b/internal/langserver/handlers/hooks_module.go
@@ -156,9 +156,12 @@ func updateDiagnostics(dNotifier *diagnostics.Notifier) notifier.Hook {
 			defer dNotifier.PublishHCLDiags(ctx, mod.Path, diags)
 
 			if mod != nil {
-				diags.Append("early validation", mod.ValidationDiagnostics)
-				diags.Append("HCL", mod.ModuleDiagnostics.AutoloadedOnly().AsMap())
-				diags.Append("HCL", mod.VarsDiagnostics.AutoloadedOnly().AsMap())
+				for source, dm := range mod.ModuleDiagnostics {
+					diags.Append(source.String(), dm.AutoloadedOnly().AsMap())
+				}
+				for source, dm := range mod.VarsDiagnostics {
+					diags.Append(source.String(), dm.AutoloadedOnly().AsMap())
+				}
 			}
 		}
 		return nil

--- a/internal/langserver/handlers/hooks_module.go
+++ b/internal/langserver/handlers/hooks_module.go
@@ -153,16 +153,14 @@ func updateDiagnostics(dNotifier *diagnostics.Notifier) notifier.Hook {
 			diags := diagnostics.NewDiagnostics()
 			diags.EmptyRootDiagnostic()
 
-			defer dNotifier.PublishHCLDiags(ctx, mod.Path, diags)
-
-			if mod != nil {
-				for source, dm := range mod.ModuleDiagnostics {
-					diags.Append(source.String(), dm.AutoloadedOnly().AsMap())
-				}
-				for source, dm := range mod.VarsDiagnostics {
-					diags.Append(source.String(), dm.AutoloadedOnly().AsMap())
-				}
+			for source, dm := range mod.ModuleDiagnostics {
+				diags.Append(source, dm.AutoloadedOnly().AsMap())
 			}
+			for source, dm := range mod.VarsDiagnostics {
+				diags.Append(source, dm.AutoloadedOnly().AsMap())
+			}
+
+			dNotifier.PublishHCLDiags(ctx, mod.Path, diags)
 		}
 		return nil
 	}

--- a/internal/state/module.go
+++ b/internal/state/module.go
@@ -252,8 +252,7 @@ func newModule(modPath string) *Module {
 		ModuleParsingState:         op.OpStateUnknown,
 		MetaState:                  op.OpStateUnknown,
 		DiagnosticsState: ast.DiagnosticSourceState{
-			ast.ModuleParsingSource:       op.OpStateUnknown,
-			ast.VarsParsingSource:         op.OpStateUnknown,
+			ast.HCLParsingSource:          op.OpStateUnknown,
 			ast.SchemaValidationSource:    op.OpStateUnknown,
 			ast.ReferenceValidationSource: op.OpStateUnknown,
 			ast.TerraformValidateSource:   op.OpStateUnknown,

--- a/internal/state/module_changes.go
+++ b/internal/state/module_changes.go
@@ -142,10 +142,20 @@ func (s *ModuleStore) queueModuleChange(txn *memdb.Txn, oldMod, newMod *Module) 
 
 	oldDiags, newDiags := 0, 0
 	if oldMod != nil {
-		oldDiags = oldMod.ModuleDiagnostics.Count() + oldMod.VarsDiagnostics.Count() + oldMod.ValidationDiagnostics.Count()
+		for _, diags := range oldMod.ModuleDiagnostics {
+			oldDiags += diags.Count()
+		}
+		for _, diags := range oldMod.VarsDiagnostics {
+			oldDiags += diags.Count()
+		}
 	}
 	if newMod != nil {
-		newDiags = newMod.ModuleDiagnostics.Count() + newMod.VarsDiagnostics.Count() + newMod.ValidationDiagnostics.Count()
+		for _, diags := range newMod.ModuleDiagnostics {
+			newDiags += diags.Count()
+		}
+		for _, diags := range newMod.VarsDiagnostics {
+			newDiags += diags.Count()
+		}
 	}
 	// Comparing diagnostics accurately could be expensive
 	// so we just treat any non-empty diags as a change

--- a/internal/state/module_changes.go
+++ b/internal/state/module_changes.go
@@ -142,20 +142,10 @@ func (s *ModuleStore) queueModuleChange(txn *memdb.Txn, oldMod, newMod *Module) 
 
 	oldDiags, newDiags := 0, 0
 	if oldMod != nil {
-		for _, diags := range oldMod.ModuleDiagnostics {
-			oldDiags += diags.Count()
-		}
-		for _, diags := range oldMod.VarsDiagnostics {
-			oldDiags += diags.Count()
-		}
+		oldDiags = oldMod.ModuleDiagnostics.Count() + oldMod.VarsDiagnostics.Count()
 	}
 	if newMod != nil {
-		for _, diags := range newMod.ModuleDiagnostics {
-			newDiags += diags.Count()
-		}
-		for _, diags := range newMod.VarsDiagnostics {
-			newDiags += diags.Count()
-		}
+		newDiags = newMod.ModuleDiagnostics.Count() + newMod.VarsDiagnostics.Count()
 	}
 	// Comparing diagnostics accurately could be expensive
 	// so we just treat any non-empty diags as a change

--- a/internal/state/module_test.go
+++ b/internal/state/module_test.go
@@ -77,6 +77,18 @@ func TestModuleStore_ModuleByPath(t *testing.T) {
 		Path:                  modPath,
 		TerraformVersion:      tfVersion,
 		TerraformVersionState: operation.OpStateLoaded,
+		ModuleDiagnosticsState: ast.DiagnosticSourceState{
+			ast.HCLParsingSource:          operation.OpStateUnknown,
+			ast.SchemaValidationSource:    operation.OpStateUnknown,
+			ast.ReferenceValidationSource: operation.OpStateUnknown,
+			ast.TerraformValidateSource:   operation.OpStateUnknown,
+		},
+		VarsDiagnosticsState: ast.DiagnosticSourceState{
+			ast.HCLParsingSource:          operation.OpStateUnknown,
+			ast.SchemaValidationSource:    operation.OpStateUnknown,
+			ast.ReferenceValidationSource: operation.OpStateUnknown,
+			ast.TerraformValidateSource:   operation.OpStateUnknown,
+		},
 	}
 	if diff := cmp.Diff(expectedModule, mod); diff != "" {
 		t.Fatalf("unexpected module: %s", diff)
@@ -184,11 +196,35 @@ func TestModuleStore_CallersOfModule(t *testing.T) {
 			Path:             filepath.Join(tmpDir, "alpha"),
 			ModManifest:      alphaManifest,
 			ModManifestState: operation.OpStateLoaded,
+			ModuleDiagnosticsState: ast.DiagnosticSourceState{
+				ast.HCLParsingSource:          operation.OpStateUnknown,
+				ast.SchemaValidationSource:    operation.OpStateUnknown,
+				ast.ReferenceValidationSource: operation.OpStateUnknown,
+				ast.TerraformValidateSource:   operation.OpStateUnknown,
+			},
+			VarsDiagnosticsState: ast.DiagnosticSourceState{
+				ast.HCLParsingSource:          operation.OpStateUnknown,
+				ast.SchemaValidationSource:    operation.OpStateUnknown,
+				ast.ReferenceValidationSource: operation.OpStateUnknown,
+				ast.TerraformValidateSource:   operation.OpStateUnknown,
+			},
 		},
 		{
 			Path:             filepath.Join(tmpDir, "gamma"),
 			ModManifest:      gammaManifest,
 			ModManifestState: operation.OpStateLoaded,
+			ModuleDiagnosticsState: ast.DiagnosticSourceState{
+				ast.HCLParsingSource:          operation.OpStateUnknown,
+				ast.SchemaValidationSource:    operation.OpStateUnknown,
+				ast.ReferenceValidationSource: operation.OpStateUnknown,
+				ast.TerraformValidateSource:   operation.OpStateUnknown,
+			},
+			VarsDiagnosticsState: ast.DiagnosticSourceState{
+				ast.HCLParsingSource:          operation.OpStateUnknown,
+				ast.SchemaValidationSource:    operation.OpStateUnknown,
+				ast.ReferenceValidationSource: operation.OpStateUnknown,
+				ast.TerraformValidateSource:   operation.OpStateUnknown,
+			},
 		},
 	}
 
@@ -223,9 +259,51 @@ func TestModuleStore_List(t *testing.T) {
 	}
 
 	expectedModules := []*Module{
-		{Path: filepath.Join(tmpDir, "alpha")},
-		{Path: filepath.Join(tmpDir, "beta")},
-		{Path: filepath.Join(tmpDir, "gamma")},
+		{
+			Path: filepath.Join(tmpDir, "alpha"),
+			ModuleDiagnosticsState: ast.DiagnosticSourceState{
+				ast.HCLParsingSource:          operation.OpStateUnknown,
+				ast.SchemaValidationSource:    operation.OpStateUnknown,
+				ast.ReferenceValidationSource: operation.OpStateUnknown,
+				ast.TerraformValidateSource:   operation.OpStateUnknown,
+			},
+			VarsDiagnosticsState: ast.DiagnosticSourceState{
+				ast.HCLParsingSource:          operation.OpStateUnknown,
+				ast.SchemaValidationSource:    operation.OpStateUnknown,
+				ast.ReferenceValidationSource: operation.OpStateUnknown,
+				ast.TerraformValidateSource:   operation.OpStateUnknown,
+			},
+		},
+		{
+			Path: filepath.Join(tmpDir, "beta"),
+			ModuleDiagnosticsState: ast.DiagnosticSourceState{
+				ast.HCLParsingSource:          operation.OpStateUnknown,
+				ast.SchemaValidationSource:    operation.OpStateUnknown,
+				ast.ReferenceValidationSource: operation.OpStateUnknown,
+				ast.TerraformValidateSource:   operation.OpStateUnknown,
+			},
+			VarsDiagnosticsState: ast.DiagnosticSourceState{
+				ast.HCLParsingSource:          operation.OpStateUnknown,
+				ast.SchemaValidationSource:    operation.OpStateUnknown,
+				ast.ReferenceValidationSource: operation.OpStateUnknown,
+				ast.TerraformValidateSource:   operation.OpStateUnknown,
+			},
+		},
+		{
+			Path: filepath.Join(tmpDir, "gamma"),
+			ModuleDiagnosticsState: ast.DiagnosticSourceState{
+				ast.HCLParsingSource:          operation.OpStateUnknown,
+				ast.SchemaValidationSource:    operation.OpStateUnknown,
+				ast.ReferenceValidationSource: operation.OpStateUnknown,
+				ast.TerraformValidateSource:   operation.OpStateUnknown,
+			},
+			VarsDiagnosticsState: ast.DiagnosticSourceState{
+				ast.HCLParsingSource:          operation.OpStateUnknown,
+				ast.SchemaValidationSource:    operation.OpStateUnknown,
+				ast.ReferenceValidationSource: operation.OpStateUnknown,
+				ast.TerraformValidateSource:   operation.OpStateUnknown,
+			},
+		},
 	}
 
 	if diff := cmp.Diff(expectedModules, modules, cmpOpts); diff != "" {
@@ -283,6 +361,18 @@ func TestModuleStore_UpdateMetadata(t *testing.T) {
 			},
 		},
 		MetaState: operation.OpStateLoaded,
+		ModuleDiagnosticsState: ast.DiagnosticSourceState{
+			ast.HCLParsingSource:          operation.OpStateUnknown,
+			ast.SchemaValidationSource:    operation.OpStateUnknown,
+			ast.ReferenceValidationSource: operation.OpStateUnknown,
+			ast.TerraformValidateSource:   operation.OpStateUnknown,
+		},
+		VarsDiagnosticsState: ast.DiagnosticSourceState{
+			ast.HCLParsingSource:          operation.OpStateUnknown,
+			ast.SchemaValidationSource:    operation.OpStateUnknown,
+			ast.ReferenceValidationSource: operation.OpStateUnknown,
+			ast.TerraformValidateSource:   operation.OpStateUnknown,
+		},
 	}
 
 	if diff := cmp.Diff(expectedModule, mod, cmpOpts); diff != "" {
@@ -319,6 +409,18 @@ func TestModuleStore_UpdateTerraformAndProviderVersions(t *testing.T) {
 		TerraformVersion:      testVersion(t, "0.12.4"),
 		TerraformVersionState: operation.OpStateLoaded,
 		TerraformVersionErr:   vErr,
+		ModuleDiagnosticsState: ast.DiagnosticSourceState{
+			ast.HCLParsingSource:          operation.OpStateUnknown,
+			ast.SchemaValidationSource:    operation.OpStateUnknown,
+			ast.ReferenceValidationSource: operation.OpStateUnknown,
+			ast.TerraformValidateSource:   operation.OpStateUnknown,
+		},
+		VarsDiagnosticsState: ast.DiagnosticSourceState{
+			ast.HCLParsingSource:          operation.OpStateUnknown,
+			ast.SchemaValidationSource:    operation.OpStateUnknown,
+			ast.ReferenceValidationSource: operation.OpStateUnknown,
+			ast.TerraformValidateSource:   operation.OpStateUnknown,
+		},
 	}
 	if diff := cmp.Diff(expectedModule, mod, cmpOpts); diff != "" {
 		t.Fatalf("unexpected module data: %s", diff)
@@ -427,7 +529,7 @@ provider "blah" {
   region = "london"
 `), "test.tf")
 
-	err = s.Modules.UpdateModuleDiagnostics(tmpDir, ast.ModuleParsingSource, ast.ModDiagsFromMap(map[string]hcl.Diagnostics{
+	err = s.Modules.UpdateModuleDiagnostics(tmpDir, ast.HCLParsingSource, ast.ModDiagsFromMap(map[string]hcl.Diagnostics{
 		"test.tf": diags,
 	}))
 	if err != nil {
@@ -440,7 +542,7 @@ provider "blah" {
 	}
 
 	expectedDiags := ast.SourceModDiags{
-		ast.ModuleParsingSource: ast.ModDiagsFromMap(map[string]hcl.Diagnostics{
+		ast.HCLParsingSource: ast.ModDiagsFromMap(map[string]hcl.Diagnostics{
 			"test.tf": {
 				{
 					Severity: hcl.DiagError,
@@ -486,7 +588,7 @@ dev = {
   region = "london"
 `), "test.tfvars")
 
-	err = s.Modules.UpdateVarsDiagnostics(tmpDir, ast.VarsParsingSource, ast.VarsDiagsFromMap(map[string]hcl.Diagnostics{
+	err = s.Modules.UpdateVarsDiagnostics(tmpDir, ast.HCLParsingSource, ast.VarsDiagsFromMap(map[string]hcl.Diagnostics{
 		"test.tfvars": diags,
 	}))
 	if err != nil {
@@ -499,7 +601,7 @@ dev = {
 	}
 
 	expectedDiags := ast.SourceVarsDiags{
-		ast.VarsParsingSource: ast.VarsDiagsFromMap(map[string]hcl.Diagnostics{
+		ast.HCLParsingSource: ast.VarsDiagsFromMap(map[string]hcl.Diagnostics{
 			"test.tfvars": {
 				{
 					Severity: hcl.DiagError,
@@ -742,17 +844,19 @@ func BenchmarkModuleByPath(b *testing.B) {
 		b.Fatal(err)
 	}
 	mDiags := ast.ModDiagsFromMap(diags)
-	err = s.Modules.UpdateModuleDiagnostics(modPath, ast.ModuleParsingSource, mDiags)
+	err = s.Modules.UpdateModuleDiagnostics(modPath, ast.HCLParsingSource, mDiags)
 	if err != nil {
 		b.Fatal(err)
 	}
 
 	expectedMod := &Module{
-		Path:               modPath,
-		ParsedModuleFiles:  mFiles,
-		ModuleParsingState: operation.OpStateLoaded,
+		Path:              modPath,
+		ParsedModuleFiles: mFiles,
 		ModuleDiagnostics: ast.SourceModDiags{
-			ast.ModuleParsingSource: mDiags,
+			ast.HCLParsingSource: mDiags,
+		},
+		ModuleDiagnosticsState: ast.DiagnosticSourceState{
+			ast.HCLParsingSource: operation.OpStateLoaded,
 		},
 	}
 

--- a/internal/terraform/ast/diagnostics.go
+++ b/internal/terraform/ast/diagnostics.go
@@ -30,7 +30,7 @@ func (d DiagnosticSource) String() string {
 	case TerraformValidateSource:
 		return "terraform validate"
 	default:
-		return fmt.Sprintf("Unknown %d", d)
+		panic(fmt.Sprintf("Unknown diagnostic source %d", d))
 	}
 }
 

--- a/internal/terraform/ast/diagnostics.go
+++ b/internal/terraform/ast/diagnostics.go
@@ -13,8 +13,7 @@ import (
 type DiagnosticSource int
 
 const (
-	ModuleParsingSource DiagnosticSource = iota
-	VarsParsingSource
+	HCLParsingSource DiagnosticSource = iota
 	SchemaValidationSource
 	ReferenceValidationSource
 	TerraformValidateSource
@@ -22,22 +21,18 @@ const (
 
 func (d DiagnosticSource) String() string {
 	switch d {
-	case ModuleParsingSource:
+	case HCLParsingSource:
 		return "HCL"
-	case VarsParsingSource:
-		return "HCL Vars"
 	case SchemaValidationSource:
-		return "schema validation"
+		return "early validation"
 	case ReferenceValidationSource:
-		return "reference validation"
+		return "early validation"
 	case TerraformValidateSource:
 		return "terraform validate"
 	default:
 		return fmt.Sprintf("Unknown %d", d)
 	}
 }
-
-// TODO? combine with langserver/diagnostics
 
 type DiagnosticSourceState map[DiagnosticSource]op.OpState
 

--- a/internal/terraform/ast/diagnostics.go
+++ b/internal/terraform/ast/diagnostics.go
@@ -1,0 +1,36 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package ast
+
+import "fmt"
+
+// DiagnosticSource differentiates different sources of diagnostics.
+type DiagnosticSource int
+
+const (
+	ModuleParsingSource DiagnosticSource = iota
+	VarsParsingSource
+	SchemaValidationSource
+	ReferenceValidationSource
+	TerraformValidateSource
+)
+
+func (d DiagnosticSource) String() string {
+	switch d {
+	case ModuleParsingSource:
+		return "HCL"
+	case VarsParsingSource:
+		return "HCL Vars"
+	case SchemaValidationSource:
+		return "schema validation"
+	case ReferenceValidationSource:
+		return "reference validation"
+	case TerraformValidateSource:
+		return "terraform validate"
+	default:
+		return fmt.Sprintf("Unknown %d", d)
+	}
+}
+
+// TODO? combine with langserver/diagnostics

--- a/internal/terraform/ast/diagnostics.go
+++ b/internal/terraform/ast/diagnostics.go
@@ -3,7 +3,11 @@
 
 package ast
 
-import "fmt"
+import (
+	"fmt"
+
+	op "github.com/hashicorp/terraform-ls/internal/terraform/module/operation"
+)
 
 // DiagnosticSource differentiates different sources of diagnostics.
 type DiagnosticSource int
@@ -34,3 +38,14 @@ func (d DiagnosticSource) String() string {
 }
 
 // TODO? combine with langserver/diagnostics
+
+type DiagnosticSourceState map[DiagnosticSource]op.OpState
+
+func (dss DiagnosticSourceState) Copy() DiagnosticSourceState {
+	newDiagnosticSourceState := make(DiagnosticSourceState, len(dss))
+	for source, state := range dss {
+		newDiagnosticSourceState[source] = state
+	}
+
+	return newDiagnosticSourceState
+}

--- a/internal/terraform/ast/module.go
+++ b/internal/terraform/ast/module.go
@@ -90,3 +90,5 @@ func (md ModDiags) Count() int {
 	}
 	return count
 }
+
+type SourceModDiags map[DiagnosticSource]ModDiags

--- a/internal/terraform/ast/module.go
+++ b/internal/terraform/ast/module.go
@@ -92,3 +92,11 @@ func (md ModDiags) Count() int {
 }
 
 type SourceModDiags map[DiagnosticSource]ModDiags
+
+func (smd SourceModDiags) Count() int {
+	count := 0
+	for _, diags := range smd {
+		count += diags.Count()
+	}
+	return count
+}

--- a/internal/terraform/ast/variables.go
+++ b/internal/terraform/ast/variables.go
@@ -89,3 +89,11 @@ func (vd VarsDiags) Count() int {
 }
 
 type SourceVarsDiags map[DiagnosticSource]VarsDiags
+
+func (svd SourceVarsDiags) Count() int {
+	count := 0
+	for _, diags := range svd {
+		count += diags.Count()
+	}
+	return count
+}

--- a/internal/terraform/ast/variables.go
+++ b/internal/terraform/ast/variables.go
@@ -87,3 +87,5 @@ func (vd VarsDiags) Count() int {
 	}
 	return count
 }
+
+type SourceVarsDiags map[DiagnosticSource]VarsDiags

--- a/internal/terraform/module/module_ops.go
+++ b/internal/terraform/module/module_ops.go
@@ -665,7 +665,7 @@ func DecodeVarsReferences(ctx context.Context, modStore *state.ModuleStore, sche
 	return rErr
 }
 
-func EarlyValidation(ctx context.Context, modStore *state.ModuleStore, schemaReader state.SchemaReader, modPath string) error {
+func SchemaValidation(ctx context.Context, modStore *state.ModuleStore, schemaReader state.SchemaReader, modPath string) error {
 	mod, err := modStore.ModuleByPath(modPath)
 	if err != nil {
 		return err

--- a/internal/terraform/module/module_ops.go
+++ b/internal/terraform/module/module_ops.go
@@ -666,21 +666,20 @@ func DecodeVarsReferences(ctx context.Context, modStore *state.ModuleStore, sche
 }
 
 func EarlyValidation(ctx context.Context, modStore *state.ModuleStore, schemaReader state.SchemaReader, modPath string) error {
-	// mod, err := modStore.ModuleByPath(modPath)
-	// if err != nil {
-	// 	return err
-	// }
+	mod, err := modStore.ModuleByPath(modPath)
+	if err != nil {
+		return err
+	}
 
-	// // Avoid validation if it is already in progress or already finished
-	// if mod.ValidationDiagnosticsState != op.OpStateUnknown && !job.IgnoreState(ctx) {
-	// 	return job.StateNotChangedErr{Dir: document.DirHandleFromPath(modPath)}
-	// }
+	// Avoid validation if it is already in progress or already finished
+	if mod.DiagnosticsState[ast.SchemaValidationSource] != op.OpStateUnknown && !job.IgnoreState(ctx) {
+		return job.StateNotChangedErr{Dir: document.DirHandleFromPath(modPath)}
+	}
 
-	// err = modStore.SetValidationDiagnosticsState(modPath, op.OpStateLoading)
-	// if err != nil {
-	// 	return err
-	// }
-	// TODO! track job state
+	err = modStore.SetDiagnosticsState(modPath, ast.SchemaValidationSource, op.OpStateLoading)
+	if err != nil {
+		return err
+	}
 
 	d := decoder.NewDecoder(&idecoder.PathReader{
 		ModuleReader: modStore,
@@ -706,21 +705,20 @@ func EarlyValidation(ctx context.Context, modStore *state.ModuleStore, schemaRea
 }
 
 func ReferenceValidation(ctx context.Context, modStore *state.ModuleStore, schemaReader state.SchemaReader, modPath string) error {
-	// mod, err := modStore.ModuleByPath(modPath)
-	// if err != nil {
-	// 	return err
-	// }
+	mod, err := modStore.ModuleByPath(modPath)
+	if err != nil {
+		return err
+	}
 
-	// // Avoid validation if it is already in progress or already known
-	// if mod.ValidationDiagnosticsState != op.OpStateUnknown && !job.IgnoreState(ctx) {
-	// 	return job.StateNotChangedErr{Dir: document.DirHandleFromPath(modPath)}
-	// }
+	// Avoid validation if it is already in progress or already finished
+	if mod.DiagnosticsState[ast.ReferenceValidationSource] != op.OpStateUnknown && !job.IgnoreState(ctx) {
+		return job.StateNotChangedErr{Dir: document.DirHandleFromPath(modPath)}
+	}
 
-	// err = modStore.SetValidationDiagnosticsState(modPath, op.OpStateLoading)
-	// if err != nil {
-	// 	return err
-	// }
-	// TODO! track job state
+	err = modStore.SetDiagnosticsState(modPath, ast.ReferenceValidationSource, op.OpStateLoading)
+	if err != nil {
+		return err
+	}
 
 	pathReader := &idecoder.PathReader{
 		ModuleReader: modStore,
@@ -742,6 +740,16 @@ func ReferenceValidation(ctx context.Context, modStore *state.ModuleStore, schem
 
 func TerraformValidate(ctx context.Context, modStore *state.ModuleStore, modPath string) error {
 	mod, err := modStore.ModuleByPath(modPath)
+	if err != nil {
+		return err
+	}
+
+	// Avoid validation if it is already in progress or already finished
+	if mod.DiagnosticsState[ast.TerraformValidateSource] != op.OpStateUnknown && !job.IgnoreState(ctx) {
+		return job.StateNotChangedErr{Dir: document.DirHandleFromPath(modPath)}
+	}
+
+	err = modStore.SetDiagnosticsState(modPath, ast.TerraformValidateSource, op.OpStateLoading)
 	if err != nil {
 		return err
 	}

--- a/internal/terraform/module/module_ops.go
+++ b/internal/terraform/module/module_ops.go
@@ -365,11 +365,11 @@ func ParseModuleConfiguration(ctx context.Context, fs ReadOnlyFS, modStore *stat
 	// TODO: Only parse the file that's being changed/opened, unless this is 1st-time parsing
 
 	// Avoid parsing if it is already in progress or already known
-	if mod.ModuleParsingState != op.OpStateUnknown && !job.IgnoreState(ctx) {
+	if mod.ModuleDiagnosticsState[ast.HCLParsingSource] != op.OpStateUnknown && !job.IgnoreState(ctx) {
 		return job.StateNotChangedErr{Dir: document.DirHandleFromPath(modPath)}
 	}
 
-	err = modStore.SetModuleParsingState(modPath, op.OpStateLoading)
+	err = modStore.SetModuleDiagnosticsState(modPath, ast.HCLParsingSource, op.OpStateLoading)
 	if err != nil {
 		return err
 	}
@@ -400,11 +400,11 @@ func ParseVariables(ctx context.Context, fs ReadOnlyFS, modStore *state.ModuleSt
 	// TODO: Only parse the file that's being changed/opened, unless this is 1st-time parsing
 
 	// Avoid parsing if it is already in progress or already known
-	if mod.VarsParsingState != op.OpStateUnknown && !job.IgnoreState(ctx) {
+	if mod.VarsDiagnosticsState[ast.HCLParsingSource] != op.OpStateUnknown && !job.IgnoreState(ctx) {
 		return job.StateNotChangedErr{Dir: document.DirHandleFromPath(modPath)}
 	}
 
-	err = modStore.SetVarsParsingState(modPath, op.OpStateLoading)
+	err = modStore.SetVarsDiagnosticsState(modPath, ast.HCLParsingSource, op.OpStateLoading)
 	if err != nil {
 		return err
 	}
@@ -672,11 +672,11 @@ func SchemaValidation(ctx context.Context, modStore *state.ModuleStore, schemaRe
 	}
 
 	// Avoid validation if it is already in progress or already finished
-	if mod.DiagnosticsState[ast.SchemaValidationSource] != op.OpStateUnknown && !job.IgnoreState(ctx) {
+	if mod.ModuleDiagnosticsState[ast.SchemaValidationSource] != op.OpStateUnknown && !job.IgnoreState(ctx) {
 		return job.StateNotChangedErr{Dir: document.DirHandleFromPath(modPath)}
 	}
 
-	err = modStore.SetDiagnosticsState(modPath, ast.SchemaValidationSource, op.OpStateLoading)
+	err = modStore.SetModuleDiagnosticsState(modPath, ast.SchemaValidationSource, op.OpStateLoading)
 	if err != nil {
 		return err
 	}
@@ -711,11 +711,11 @@ func ReferenceValidation(ctx context.Context, modStore *state.ModuleStore, schem
 	}
 
 	// Avoid validation if it is already in progress or already finished
-	if mod.DiagnosticsState[ast.ReferenceValidationSource] != op.OpStateUnknown && !job.IgnoreState(ctx) {
+	if mod.ModuleDiagnosticsState[ast.ReferenceValidationSource] != op.OpStateUnknown && !job.IgnoreState(ctx) {
 		return job.StateNotChangedErr{Dir: document.DirHandleFromPath(modPath)}
 	}
 
-	err = modStore.SetDiagnosticsState(modPath, ast.ReferenceValidationSource, op.OpStateLoading)
+	err = modStore.SetModuleDiagnosticsState(modPath, ast.ReferenceValidationSource, op.OpStateLoading)
 	if err != nil {
 		return err
 	}
@@ -743,11 +743,11 @@ func TerraformValidate(ctx context.Context, modStore *state.ModuleStore, modPath
 	}
 
 	// Avoid validation if it is already in progress or already finished
-	if mod.DiagnosticsState[ast.TerraformValidateSource] != op.OpStateUnknown && !job.IgnoreState(ctx) {
+	if mod.ModuleDiagnosticsState[ast.TerraformValidateSource] != op.OpStateUnknown && !job.IgnoreState(ctx) {
 		return job.StateNotChangedErr{Dir: document.DirHandleFromPath(modPath)}
 	}
 
-	err = modStore.SetDiagnosticsState(modPath, ast.TerraformValidateSource, op.OpStateLoading)
+	err = modStore.SetModuleDiagnosticsState(modPath, ast.TerraformValidateSource, op.OpStateLoading)
 	if err != nil {
 		return err
 	}

--- a/internal/terraform/module/module_ops.go
+++ b/internal/terraform/module/module_ops.go
@@ -381,7 +381,7 @@ func ParseModuleConfiguration(ctx context.Context, fs ReadOnlyFS, modStore *stat
 		return sErr
 	}
 
-	sErr = modStore.UpdateModuleDiagnostics(modPath, ast.ModuleParsingSource, diags)
+	sErr = modStore.UpdateModuleDiagnostics(modPath, ast.HCLParsingSource, diags)
 	if sErr != nil {
 		return sErr
 	}
@@ -416,7 +416,7 @@ func ParseVariables(ctx context.Context, fs ReadOnlyFS, modStore *state.ModuleSt
 		return sErr
 	}
 
-	sErr = modStore.UpdateVarsDiagnostics(modPath, ast.VarsParsingSource, diags)
+	sErr = modStore.UpdateVarsDiagnostics(modPath, ast.HCLParsingSource, diags)
 	if sErr != nil {
 		return sErr
 	}

--- a/internal/terraform/module/module_ops.go
+++ b/internal/terraform/module/module_ops.go
@@ -378,7 +378,7 @@ func ParseModuleConfiguration(ctx context.Context, fs ReadOnlyFS, modStore *stat
 		return sErr
 	}
 
-	sErr = modStore.UpdateModuleDiagnostics(modPath, diags)
+	sErr = modStore.UpdateModuleDiagnostics(modPath, ast.ModuleParsingSource, diags)
 	if sErr != nil {
 		return sErr
 	}
@@ -413,7 +413,7 @@ func ParseVariables(ctx context.Context, fs ReadOnlyFS, modStore *state.ModuleSt
 		return sErr
 	}
 
-	sErr = modStore.UpdateVarsDiagnostics(modPath, diags)
+	sErr = modStore.UpdateVarsDiagnostics(modPath, ast.VarsParsingSource, diags)
 	if sErr != nil {
 		return sErr
 	}

--- a/internal/terraform/module/module_ops.go
+++ b/internal/terraform/module/module_ops.go
@@ -732,9 +732,7 @@ func ReferenceValidation(ctx context.Context, modStore *state.ModuleStore, schem
 		return err
 	}
 
-	ctx = decoder.WithPathContext(ctx, pathCtx)
-
-	diags := validations.UnreferencedOrigins(ctx)
+	diags := validations.UnreferencedOrigins(ctx, pathCtx)
 	return modStore.UpdateModuleDiagnostics(modPath, ast.ReferenceValidationSource, ast.ModDiagsFromMap(diags))
 }
 

--- a/internal/terraform/module/operation/op_type_string.go
+++ b/internal/terraform/module/operation/op_type_string.go
@@ -23,11 +23,12 @@ func _() {
 	_ = x[OpTypePreloadEmbeddedSchema-12]
 	_ = x[OpTypeEarlyValidation-13]
 	_ = x[OpTypeReferenceValidation-14]
+	_ = x[OpTypeTerraformValidate-15]
 }
 
-const _OpType_name = "OpTypeUnknownOpTypeGetTerraformVersionOpTypeObtainSchemaOpTypeParseModuleConfigurationOpTypeParseVariablesOpTypeParseModuleManifestOpTypeLoadModuleMetadataOpTypeDecodeReferenceTargetsOpTypeDecodeReferenceOriginsOpTypeDecodeVarsReferencesOpTypeGetModuleDataFromRegistryOpTypeParseProviderVersionsOpTypePreloadEmbeddedSchemaOpTypeEarlyValidationOpTypeReferenceValidation"
+const _OpType_name = "OpTypeUnknownOpTypeGetTerraformVersionOpTypeObtainSchemaOpTypeParseModuleConfigurationOpTypeParseVariablesOpTypeParseModuleManifestOpTypeLoadModuleMetadataOpTypeDecodeReferenceTargetsOpTypeDecodeReferenceOriginsOpTypeDecodeVarsReferencesOpTypeGetModuleDataFromRegistryOpTypeParseProviderVersionsOpTypePreloadEmbeddedSchemaOpTypeEarlyValidationOpTypeReferenceValidationOpTypeTerraformValidate"
 
-var _OpType_index = [...]uint16{0, 13, 38, 56, 86, 106, 131, 155, 183, 211, 237, 268, 295, 322, 343, 368}
+var _OpType_index = [...]uint16{0, 13, 38, 56, 86, 106, 131, 155, 183, 211, 237, 268, 295, 322, 343, 368, 391}
 
 func (i OpType) String() string {
 	if i >= OpType(len(_OpType_index)-1) {

--- a/internal/terraform/module/operation/op_type_string.go
+++ b/internal/terraform/module/operation/op_type_string.go
@@ -21,14 +21,14 @@ func _() {
 	_ = x[OpTypeGetModuleDataFromRegistry-10]
 	_ = x[OpTypeParseProviderVersions-11]
 	_ = x[OpTypePreloadEmbeddedSchema-12]
-	_ = x[OpTypeEarlyValidation-13]
+	_ = x[OpTypeSchemaValidation-13]
 	_ = x[OpTypeReferenceValidation-14]
 	_ = x[OpTypeTerraformValidate-15]
 }
 
-const _OpType_name = "OpTypeUnknownOpTypeGetTerraformVersionOpTypeObtainSchemaOpTypeParseModuleConfigurationOpTypeParseVariablesOpTypeParseModuleManifestOpTypeLoadModuleMetadataOpTypeDecodeReferenceTargetsOpTypeDecodeReferenceOriginsOpTypeDecodeVarsReferencesOpTypeGetModuleDataFromRegistryOpTypeParseProviderVersionsOpTypePreloadEmbeddedSchemaOpTypeEarlyValidationOpTypeReferenceValidationOpTypeTerraformValidate"
+const _OpType_name = "OpTypeUnknownOpTypeGetTerraformVersionOpTypeObtainSchemaOpTypeParseModuleConfigurationOpTypeParseVariablesOpTypeParseModuleManifestOpTypeLoadModuleMetadataOpTypeDecodeReferenceTargetsOpTypeDecodeReferenceOriginsOpTypeDecodeVarsReferencesOpTypeGetModuleDataFromRegistryOpTypeParseProviderVersionsOpTypePreloadEmbeddedSchemaOpTypeSchemaValidationOpTypeReferenceValidationOpTypeTerraformValidate"
 
-var _OpType_index = [...]uint16{0, 13, 38, 56, 86, 106, 131, 155, 183, 211, 237, 268, 295, 322, 343, 368, 391}
+var _OpType_index = [...]uint16{0, 13, 38, 56, 86, 106, 131, 155, 183, 211, 237, 268, 295, 322, 344, 369, 392}
 
 func (i OpType) String() string {
 	if i >= OpType(len(_OpType_index)-1) {

--- a/internal/terraform/module/operation/op_type_string.go
+++ b/internal/terraform/module/operation/op_type_string.go
@@ -22,11 +22,12 @@ func _() {
 	_ = x[OpTypeParseProviderVersions-11]
 	_ = x[OpTypePreloadEmbeddedSchema-12]
 	_ = x[OpTypeEarlyValidation-13]
+	_ = x[OpTypeReferenceValidation-14]
 }
 
-const _OpType_name = "OpTypeUnknownOpTypeGetTerraformVersionOpTypeObtainSchemaOpTypeParseModuleConfigurationOpTypeParseVariablesOpTypeParseModuleManifestOpTypeLoadModuleMetadataOpTypeDecodeReferenceTargetsOpTypeDecodeReferenceOriginsOpTypeDecodeVarsReferencesOpTypeGetModuleDataFromRegistryOpTypeParseProviderVersionsOpTypePreloadEmbeddedSchemaOpTypeEarlyValidation"
+const _OpType_name = "OpTypeUnknownOpTypeGetTerraformVersionOpTypeObtainSchemaOpTypeParseModuleConfigurationOpTypeParseVariablesOpTypeParseModuleManifestOpTypeLoadModuleMetadataOpTypeDecodeReferenceTargetsOpTypeDecodeReferenceOriginsOpTypeDecodeVarsReferencesOpTypeGetModuleDataFromRegistryOpTypeParseProviderVersionsOpTypePreloadEmbeddedSchemaOpTypeEarlyValidationOpTypeReferenceValidation"
 
-var _OpType_index = [...]uint16{0, 13, 38, 56, 86, 106, 131, 155, 183, 211, 237, 268, 295, 322, 343}
+var _OpType_index = [...]uint16{0, 13, 38, 56, 86, 106, 131, 155, 183, 211, 237, 268, 295, 322, 343, 368}
 
 func (i OpType) String() string {
 	if i >= OpType(len(_OpType_index)-1) {

--- a/internal/terraform/module/operation/operation.go
+++ b/internal/terraform/module/operation/operation.go
@@ -32,4 +32,5 @@ const (
 	OpTypePreloadEmbeddedSchema
 	OpTypeEarlyValidation
 	OpTypeReferenceValidation
+	OpTypeTerraformValidate
 )

--- a/internal/terraform/module/operation/operation.go
+++ b/internal/terraform/module/operation/operation.go
@@ -30,7 +30,7 @@ const (
 	OpTypeGetModuleDataFromRegistry
 	OpTypeParseProviderVersions
 	OpTypePreloadEmbeddedSchema
-	OpTypeEarlyValidation
+	OpTypeSchemaValidation
 	OpTypeReferenceValidation
 	OpTypeTerraformValidate
 )

--- a/internal/terraform/module/operation/operation.go
+++ b/internal/terraform/module/operation/operation.go
@@ -31,4 +31,5 @@ const (
 	OpTypeParseProviderVersions
 	OpTypePreloadEmbeddedSchema
 	OpTypeEarlyValidation
+	OpTypeReferenceValidation
 )


### PR DESCRIPTION
This PR updates the way we store and publish diagnostics to allow publishing from a single location (a module hook).

Whereas before we only stored diagnostics from parsing inside the module state, we now store a map instead, which can contain diagnostics from different sources. The map is filled by different jobs, such as parsing or early validation.

We've moved the execution of `terraform validate` into its own job that is scheduled on save (if enabled) to remove the manual publishing of diagnostics in that command. This leaves us with a single place for publishing (a module hook) that is automatically triggered whenever a module's diagnostic map changes.

Resolves #1337 