### PR TITLE
indexer: Ensure declared module calls get decoded

### DIFF
--- a/internal/indexer/module_calls.go
+++ b/internal/indexer/module_calls.go
@@ -39,99 +39,106 @@ func (idx *Indexer) decodeInstalledModuleCalls(ctx context.Context, modHandle do
 		}
 
 		mcHandle := document.DirHandleFromPath(mc.Path)
-		// copy path for queued jobs below
-		mcPath := mc.Path
+		mcJobIds, mcErr := idx.decodeModuleAtPath(ctx, mcHandle, ignoreState)
+		jobIds = append(jobIds, mcJobIds...)
+		multierror.Append(errs, mcErr)
+	}
 
-		refCollectionDeps := make(job.IDs, 0)
+	return jobIds, errs.ErrorOrNil()
+}
 
-		parseId, err := idx.jobStore.EnqueueJob(ctx, job.Job{
-			Dir: mcHandle,
+func (idx *Indexer) decodeModuleAtPath(ctx context.Context, modHandle document.DirHandle, ignoreState bool) (job.IDs, error) {
+	var errs *multierror.Error
+	jobIds := make(job.IDs, 0)
+	refCollectionDeps := make(job.IDs, 0)
+
+	parseId, err := idx.jobStore.EnqueueJob(ctx, job.Job{
+		Dir: modHandle,
+		Func: func(ctx context.Context) error {
+			return module.ParseModuleConfiguration(ctx, idx.fs, idx.modStore, modHandle.Path())
+		},
+		Type:        op.OpTypeParseModuleConfiguration.String(),
+		IgnoreState: ignoreState,
+	})
+	if err != nil {
+		multierror.Append(errs, err)
+	} else {
+		jobIds = append(jobIds, parseId)
+		refCollectionDeps = append(refCollectionDeps, parseId)
+	}
+
+	var metaId job.ID
+	if parseId != "" {
+		metaId, err = idx.jobStore.EnqueueJob(ctx, job.Job{
+			Dir:  modHandle,
+			Type: op.OpTypeLoadModuleMetadata.String(),
 			Func: func(ctx context.Context) error {
-				return module.ParseModuleConfiguration(ctx, idx.fs, idx.modStore, mcPath)
+				return module.LoadModuleMetadata(ctx, idx.modStore, modHandle.Path())
 			},
-			Type:        op.OpTypeParseModuleConfiguration.String(),
+			DependsOn:   job.IDs{parseId},
 			IgnoreState: ignoreState,
 		})
 		if err != nil {
 			multierror.Append(errs, err)
 		} else {
-			jobIds = append(jobIds, parseId)
-			refCollectionDeps = append(refCollectionDeps, parseId)
+			jobIds = append(jobIds, metaId)
+			refCollectionDeps = append(refCollectionDeps, metaId)
 		}
 
-		var metaId job.ID
-		if parseId != "" {
-			metaId, err = idx.jobStore.EnqueueJob(ctx, job.Job{
-				Dir:  mcHandle,
-				Type: op.OpTypeLoadModuleMetadata.String(),
-				Func: func(ctx context.Context) error {
-					return module.LoadModuleMetadata(ctx, idx.modStore, mcPath)
-				},
-				DependsOn:   job.IDs{parseId},
-				IgnoreState: ignoreState,
-			})
-			if err != nil {
-				multierror.Append(errs, err)
-			} else {
-				jobIds = append(jobIds, metaId)
-				refCollectionDeps = append(refCollectionDeps, metaId)
-			}
-
-			eSchemaId, err := idx.jobStore.EnqueueJob(ctx, job.Job{
-				Dir: mcHandle,
-				Func: func(ctx context.Context) error {
-					return module.PreloadEmbeddedSchema(ctx, idx.logger, schemas.FS, idx.modStore, idx.schemaStore, mcPath)
-				},
-				Type:        op.OpTypePreloadEmbeddedSchema.String(),
-				DependsOn:   job.IDs{metaId},
-				IgnoreState: ignoreState,
-			})
-			if err != nil {
-				multierror.Append(errs, err)
-			} else {
-				jobIds = append(jobIds, eSchemaId)
-				refCollectionDeps = append(refCollectionDeps, eSchemaId)
-			}
-		}
-
-		if parseId != "" {
-			ids, err := idx.collectReferences(ctx, mcHandle, refCollectionDeps, ignoreState)
-			if err != nil {
-				multierror.Append(errs, err)
-			} else {
-				jobIds = append(jobIds, ids...)
-			}
-		}
-
-		varsParseId, err := idx.jobStore.EnqueueJob(ctx, job.Job{
-			Dir: mcHandle,
+		eSchemaId, err := idx.jobStore.EnqueueJob(ctx, job.Job{
+			Dir: modHandle,
 			Func: func(ctx context.Context) error {
-				return module.ParseVariables(ctx, idx.fs, idx.modStore, mcPath)
+				return module.PreloadEmbeddedSchema(ctx, idx.logger, schemas.FS, idx.modStore, idx.schemaStore, modHandle.Path())
 			},
-			Type:        op.OpTypeParseVariables.String(),
+			Type:        op.OpTypePreloadEmbeddedSchema.String(),
+			DependsOn:   job.IDs{metaId},
 			IgnoreState: ignoreState,
 		})
 		if err != nil {
 			multierror.Append(errs, err)
 		} else {
-			jobIds = append(jobIds, varsParseId)
+			jobIds = append(jobIds, eSchemaId)
+			refCollectionDeps = append(refCollectionDeps, eSchemaId)
 		}
+	}
 
-		if varsParseId != "" {
-			varsRefId, err := idx.jobStore.EnqueueJob(ctx, job.Job{
-				Dir: mcHandle,
-				Func: func(ctx context.Context) error {
-					return module.DecodeVarsReferences(ctx, idx.modStore, idx.schemaStore, mcPath)
-				},
-				Type:        op.OpTypeDecodeVarsReferences.String(),
-				DependsOn:   job.IDs{varsParseId},
-				IgnoreState: ignoreState,
-			})
-			if err != nil {
-				multierror.Append(errs, err)
-			} else {
-				jobIds = append(jobIds, varsRefId)
-			}
+	if parseId != "" {
+		ids, err := idx.collectReferences(ctx, modHandle, refCollectionDeps, ignoreState)
+		if err != nil {
+			multierror.Append(errs, err)
+		} else {
+			jobIds = append(jobIds, ids...)
+		}
+	}
+
+	varsParseId, err := idx.jobStore.EnqueueJob(ctx, job.Job{
+		Dir: modHandle,
+		Func: func(ctx context.Context) error {
+			return module.ParseVariables(ctx, idx.fs, idx.modStore, modHandle.Path())
+		},
+		Type:        op.OpTypeParseVariables.String(),
+		IgnoreState: ignoreState,
+	})
+	if err != nil {
+		multierror.Append(errs, err)
+	} else {
+		jobIds = append(jobIds, varsParseId)
+	}
+
+	if varsParseId != "" {
+		varsRefId, err := idx.jobStore.EnqueueJob(ctx, job.Job{
+			Dir: modHandle,
+			Func: func(ctx context.Context) error {
+				return module.DecodeVarsReferences(ctx, idx.modStore, idx.schemaStore, modHandle.Path())
+			},
+			Type:        op.OpTypeDecodeVarsReferences.String(),
+			DependsOn:   job.IDs{varsParseId},
+			IgnoreState: ignoreState,
+		})
+		if err != nil {
+			multierror.Append(errs, err)
+		} else {
+			jobIds = append(jobIds, varsRefId)
 		}
 	}
 


### PR DESCRIPTION
Related: https://github.com/hashicorp/terraform-schema/pull/254

The PR is not strictly hard dependency for this one but it is helpful in testing, to verify that the race condition is no longer present.

--- 

## Context

Some time ago, we discovered a race condition, which may not have been as well understood at the time. We needed to make sure that go-to-definition and go-to-references works on first load for module inputs.

Module inputs are represented as reference origins and as with everything else, the attribute schema is what instructs the job collecting the reference origins how and whether to collect those origins. Obtaining the schema for _modules_ is basically the job of [`LoadModuleMetadata`](https://github.com/hashicorp/terraform-ls/blob/da68b876c05ac9b1e46697650d4785da8d498ed0/internal/terraform/module/module_ops.go#L494C8-L537) - in particular we generate the schema based on parsed variables & outputs.

Prior to this PR, we never processed "module calls" directly from `didOpen` or `didChange` and only relied on the walker to get to them by the time we needed them. This would usually work fine if no documents were open at the time of initial walking. Often times though the walking may take a lot of time for larger workspaces and users may open files very early. This meant submodule data was unavailable when the user opened the module which calls those submodules, making the reference origin collection job "clue-less" about those module inputs.

We worked around that race condition by inferring the inputs - basically assuming all declared inputs have their corresponding variable declarations. As with most workarounds, this eventually caught up with us 😅 . In particular, validation (as implemented in https://github.com/hashicorp/terraform-ls/pull/1368) was also acting based on this inferred (potentially incorrect) schema and worse - the inferred schema was assumed to be relevant for all modules with the same `source`.

Therefore, https://github.com/hashicorp/terraform-schema/pull/254 removes the workaround and this PR addresses the race condition.

Technically this may result in more jobs getting scheduled but the overall performance impact should be relatively minimal because:

 - it only impacts open files/modules and the assumption is that users generally don't open _all_ modules that are in their workspace at the same time
 - the jobs exit early if the module data is already available
