### PR TITLE
Only validate a single file on `didChange`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/hc-install v0.5.2
-	github.com/hashicorp/hcl-lang v0.0.0-20230825134805-29034e9d534d
+	github.com/hashicorp/hcl-lang v0.0.0-20230831100527-485c60767f2d
 	github.com/hashicorp/hcl/v2 v2.17.0
 	github.com/hashicorp/terraform-exec v0.18.1
 	github.com/hashicorp/terraform-json v0.17.1

--- a/go.sum
+++ b/go.sum
@@ -215,8 +215,8 @@ github.com/hashicorp/hc-install v0.5.2 h1:SfwMFnEXVVirpwkDuSF5kymUOhrUxrTq3udEse
 github.com/hashicorp/hc-install v0.5.2/go.mod h1:9QISwe6newMWIfEiXpzuu1k9HAGtQYgnSH8H9T8wmoI=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/hashicorp/hcl-lang v0.0.0-20230825134805-29034e9d534d h1:kr/f+fJGnFGe2al/H55/blLb1Ne5BAZWe4qY/BxA2D0=
-github.com/hashicorp/hcl-lang v0.0.0-20230825134805-29034e9d534d/go.mod h1:X9wA1+6Zr0nVspFxRvhVZnDhBMWhvb0uuAjp4bGujuc=
+github.com/hashicorp/hcl-lang v0.0.0-20230831100527-485c60767f2d h1:6ZwX2CLjjwOb+3ogeXWnsJGtwbE6r5//7FTL2tC6lPk=
+github.com/hashicorp/hcl-lang v0.0.0-20230831100527-485c60767f2d/go.mod h1:X9wA1+6Zr0nVspFxRvhVZnDhBMWhvb0uuAjp4bGujuc=
 github.com/hashicorp/hcl/v2 v2.17.0 h1:z1XvSUyXd1HP10U4lrLg5e0JMVz6CPaJvAgxM0KNZVY=
 github.com/hashicorp/hcl/v2 v2.17.0/go.mod h1:gJyW2PTShkJqQBKpAmPO3yxMxIuoXkOF2TpqXzrQyx4=
 github.com/hashicorp/terraform-exec v0.18.1 h1:LAbfDvNQU1l0NOQlTuudjczVhHj061fNX5H8XZxHlH4=

--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -5,6 +5,7 @@ package context
 
 import (
 	"context"
+	"path"
 	"time"
 
 	"github.com/hashicorp/terraform-ls/internal/langserver/diagnostics"
@@ -20,6 +21,26 @@ func (k *contextKey) String() string {
 	return k.Name
 }
 
+type RPCContextData struct {
+	Method string
+	URI    string
+}
+
+func (rpcc RPCContextData) Copy() RPCContextData {
+	return RPCContextData{
+		Method: rpcc.Method,
+		URI:    rpcc.URI,
+	}
+}
+
+func (rpcc RPCContextData) IsSingleFileChange() (string, bool) {
+	if rpcc.Method == "textDocument/didChange" {
+		return path.Base(rpcc.URI), true
+	}
+
+	return "", false
+}
+
 var (
 	ctxTfExecPath           = &contextKey{"terraform executable path"}
 	ctxTfExecLogPath        = &contextKey{"terraform executor log path"}
@@ -31,6 +52,7 @@ var (
 	ctxProgressToken        = &contextKey{"progress token"}
 	ctxExperimentalFeatures = &contextKey{"experimental features"}
 	ctxValidationOptions    = &contextKey{"validation options"}
+	ctxRPCContext           = &contextKey{"rpc context"}
 )
 
 func missingContextErr(ctxKey *contextKey) *MissingContextErr {
@@ -187,4 +209,12 @@ func ValidationOptions(ctx context.Context) (settings.ValidationOptions, error) 
 		return settings.ValidationOptions{}, missingContextErr(ctxValidationOptions)
 	}
 	return *validationOptions, nil
+}
+
+func WithRPCContext(ctx context.Context, rpcc RPCContextData) context.Context {
+	return context.WithValue(ctx, ctxRPCContext, rpcc)
+}
+
+func RPCContext(ctx context.Context) RPCContextData {
+	return ctx.Value(ctxRPCContext).(RPCContextData)
 }

--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -5,7 +5,6 @@ package context
 
 import (
 	"context"
-	"path"
 	"time"
 
 	"github.com/hashicorp/terraform-ls/internal/langserver/diagnostics"
@@ -31,14 +30,6 @@ func (rpcc RPCContextData) Copy() RPCContextData {
 		Method: rpcc.Method,
 		URI:    rpcc.URI,
 	}
-}
-
-func (rpcc RPCContextData) IsSingleFileChange() (string, bool) {
-	if rpcc.Method == "textDocument/didChange" {
-		return path.Base(rpcc.URI), true
-	}
-
-	return "", false
 }
 
 var (

--- a/internal/langserver/handlers/initialize.go
+++ b/internal/langserver/handlers/initialize.go
@@ -166,6 +166,8 @@ func (svc *service) Initialize(ctx context.Context, params lsp.InitializeParams)
 	// passing the request context here
 	// Static user-provided paths take precedence over dynamic discovery
 	walkerCtx := context.Background()
+	walkerCtx = lsctx.WithRPCContext(walkerCtx, lsctx.RPCContext(ctx))
+
 	err = svc.closedDirWalker.StartWalking(walkerCtx)
 	if err != nil {
 		return serverCaps, fmt.Errorf("failed to start closedDirWalker: %w", err)

--- a/internal/langserver/handlers/service.go
+++ b/internal/langserver/handlers/service.go
@@ -619,17 +619,29 @@ func handle(ctx context.Context, req *jrpc2.Request, fn interface{}) (interface{
 	}
 	params := p{}
 	err := req.UnmarshalParams(&params)
-	if err == nil {
-		attrs = append(attrs, attribute.KeyValue{
-			Key:   attribute.Key("URI"),
-			Value: attribute.StringValue(string(params.URI)),
-		})
+	if err != nil {
+		return nil, err
 	}
+
+	uri := params.URI
+	if params.RootURI != "" {
+		uri = params.RootURI
+	}
+
+	attrs = append(attrs, attribute.KeyValue{
+		Key:   attribute.Key("URI"),
+		Value: attribute.StringValue(uri),
+	})
 
 	tracer := otel.Tracer(tracerName)
 	ctx, span := tracer.Start(ctx, "rpc:"+req.Method(),
 		trace.WithAttributes(attrs...))
 	defer span.End()
+
+	ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{
+		Method: req.Method(),
+		URI:    uri,
+	})
 
 	result, err := rpch.New(fn)(ctx, req)
 	if ctx.Err() != nil && errors.Is(ctx.Err(), context.Canceled) {

--- a/internal/langserver/handlers/service.go
+++ b/internal/langserver/handlers/service.go
@@ -613,9 +613,12 @@ func handle(ctx context.Context, req *jrpc2.Request, fn interface{}) (interface{
 
 	// We could capture all parameters here but for now we just
 	// opportunistically track the most important ones only.
+	type t struct {
+		URI string `json:"uri,omitempty"`
+	}
 	type p struct {
-		URI     string `json:"uri,omitempty"`
-		RootURI string `json:"rootUri,omitempty"`
+		TextDocument t      `json:"textDocument,omitempty"`
+		RootURI      string `json:"rootUri,omitempty"`
 	}
 	params := p{}
 	err := req.UnmarshalParams(&params)
@@ -623,7 +626,7 @@ func handle(ctx context.Context, req *jrpc2.Request, fn interface{}) (interface{
 		return nil, err
 	}
 
-	uri := params.URI
+	uri := params.TextDocument.URI
 	if params.RootURI != "" {
 		uri = params.RootURI
 	}

--- a/internal/terraform/module/module_ops.go
+++ b/internal/terraform/module/module_ops.go
@@ -17,7 +17,9 @@ import (
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/hcl-lang/decoder"
 	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl/v2"
 	tfjson "github.com/hashicorp/terraform-json"
+	lsctx "github.com/hashicorp/terraform-ls/internal/context"
 	idecoder "github.com/hashicorp/terraform-ls/internal/decoder"
 	"github.com/hashicorp/terraform-ls/internal/decoder/validations"
 	"github.com/hashicorp/terraform-ls/internal/document"
@@ -695,10 +697,33 @@ func SchemaValidation(ctx context.Context, modStore *state.ModuleStore, schemaRe
 		return err
 	}
 
-	diags, rErr := moduleDecoder.Validate(ctx)
-	sErr := modStore.UpdateModuleDiagnostics(modPath, ast.SchemaValidationSource, ast.ModDiagsFromMap(diags))
-	if sErr != nil {
-		return sErr
+	var rErr error
+	rpcContext := lsctx.RPCContext(ctx)
+	filename, isSingleFileChange := rpcContext.IsSingleFileChange()
+	if isSingleFileChange {
+		// We only revalidate a single file that changed
+		var fileDiags hcl.Diagnostics
+		fileDiags, rErr = moduleDecoder.ValidateFile(ctx, filename)
+
+		modDiags, ok := mod.ModuleDiagnostics[ast.SchemaValidationSource]
+		if !ok {
+			modDiags = make(ast.ModDiags)
+		}
+		modDiags[ast.ModFilename(filename)] = fileDiags
+
+		sErr := modStore.UpdateModuleDiagnostics(modPath, ast.SchemaValidationSource, modDiags)
+		if sErr != nil {
+			return sErr
+		}
+	} else {
+		// We validate the whole module, e.g. on open
+		var diags lang.DiagnosticsMap
+		diags, rErr = moduleDecoder.Validate(ctx)
+
+		sErr := modStore.UpdateModuleDiagnostics(modPath, ast.SchemaValidationSource, ast.ModDiagsFromMap(diags))
+		if sErr != nil {
+			return sErr
+		}
 	}
 
 	return rErr

--- a/internal/terraform/module/module_ops.go
+++ b/internal/terraform/module/module_ops.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"io/fs"
 	"log"
+	"path"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
@@ -699,8 +700,9 @@ func SchemaValidation(ctx context.Context, modStore *state.ModuleStore, schemaRe
 
 	var rErr error
 	rpcContext := lsctx.RPCContext(ctx)
-	filename, isSingleFileChange := rpcContext.IsSingleFileChange()
+	isSingleFileChange := rpcContext.Method == "textDocument/didChange"
 	if isSingleFileChange {
+		filename := path.Base(rpcContext.URI)
 		// We only revalidate a single file that changed
 		var fileDiags hcl.Diagnostics
 		fileDiags, rErr = moduleDecoder.ValidateFile(ctx, filename)

--- a/internal/terraform/module/testdata/invalid-config/main.tf
+++ b/internal/terraform/module/testdata/invalid-config/main.tf
@@ -1,0 +1,9 @@
+test {}
+
+variable {
+
+}
+
+locals {
+  test = 1
+}

--- a/internal/terraform/module/testdata/invalid-config/variables.tf
+++ b/internal/terraform/module/testdata/invalid-config/variables.tf
@@ -1,0 +1,11 @@
+variable {
+
+}
+
+variable "test" {
+
+}
+
+output {
+
+}


### PR DESCRIPTION
This PR updates the schema validation job to check if it was scheduled by a `didChange` request. This request is sent by a client when a user edits a file.

If the content of a single file changes, it should not be necessary to re-validate all the files in the module. We can reuse our stored diagnostics for most of the module's files, and re-validate only the file being edited.

To achieve this we introduce a new `RPCContext`, that we attach to all jobs.