### PR TITLE
Re-add progress reporting for Terraform validate

### DIFF
--- a/internal/langserver/handlers/command/validate.go
+++ b/internal/langserver/handlers/command/validate.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-ls/internal/document"
 	"github.com/hashicorp/terraform-ls/internal/job"
 	"github.com/hashicorp/terraform-ls/internal/langserver/cmd"
+	"github.com/hashicorp/terraform-ls/internal/langserver/progress"
 	"github.com/hashicorp/terraform-ls/internal/terraform/module"
 	op "github.com/hashicorp/terraform-ls/internal/terraform/module/operation"
 	"github.com/hashicorp/terraform-ls/internal/uri"
@@ -28,6 +29,12 @@ func (h *CmdHandler) TerraformValidateHandler(ctx context.Context, args cmd.Comm
 
 	dirHandle := document.DirHandleFromURI(dirUri)
 
+	progress.Begin(ctx, "Validating")
+	defer func() {
+		progress.End(ctx, "Finished")
+	}()
+
+	progress.Report(ctx, "Running terraform validate ...")
 	id, err := h.StateStore.JobStore.EnqueueJob(ctx, job.Job{
 		Dir: dirHandle,
 		Func: func(ctx context.Context) error {


### PR DESCRIPTION
I accidentally removed progress reports for `terraform validate` while working on https://github.com/hashicorp/terraform-ls/pull/1361.

This PR adds it back. Although I see no difference in the LS log output