### PR TITLE
validations: Validate only first 2 segments of a reference

### DIFF
--- a/internal/decoder/validations/unreferenced_origin_test.go
+++ b/internal/decoder/validations/unreferenced_origin_test.go
@@ -51,6 +51,24 @@ func TestUnreferencedOrigins(t *testing.T) {
 			},
 		},
 		{
+			name: "unsupported variable of complex type",
+			origins: reference.Origins{
+				reference.LocalOrigin{
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{},
+						End:      hcl.Pos{},
+					},
+					Addr: lang.Address{
+						lang.RootStep{Name: "var"},
+						lang.AttrStep{Name: "obj"},
+						lang.AttrStep{Name: "field"},
+					},
+				},
+			},
+			want: lang.DiagnosticsMap{},
+		},
+		{
 			name: "unsupported path origins (module input)",
 			origins: reference.Origins{
 				reference.PathOrigin{


### PR DESCRIPTION
## Context

We don't yet support references to complex variables (or local values), which means that validating such references would raise false diagnostics. We can disable validation of such references until https://github.com/hashicorp/terraform-ls/issues/653 is addressed.

## UX Before

<img width="620" alt="Screenshot 2023-09-04 at 16 12 36" src="https://github.com/hashicorp/terraform-ls/assets/287584/a494831c-a2ec-4e2c-b3e6-832396dbf6eb">

## UX After

<img width="454" alt="Screenshot 2023-09-04 at 16 14 41" src="https://github.com/hashicorp/terraform-ls/assets/287584/a20d20aa-f986-47eb-8121-17a47abb7ba3">
