### PR TITLE
validations: Limit ref. validation to only LocalOrigin(s)

### DIFF
--- a/internal/decoder/validations/unreferenced_origin.go
+++ b/internal/decoder/validations/unreferenced_origin.go
@@ -27,6 +27,13 @@ func UnreferencedOrigins(ctx context.Context, pathCtx *decoder.PathContext) lang
 			continue
 		}
 
+		_, ok = origin.(reference.LocalOrigin)
+		if !ok {
+			// we avoid reporting on origins outside of the current module
+			// for now, to reduce complexity and reduce performance impact
+			continue
+		}
+
 		// we only initially validate variables
 		// resources and data sources can have unknown schema
 		// and will be researched at a later point

--- a/internal/decoder/validations/unreferenced_origin_test.go
+++ b/internal/decoder/validations/unreferenced_origin_test.go
@@ -51,6 +51,28 @@ func TestUnreferencedOrigins(t *testing.T) {
 			},
 		},
 		{
+			name: "unsupported path origins (module input)",
+			origins: reference.Origins{
+				reference.PathOrigin{
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{},
+						End:      hcl.Pos{},
+					},
+					TargetAddr: lang.Address{
+						lang.RootStep{Name: "var"},
+						lang.AttrStep{Name: "foo"},
+					},
+					TargetPath: lang.Path{
+						Path:       "./submodule",
+						LanguageID: "terraform",
+					},
+					Constraints: reference.OriginConstraints{},
+				},
+			},
+			want: lang.DiagnosticsMap{},
+		},
+		{
 			name: "many undeclared variables",
 			origins: reference.Origins{
 				reference.LocalOrigin{


### PR DESCRIPTION
## Context

While testing https://github.com/hashicorp/terraform-ls/pull/1368 we discovered that validating all "matchable" references means we also end up validating cross-module references, such as module inputs.

This, in combination with the fact that we limit lookups to inside of the single module, leads to false diagnostics, such as shown below:

<img width="440" alt="Screenshot 2023-09-04 at 14 23 09" src="https://github.com/hashicorp/terraform-ls/assets/287584/e9468c95-70d6-4dac-b9f3-fa9dad02de21">

## Proposal

I'm proposing in this PR to treat module input validation as a _feature_ we can enable later, when we had the time to properly assess the validation feature as a whole, and especially its performance impact and for the time being just avoid validating it.

## After patch

<img width="181" alt="Screenshot 2023-09-04 at 14 25 21" src="https://github.com/hashicorp/terraform-ls/assets/287584/52a2c978-f85f-49ad-85be-c52cc8d4dfc4">

## Follow-up

If agreed/merged, we should probably create an issue to track validation of module inputs (DirectOrigin) and also module sources (PathOrigin).