### PR TITLE
Improve `PreloadEmbeddedSchema` performance

### DIFF
--- a/internal/state/provider_schema.go
+++ b/internal/state/provider_schema.go
@@ -212,11 +212,11 @@ func (s *ProviderSchemaStore) AllSchemasExist(pvm map[tfaddr.Provider]version.Co
 // MissingSchemas checks which schemas are missing in order to preload them from the bundled schemas.
 // Since we don't know the version of a schema on disk before loading it, we assume it's
 // good to just load it by address and ignore the version constraints.
-func (s *ProviderSchemaStore) MissingSchemas(pvm map[tfaddr.Provider]version.Constraints) (map[tfaddr.Provider]version.Constraints, error) {
-	missingSchemas := make(map[tfaddr.Provider]version.Constraints, 0)
+func (s *ProviderSchemaStore) MissingSchemas(pvm map[tfaddr.Provider]version.Constraints) ([]tfaddr.Provider, error) {
+	missingSchemas := make([]tfaddr.Provider, 0)
 	fakeCons, _ := version.NewConstraint("> 0.0.0")
 
-	for pAddr, pCons := range pvm {
+	for pAddr := range pvm {
 		if pAddr.IsLegacy() && pAddr.Type == "terraform" {
 			// The terraform provider is built into Terraform 0.11+
 			// and while it's possible, users typically don't declare
@@ -242,7 +242,7 @@ func (s *ProviderSchemaStore) MissingSchemas(pvm map[tfaddr.Provider]version.Con
 			return nil, err
 		}
 		if !exists {
-			missingSchemas[pAddr] = pCons
+			missingSchemas = append(missingSchemas, pAddr)
 		}
 	}
 	return missingSchemas, nil

--- a/internal/state/provider_schema.go
+++ b/internal/state/provider_schema.go
@@ -214,7 +214,6 @@ func (s *ProviderSchemaStore) AllSchemasExist(pvm map[tfaddr.Provider]version.Co
 // good to just load it by address and ignore the version constraints.
 func (s *ProviderSchemaStore) MissingSchemas(pvm map[tfaddr.Provider]version.Constraints) ([]tfaddr.Provider, error) {
 	missingSchemas := make([]tfaddr.Provider, 0)
-	fakeCons, _ := version.NewConstraint("> 0.0.0")
 
 	for pAddr := range pvm {
 		if pAddr.IsLegacy() && pAddr.Type == "terraform" {
@@ -237,7 +236,7 @@ func (s *ProviderSchemaStore) MissingSchemas(pvm map[tfaddr.Provider]version.Con
 			pAddr.Namespace = "hashicorp"
 		}
 
-		exists, err := s.schemaExists(pAddr, fakeCons)
+		exists, err := s.schemaExists(pAddr, version.Constraints{})
 		if err != nil {
 			return nil, err
 		}

--- a/internal/terraform/module/module_ops.go
+++ b/internal/terraform/module/module_ops.go
@@ -228,7 +228,7 @@ func PreloadEmbeddedSchema(ctx context.Context, logger *log.Logger, fs fs.ReadDi
 		return nil
 	}
 
-	for pAddr := range missingReqs {
+	for _, pAddr := range missingReqs {
 		err := preloadSchemaForProviderAddr(ctx, pAddr, fs, schemaStore, logger)
 		if err != nil {
 			return err


### PR DESCRIPTION
## Background

In https://github.com/hashicorp/terraform-ls/pull/1071, we have changed the way we store and load the bundled schemas to reduce our memory footprint. We released the work with version `0.29.3`. User reports indicate that in previous versions, e.g. `0.29.2`, the observed performance was better.

## The Problem

**TL:DR we read a schema file from disk every time, even if we have already loaded the file**

We schedule the `PreloadEmbeddedSchema` job when decoding a module (`textDocument/didOpen`, `textDocument/didChange`) and from the indexer when walking the workspace files.

The job reads the required providers from a module and checks which schemas are still missing in our internal memory. We use the list of missing schemas to load schemas from disk. After loading a schema from disk, we store it with the address (e.g. `registry.terraform.io/hashicorp/aws`) and the specific version (found in the schema path) (e.g. `4.33.0`) in memory. The next time we come across the same provider in another module, we would reuse the stored schema and not load it again. At least in theory.

Provider requirements usually contain a source and a version (it is a good practice to _always_ include a version). When checking for missing schemas, we were using the unique combination of both to check if a schema already exists in memory. The schemas we bundle with the language server are only the most recent versions of all official and partner providers, so a mismatch between those versions is likely.

A version mismatch triggers a read of the schema from disk (if the schema is part of our bundle) and we try to store it in memory (again). Storing fails with `schema for %s is already loaded`, because we already store the specific combination of address and version of the schema file from disk.

## The Fix

When checking for missing schemas, we now only compare the address and use a version constraint that matches any version (`> 0.0.0`). We also account for legacy sources and the builtin Terraform provider.

## Results

**0.29.2** CPU & Memory after launch
<img width="559" alt="cpu_0_29_2" src="https://github.com/hashicorp/terraform-ls/assets/45985/4023d942-86a0-4efb-baa3-4d15d7b912e1">
<img width="559" alt="memory_0_29_2" src="https://github.com/hashicorp/terraform-ls/assets/45985/4085fee6-d8c5-4e02-ad01-207cae36da20">

**>= 0.29.3** CPU & Memory after launch
<img width="559" alt="cpu_0_29_3" src="https://github.com/hashicorp/terraform-ls/assets/45985/66c0aac4-ed38-4811-ab5c-03120898bc14">
<img width="559" alt="memory_0_29_3" src="https://github.com/hashicorp/terraform-ls/assets/45985/2f77ab38-ddd7-439f-91ce-e25655eca95b">

**This PR**  CPU & Memory after launch
<img width="559" alt="cpu_fix" src="https://github.com/hashicorp/terraform-ls/assets/45985/3d18e01b-1bfe-457f-82cf-b97ead77efb4">
<img width="559" alt="memory_fix" src="https://github.com/hashicorp/terraform-ls/assets/45985/42a88e17-6ae5-4b3d-831d-66f3bbde7a0f">

As a result of this fix, we're back to `0.29.2` levels of CPU usage while maintaining the memory improvements of `0.29.3`. This also reduces the work & IO we do on each change event.