### PR TITLE
deps: bump terraform-schema to `90a397096838`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/hashicorp/terraform-exec v0.19.0
 	github.com/hashicorp/terraform-json v0.17.1
 	github.com/hashicorp/terraform-registry-address v0.2.2
-	github.com/hashicorp/terraform-schema v0.0.0-20230901110933-5a6413c62401
+	github.com/hashicorp/terraform-schema v0.0.0-20230904125443-90a397096838
 	github.com/mh-cbon/go-fmt-fail v0.0.0-20160815164508-67765b3fbcb5
 	github.com/mitchellh/cli v1.1.5
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -228,8 +228,8 @@ github.com/hashicorp/terraform-json v0.17.1 h1:eMfvh/uWggKmY7Pmb3T85u86E2EQg6EQH
 github.com/hashicorp/terraform-json v0.17.1/go.mod h1:Huy6zt6euxaY9knPAFKjUITn8QxUFIe9VuSzb4zn/0o=
 github.com/hashicorp/terraform-registry-address v0.2.2 h1:lPQBg403El8PPicg/qONZJDC6YlgCVbWDtNmmZKtBno=
 github.com/hashicorp/terraform-registry-address v0.2.2/go.mod h1:LtwNbCihUoUZ3RYriyS2wF/lGPB6gF9ICLRtuDk7hSo=
-github.com/hashicorp/terraform-schema v0.0.0-20230901110933-5a6413c62401 h1:Qoc127MUWLMzqc0NXCYMxrx837nqu8mmG9IchqAvEXc=
-github.com/hashicorp/terraform-schema v0.0.0-20230901110933-5a6413c62401/go.mod h1:PXhA8crTZkaqg56PrGKM+fHsOgeaORhmjjTj/7N9kyg=
+github.com/hashicorp/terraform-schema v0.0.0-20230904125443-90a397096838 h1:sixoZnLpWvkWdPObUKRuDy4dKlStgnkmFjXHqCyUeHQ=
+github.com/hashicorp/terraform-schema v0.0.0-20230904125443-90a397096838/go.mod h1:PXhA8crTZkaqg56PrGKM+fHsOgeaORhmjjTj/7N9kyg=
 github.com/hashicorp/terraform-svchost v0.1.1 h1:EZZimZ1GxdqFRinZ1tpJwVxxt49xc/S52uzrw4x0jKQ=
 github.com/hashicorp/terraform-svchost v0.1.1/go.mod h1:mNsjQfZyf/Jhz35v6/0LWcv26+X7JPS+buii2c9/ctc=
 github.com/hexops/autogold v1.3.1 h1:YgxF9OHWbEIUjhDbpnLhgVsjUDsiHDTyDfy2lrfdlzo=


### PR DESCRIPTION
This is to bring in https://github.com/hashicorp/terraform-schema/pull/251 - once merged, we should rebase https://github.com/hashicorp/terraform-ls/pull/1368

I can't think of how this could affect the end users without https://github.com/hashicorp/terraform-schema/pull/251 (in positive or negative way) but it seems better to keep dependency updates in `main` to prevent conflicts in the branch/PR.