### PR TITLE
validations: Enable reference validation of locals

### DIFF
--- a/internal/decoder/validations/unreferenced_origin.go
+++ b/internal/decoder/validations/unreferenced_origin.go
@@ -6,6 +6,7 @@ package validations
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"github.com/hashicorp/hcl-lang/decoder"
 	"github.com/hashicorp/hcl-lang/lang"

--- a/internal/decoder/validations/unreferenced_origin.go
+++ b/internal/decoder/validations/unreferenced_origin.go
@@ -47,8 +47,9 @@ func UnreferencedOrigins(ctx context.Context, pathCtx *decoder.PathContext) lang
 		// we only initially validate variables & local values
 		// resources and data sources can have unknown schema
 		// and will be researched at a later point
+		supported := []string{"var", "local"}
 		firstStep := address[0].String()
-		if firstStep != "var" && firstStep != "local" {
+		if !slices.Contains(supported, firstStep) {
 			continue
 		}
 

--- a/internal/decoder/validations/unreferenced_origin.go
+++ b/internal/decoder/validations/unreferenced_origin.go
@@ -44,11 +44,11 @@ func UnreferencedOrigins(ctx context.Context, pathCtx *decoder.PathContext) lang
 			continue
 		}
 
-		// we only initially validate variables
+		// we only initially validate variables & local values
 		// resources and data sources can have unknown schema
 		// and will be researched at a later point
-		firstStep := address[0]
-		if firstStep.String() != "var" {
+		firstStep := address[0].String()
+		if firstStep != "var" && firstStep != "local" {
 			continue
 		}
 

--- a/internal/decoder/validations/unreferenced_origin_test.go
+++ b/internal/decoder/validations/unreferenced_origin_test.go
@@ -51,6 +51,35 @@ func TestUnreferencedOrigins(t *testing.T) {
 			},
 		},
 		{
+			name: "undeclared local value",
+			origins: reference.Origins{
+				reference.LocalOrigin{
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{},
+						End:      hcl.Pos{},
+					},
+					Addr: lang.Address{
+						lang.RootStep{Name: "local"},
+						lang.AttrStep{Name: "foo"},
+					},
+				},
+			},
+			want: lang.DiagnosticsMap{
+				"test.tf": hcl.Diagnostics{
+					&hcl.Diagnostic{
+						Severity: hcl.DiagError,
+						Summary:  "No declaration found for \"local.foo\"",
+						Subject: &hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{},
+							End:      hcl.Pos{},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "unsupported variable of complex type",
 			origins: reference.Origins{
 				reference.LocalOrigin{


### PR DESCRIPTION
This addresses one small part of https://github.com/hashicorp/terraform-ls/issues/1364 - in particular `local.*` reference validation.

## UX Before

<img width="169" alt="Screenshot 2023-09-04 at 16 24 08" src="https://github.com/hashicorp/terraform-ls/assets/287584/cf701c57-081e-4ba3-b498-e04472b04916">

## UX After

<img width="504" alt="Screenshot 2023-09-04 at 16 24 33" src="https://github.com/hashicorp/terraform-ls/assets/287584/6ed282a7-f33e-4a25-8550-83eb2359ab81">
