### PR TITLE
indexer: Ensure declared module calls get decoded

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/hashicorp/terraform-exec v0.19.0
 	github.com/hashicorp/terraform-json v0.17.1
 	github.com/hashicorp/terraform-registry-address v0.2.2
-	github.com/hashicorp/terraform-schema v0.0.0-20230904125443-90a397096838
+	github.com/hashicorp/terraform-schema v0.0.0-20230908130940-b39f3de08c04
 	github.com/mh-cbon/go-fmt-fail v0.0.0-20160815164508-67765b3fbcb5
 	github.com/mitchellh/cli v1.1.5
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -228,8 +228,8 @@ github.com/hashicorp/terraform-json v0.17.1 h1:eMfvh/uWggKmY7Pmb3T85u86E2EQg6EQH
 github.com/hashicorp/terraform-json v0.17.1/go.mod h1:Huy6zt6euxaY9knPAFKjUITn8QxUFIe9VuSzb4zn/0o=
 github.com/hashicorp/terraform-registry-address v0.2.2 h1:lPQBg403El8PPicg/qONZJDC6YlgCVbWDtNmmZKtBno=
 github.com/hashicorp/terraform-registry-address v0.2.2/go.mod h1:LtwNbCihUoUZ3RYriyS2wF/lGPB6gF9ICLRtuDk7hSo=
-github.com/hashicorp/terraform-schema v0.0.0-20230904125443-90a397096838 h1:sixoZnLpWvkWdPObUKRuDy4dKlStgnkmFjXHqCyUeHQ=
-github.com/hashicorp/terraform-schema v0.0.0-20230904125443-90a397096838/go.mod h1:PXhA8crTZkaqg56PrGKM+fHsOgeaORhmjjTj/7N9kyg=
+github.com/hashicorp/terraform-schema v0.0.0-20230908130940-b39f3de08c04 h1:3Kemwg4PV/HGrACFEthhiLBF6vmZFT34HFHNIUDx19s=
+github.com/hashicorp/terraform-schema v0.0.0-20230908130940-b39f3de08c04/go.mod h1:yxWEW1URl7wekbnH7OEoiwtb7CNYPVeguOv8LwHh0UI=
 github.com/hashicorp/terraform-svchost v0.1.1 h1:EZZimZ1GxdqFRinZ1tpJwVxxt49xc/S52uzrw4x0jKQ=
 github.com/hashicorp/terraform-svchost v0.1.1/go.mod h1:mNsjQfZyf/Jhz35v6/0LWcv26+X7JPS+buii2c9/ctc=
 github.com/hexops/autogold v1.3.1 h1:YgxF9OHWbEIUjhDbpnLhgVsjUDsiHDTyDfy2lrfdlzo=

--- a/internal/indexer/document_change.go
+++ b/internal/indexer/document_change.go
@@ -76,25 +76,50 @@ func (idx *Indexer) decodeModule(ctx context.Context, modHandle document.DirHand
 		Type:        op.OpTypeLoadModuleMetadata.String(),
 		DependsOn:   dependsOn,
 		IgnoreState: ignoreState,
+		Defer: func(ctx context.Context, jobErr error) (jobIds job.IDs, err error) {
+			if jobErr != nil {
+				err = jobErr
+				return
+			}
+			modCalls, mcErr := idx.decodeDeclaredModuleCalls(ctx, modHandle, ignoreState)
+			if mcErr != nil {
+				idx.logger.Printf("decoding declared module calls for %q failed: %s", modHandle.URI, mcErr)
+				// We log the error but still continue scheduling other jobs
+				// which are still valuable for the rest of the configuration
+				// even if they may not have the data for module calls.
+			}
+
+			eSchemaId, err := idx.jobStore.EnqueueJob(ctx, job.Job{
+				Dir: modHandle,
+				Func: func(ctx context.Context) error {
+					return module.PreloadEmbeddedSchema(ctx, idx.logger, schemas.FS, idx.modStore, idx.schemaStore, modHandle.Path())
+				},
+				DependsOn:   modCalls,
+				Type:        op.OpTypePreloadEmbeddedSchema.String(),
+				IgnoreState: ignoreState,
+			})
+			if err != nil {
+				return
+			}
+			jobIds = append(jobIds, eSchemaId)
+
+			refOriginsId, err := idx.jobStore.EnqueueJob(ctx, job.Job{
+				Dir: modHandle,
+				Func: func(ctx context.Context) error {
+					return module.DecodeReferenceOrigins(ctx, idx.modStore, idx.schemaStore, modHandle.Path())
+				},
+				Type:        op.OpTypeDecodeReferenceOrigins.String(),
+				DependsOn:   modCalls,
+				IgnoreState: ignoreState,
+			})
+			jobIds = append(jobIds, refOriginsId)
+			return
+		},
 	})
 	if err != nil {
 		return ids, err
 	}
 	ids = append(ids, metaId)
-
-	eSchemaId, err := idx.jobStore.EnqueueJob(ctx, job.Job{
-		Dir: modHandle,
-		Func: func(ctx context.Context) error {
-			return module.PreloadEmbeddedSchema(ctx, idx.logger, schemas.FS, idx.modStore, idx.schemaStore, modHandle.Path())
-		},
-		DependsOn:   job.IDs{metaId},
-		Type:        op.OpTypePreloadEmbeddedSchema.String(),
-		IgnoreState: ignoreState,
-	})
-	if err != nil {
-		return ids, err
-	}
-	ids = append(ids, eSchemaId)
 
 	refTargetsId, err := idx.jobStore.EnqueueJob(ctx, job.Job{
 		Dir: modHandle,
@@ -109,20 +134,6 @@ func (idx *Indexer) decodeModule(ctx context.Context, modHandle document.DirHand
 		return ids, err
 	}
 	ids = append(ids, refTargetsId)
-
-	refOriginsId, err := idx.jobStore.EnqueueJob(ctx, job.Job{
-		Dir: modHandle,
-		Func: func(ctx context.Context) error {
-			return module.DecodeReferenceOrigins(ctx, idx.modStore, idx.schemaStore, modHandle.Path())
-		},
-		Type:        op.OpTypeDecodeReferenceOrigins.String(),
-		DependsOn:   job.IDs{metaId},
-		IgnoreState: ignoreState,
-	})
-	if err != nil {
-		return ids, err
-	}
-	ids = append(ids, refOriginsId)
 
 	// This job may make an HTTP request, and we schedule it in
 	// the low-priority queue, so we don't want to wait for it.

--- a/internal/indexer/document_change.go
+++ b/internal/indexer/document_change.go
@@ -109,7 +109,7 @@ func (idx *Indexer) decodeModule(ctx context.Context, modHandle document.DirHand
 					return module.DecodeReferenceOrigins(ctx, idx.modStore, idx.schemaStore, modHandle.Path())
 				},
 				Type:        op.OpTypeDecodeReferenceOrigins.String(),
-				DependsOn:   modCalls,
+				DependsOn:   append(modCalls, eSchemaId),
 				IgnoreState: ignoreState,
 			})
 			jobIds = append(jobIds, refOriginsId)

--- a/internal/indexer/module_calls.go
+++ b/internal/indexer/module_calls.go
@@ -39,99 +39,106 @@ func (idx *Indexer) decodeInstalledModuleCalls(ctx context.Context, modHandle do
 		}
 
 		mcHandle := document.DirHandleFromPath(mc.Path)
-		// copy path for queued jobs below
-		mcPath := mc.Path
+		mcJobIds, mcErr := idx.decodeModuleAtPath(ctx, mcHandle, ignoreState)
+		jobIds = append(jobIds, mcJobIds...)
+		multierror.Append(errs, mcErr)
+	}
 
-		refCollectionDeps := make(job.IDs, 0)
+	return jobIds, errs.ErrorOrNil()
+}
 
-		parseId, err := idx.jobStore.EnqueueJob(ctx, job.Job{
-			Dir: mcHandle,
+func (idx *Indexer) decodeModuleAtPath(ctx context.Context, modHandle document.DirHandle, ignoreState bool) (job.IDs, error) {
+	var errs *multierror.Error
+	jobIds := make(job.IDs, 0)
+	refCollectionDeps := make(job.IDs, 0)
+
+	parseId, err := idx.jobStore.EnqueueJob(ctx, job.Job{
+		Dir: modHandle,
+		Func: func(ctx context.Context) error {
+			return module.ParseModuleConfiguration(ctx, idx.fs, idx.modStore, modHandle.Path())
+		},
+		Type:        op.OpTypeParseModuleConfiguration.String(),
+		IgnoreState: ignoreState,
+	})
+	if err != nil {
+		multierror.Append(errs, err)
+	} else {
+		jobIds = append(jobIds, parseId)
+		refCollectionDeps = append(refCollectionDeps, parseId)
+	}
+
+	var metaId job.ID
+	if parseId != "" {
+		metaId, err = idx.jobStore.EnqueueJob(ctx, job.Job{
+			Dir:  modHandle,
+			Type: op.OpTypeLoadModuleMetadata.String(),
 			Func: func(ctx context.Context) error {
-				return module.ParseModuleConfiguration(ctx, idx.fs, idx.modStore, mcPath)
+				return module.LoadModuleMetadata(ctx, idx.modStore, modHandle.Path())
 			},
-			Type:        op.OpTypeParseModuleConfiguration.String(),
+			DependsOn:   job.IDs{parseId},
 			IgnoreState: ignoreState,
 		})
 		if err != nil {
 			multierror.Append(errs, err)
 		} else {
-			jobIds = append(jobIds, parseId)
-			refCollectionDeps = append(refCollectionDeps, parseId)
+			jobIds = append(jobIds, metaId)
+			refCollectionDeps = append(refCollectionDeps, metaId)
 		}
 
-		var metaId job.ID
-		if parseId != "" {
-			metaId, err = idx.jobStore.EnqueueJob(ctx, job.Job{
-				Dir:  mcHandle,
-				Type: op.OpTypeLoadModuleMetadata.String(),
-				Func: func(ctx context.Context) error {
-					return module.LoadModuleMetadata(ctx, idx.modStore, mcPath)
-				},
-				DependsOn:   job.IDs{parseId},
-				IgnoreState: ignoreState,
-			})
-			if err != nil {
-				multierror.Append(errs, err)
-			} else {
-				jobIds = append(jobIds, metaId)
-				refCollectionDeps = append(refCollectionDeps, metaId)
-			}
-
-			eSchemaId, err := idx.jobStore.EnqueueJob(ctx, job.Job{
-				Dir: mcHandle,
-				Func: func(ctx context.Context) error {
-					return module.PreloadEmbeddedSchema(ctx, idx.logger, schemas.FS, idx.modStore, idx.schemaStore, mcPath)
-				},
-				Type:        op.OpTypePreloadEmbeddedSchema.String(),
-				DependsOn:   job.IDs{metaId},
-				IgnoreState: ignoreState,
-			})
-			if err != nil {
-				multierror.Append(errs, err)
-			} else {
-				jobIds = append(jobIds, eSchemaId)
-				refCollectionDeps = append(refCollectionDeps, eSchemaId)
-			}
-		}
-
-		if parseId != "" {
-			ids, err := idx.collectReferences(ctx, mcHandle, refCollectionDeps, ignoreState)
-			if err != nil {
-				multierror.Append(errs, err)
-			} else {
-				jobIds = append(jobIds, ids...)
-			}
-		}
-
-		varsParseId, err := idx.jobStore.EnqueueJob(ctx, job.Job{
-			Dir: mcHandle,
+		eSchemaId, err := idx.jobStore.EnqueueJob(ctx, job.Job{
+			Dir: modHandle,
 			Func: func(ctx context.Context) error {
-				return module.ParseVariables(ctx, idx.fs, idx.modStore, mcPath)
+				return module.PreloadEmbeddedSchema(ctx, idx.logger, schemas.FS, idx.modStore, idx.schemaStore, modHandle.Path())
 			},
-			Type:        op.OpTypeParseVariables.String(),
+			Type:        op.OpTypePreloadEmbeddedSchema.String(),
+			DependsOn:   job.IDs{metaId},
 			IgnoreState: ignoreState,
 		})
 		if err != nil {
 			multierror.Append(errs, err)
 		} else {
-			jobIds = append(jobIds, varsParseId)
+			jobIds = append(jobIds, eSchemaId)
+			refCollectionDeps = append(refCollectionDeps, eSchemaId)
 		}
+	}
 
-		if varsParseId != "" {
-			varsRefId, err := idx.jobStore.EnqueueJob(ctx, job.Job{
-				Dir: mcHandle,
-				Func: func(ctx context.Context) error {
-					return module.DecodeVarsReferences(ctx, idx.modStore, idx.schemaStore, mcPath)
-				},
-				Type:        op.OpTypeDecodeVarsReferences.String(),
-				DependsOn:   job.IDs{varsParseId},
-				IgnoreState: ignoreState,
-			})
-			if err != nil {
-				multierror.Append(errs, err)
-			} else {
-				jobIds = append(jobIds, varsRefId)
-			}
+	if parseId != "" {
+		ids, err := idx.collectReferences(ctx, modHandle, refCollectionDeps, ignoreState)
+		if err != nil {
+			multierror.Append(errs, err)
+		} else {
+			jobIds = append(jobIds, ids...)
+		}
+	}
+
+	varsParseId, err := idx.jobStore.EnqueueJob(ctx, job.Job{
+		Dir: modHandle,
+		Func: func(ctx context.Context) error {
+			return module.ParseVariables(ctx, idx.fs, idx.modStore, modHandle.Path())
+		},
+		Type:        op.OpTypeParseVariables.String(),
+		IgnoreState: ignoreState,
+	})
+	if err != nil {
+		multierror.Append(errs, err)
+	} else {
+		jobIds = append(jobIds, varsParseId)
+	}
+
+	if varsParseId != "" {
+		varsRefId, err := idx.jobStore.EnqueueJob(ctx, job.Job{
+			Dir: modHandle,
+			Func: func(ctx context.Context) error {
+				return module.DecodeVarsReferences(ctx, idx.modStore, idx.schemaStore, modHandle.Path())
+			},
+			Type:        op.OpTypeDecodeVarsReferences.String(),
+			DependsOn:   job.IDs{varsParseId},
+			IgnoreState: ignoreState,
+		})
+		if err != nil {
+			multierror.Append(errs, err)
+		} else {
+			jobIds = append(jobIds, varsRefId)
 		}
 	}
 


### PR DESCRIPTION
Related: https://github.com/hashicorp/terraform-schema/pull/254

The PR is not strictly hard dependency for this one but it is helpful in testing, to verify that the race condition is no longer present.

--- 

## Context

Some time ago, we discovered a race condition, which may not have been as well understood at the time. We needed to make sure that go-to-definition and go-to-references works on first load for module inputs.

Module inputs are represented as reference origins and as with everything else, the attribute schema is what instructs the job collecting the reference origins how and whether to collect those origins. Obtaining the schema for _modules_ is basically the job of [`LoadModuleMetadata`](https://github.com/hashicorp/terraform-ls/blob/da68b876c05ac9b1e46697650d4785da8d498ed0/internal/terraform/module/module_ops.go#L494C8-L537) - in particular we generate the schema based on parsed variables & outputs.

Prior to this PR, we never processed "module calls" directly from `didOpen` or `didChange` and only relied on the walker to get to them by the time we needed them. This would usually work fine if no documents were open at the time of initial walking. Often times though the walking may take a lot of time for larger workspaces and users may open files very early. This meant submodule data was unavailable when the user opened the module which calls those submodules, making the reference origin collection job "clue-less" about those module inputs.

We worked around that race condition by inferring the inputs - basically assuming all declared inputs have their corresponding variable declarations. As with most workarounds, this eventually caught up with us 😅 . In particular, validation (as implemented in https://github.com/hashicorp/terraform-ls/pull/1368) was also acting based on this inferred (potentially incorrect) schema and worse - the inferred schema was assumed to be relevant for all modules with the same `source`.

Therefore, https://github.com/hashicorp/terraform-schema/pull/254 removes the workaround and this PR addresses the race condition.

Technically this may result in more jobs getting scheduled but the overall performance impact should be relatively minimal because:

 - it only impacts open files/modules and the assumption is that users generally don't open _all_ modules that are in their workspace at the same time
 - the jobs exit early if the module data is already available

## Testing

I am frankly not sure how to best test this (in code) as the problem is usually only visible with high enough number of jobs / large workspaces.

I did test it manually in one of our large repositories and can confirm the "go-to-definition" works cca 10 out of 10 times on continuous reload, whereas previously it would end up broken on every ~5th reload.
