### PR TITLE
Run CI on PRs that don't target `main`

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -2,8 +2,6 @@ name: build-pr
 
 on:
   pull_request:
-    branches:
-      - main
 
 env:
   GOPROXY: https://proxy.golang.org/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,8 +2,6 @@ name: test
 
 on:
   pull_request:
-    branches:
-      - main
   push:
     branches:
       - main


### PR DESCRIPTION
Since we started working with feature branches, such as `f-early-validation`, we lost our CI for branches that target that feature branch instead of `main`.

This PR enables the test workflow and build workflow for all PRs.