### PR TITLE
Check early validation setting before scheduling jobs

### DIFF
--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -30,6 +30,7 @@ var (
 	ctxLsVersion            = &contextKey{"language server version"}
 	ctxProgressToken        = &contextKey{"progress token"}
 	ctxExperimentalFeatures = &contextKey{"experimental features"}
+	ctxValidationOptions    = &contextKey{"validation options"}
 )
 
 func missingContextErr(ctxKey *contextKey) *MissingContextErr {
@@ -164,4 +165,26 @@ func ExperimentalFeatures(ctx context.Context) (settings.ExperimentalFeatures, e
 		return settings.ExperimentalFeatures{}, missingContextErr(ctxExperimentalFeatures)
 	}
 	return *expFeatures, nil
+}
+
+func WithValidationOptions(ctx context.Context, validationOptions *settings.ValidationOptions) context.Context {
+	return context.WithValue(ctx, ctxValidationOptions, validationOptions)
+}
+
+func SetValidationOptions(ctx context.Context, validationOptions settings.ValidationOptions) error {
+	e, ok := ctx.Value(ctxValidationOptions).(*settings.ValidationOptions)
+	if !ok {
+		return missingContextErr(ctxValidationOptions)
+	}
+
+	*e = validationOptions
+	return nil
+}
+
+func ValidationOptions(ctx context.Context) (settings.ValidationOptions, error) {
+	validationOptions, ok := ctx.Value(ctxValidationOptions).(*settings.ValidationOptions)
+	if !ok {
+		return settings.ValidationOptions{}, missingContextErr(ctxValidationOptions)
+	}
+	return *validationOptions, nil
 }

--- a/internal/indexer/document_change.go
+++ b/internal/indexer/document_change.go
@@ -6,6 +6,7 @@ package indexer
 import (
 	"context"
 
+	lsctx "github.com/hashicorp/terraform-ls/internal/context"
 	"github.com/hashicorp/terraform-ls/internal/document"
 	"github.com/hashicorp/terraform-ls/internal/job"
 	"github.com/hashicorp/terraform-ls/internal/schemas"
@@ -96,18 +97,24 @@ func (idx *Indexer) decodeModule(ctx context.Context, modHandle document.DirHand
 	}
 	ids = append(ids, eSchemaId)
 
-	// TODO! check if early validation setting is enabled
-	_, err = idx.jobStore.EnqueueJob(ctx, job.Job{
-		Dir: modHandle,
-		Func: func(ctx context.Context) error {
-			return module.SchemaValidation(ctx, idx.modStore, idx.schemaStore, modHandle.Path())
-		},
-		Type:        op.OpTypeSchemaValidation.String(),
-		DependsOn:   job.IDs{eSchemaId},
-		IgnoreState: ignoreState,
-	})
+	validationOptions, err := lsctx.ValidationOptions(ctx)
 	if err != nil {
 		return ids, err
+	}
+
+	if validationOptions.EarlyValidation {
+		_, err = idx.jobStore.EnqueueJob(ctx, job.Job{
+			Dir: modHandle,
+			Func: func(ctx context.Context) error {
+				return module.SchemaValidation(ctx, idx.modStore, idx.schemaStore, modHandle.Path())
+			},
+			Type:        op.OpTypeSchemaValidation.String(),
+			DependsOn:   job.IDs{eSchemaId},
+			IgnoreState: ignoreState,
+		})
+		if err != nil {
+			return ids, err
+		}
 	}
 
 	refTargetsId, err := idx.jobStore.EnqueueJob(ctx, job.Job{
@@ -138,18 +145,19 @@ func (idx *Indexer) decodeModule(ctx context.Context, modHandle document.DirHand
 	}
 	ids = append(ids, refOriginsId)
 
-	// TODO! check if early validation setting is enabled
-	_, err = idx.jobStore.EnqueueJob(ctx, job.Job{
-		Dir: modHandle,
-		Func: func(ctx context.Context) error {
-			return module.ReferenceValidation(ctx, idx.modStore, idx.schemaStore, modHandle.Path())
-		},
-		Type:        op.OpTypeReferenceValidation.String(),
-		DependsOn:   job.IDs{refTargetsId, refOriginsId},
-		IgnoreState: ignoreState,
-	})
-	if err != nil {
-		return ids, err
+	if validationOptions.EarlyValidation {
+		_, err = idx.jobStore.EnqueueJob(ctx, job.Job{
+			Dir: modHandle,
+			Func: func(ctx context.Context) error {
+				return module.ReferenceValidation(ctx, idx.modStore, idx.schemaStore, modHandle.Path())
+			},
+			Type:        op.OpTypeReferenceValidation.String(),
+			DependsOn:   job.IDs{refTargetsId, refOriginsId},
+			IgnoreState: ignoreState,
+		})
+		if err != nil {
+			return ids, err
+		}
 	}
 
 	// This job may make an HTTP request, and we schedule it in

--- a/internal/langserver/handlers/initialize.go
+++ b/internal/langserver/handlers/initialize.go
@@ -107,6 +107,8 @@ func (svc *service) Initialize(ctx context.Context, params lsp.InitializeParams)
 
 	// set experimental feature flags
 	lsctx.SetExperimentalFeatures(ctx, out.Options.ExperimentalFeatures)
+	// set validation options for jobs
+	lsctx.SetValidationOptions(ctx, out.Options.Validation)
 
 	if len(out.UnusedKeys) > 0 {
 		jrpc2.ServerFromContext(ctx).Notify(ctx, "window/showMessage", &lsp.ShowMessageParams{
@@ -200,6 +202,7 @@ func getTelemetryProperties(out *settings.DecodedOptions) map[string]interface{}
 		"options.terraform.path":                          false,
 		"options.terraform.timeout":                       "",
 		"options.terraform.logFilePath":                   false,
+		"options.validation.earlyValidation":              false,
 		"root_uri":                                        "dir",
 		"lsVersion":                                       "",
 	}
@@ -215,6 +218,7 @@ func getTelemetryProperties(out *settings.DecodedOptions) map[string]interface{}
 	properties["options.terraform.path"] = len(out.Options.Terraform.Path) > 0
 	properties["options.terraform.timeout"] = out.Options.Terraform.Timeout
 	properties["options.terraform.logFilePath"] = len(out.Options.Terraform.LogFilePath) > 0
+	properties["options.validation.earlyValidation"] = out.Options.Validation.EarlyValidation
 
 	return properties
 }

--- a/internal/langserver/handlers/service.go
+++ b/internal/langserver/handlers/service.go
@@ -120,6 +120,7 @@ func (svc *service) Assigner() (jrpc2.Assigner, error) {
 	commandPrefix := ""
 	clientName := ""
 	var expFeatures settings.ExperimentalFeatures
+	var validationOptions settings.ValidationOptions
 
 	m := map[string]rpch.Func{
 		"initialize": func(ctx context.Context, req *jrpc2.Request) (interface{}, error) {
@@ -133,6 +134,7 @@ func (svc *service) Assigner() (jrpc2.Assigner, error) {
 			ctx = lsctx.WithCommandPrefix(ctx, &commandPrefix)
 			ctx = ilsp.ContextWithClientName(ctx, &clientName)
 			ctx = lsctx.WithExperimentalFeatures(ctx, &expFeatures)
+			ctx = lsctx.WithValidationOptions(ctx, &validationOptions)
 
 			version, ok := lsctx.LanguageServerVersion(svc.srvCtx)
 			if ok {
@@ -156,6 +158,8 @@ func (svc *service) Assigner() (jrpc2.Assigner, error) {
 			if err != nil {
 				return nil, err
 			}
+			ctx = lsctx.WithValidationOptions(ctx, &validationOptions)
+
 			return handle(ctx, req, svc.TextDocumentDidChange)
 		},
 		"textDocument/didOpen": func(ctx context.Context, req *jrpc2.Request) (interface{}, error) {
@@ -163,6 +167,8 @@ func (svc *service) Assigner() (jrpc2.Assigner, error) {
 			if err != nil {
 				return nil, err
 			}
+			ctx = lsctx.WithValidationOptions(ctx, &validationOptions)
+
 			return handle(ctx, req, svc.TextDocumentDidOpen)
 		},
 		"textDocument/didClose": func(ctx context.Context, req *jrpc2.Request) (interface{}, error) {
@@ -325,6 +331,7 @@ func (svc *service) Assigner() (jrpc2.Assigner, error) {
 			if err != nil {
 				return nil, err
 			}
+			ctx = lsctx.WithValidationOptions(ctx, &validationOptions)
 
 			return handle(ctx, req, svc.DidChangeWatchedFiles)
 		},


### PR DESCRIPTION
Requires #1361

This PR uses the new setting introduced in #1353, to check if the early validation feature is enabled before running any early validation jobs.