### PR TITLE
Update diagnostic source to `Terraform`

### DIFF
--- a/internal/terraform/ast/diagnostics.go
+++ b/internal/terraform/ast/diagnostics.go
@@ -4,8 +4,6 @@
 package ast
 
 import (
-	"fmt"
-
 	op "github.com/hashicorp/terraform-ls/internal/terraform/module/operation"
 )
 
@@ -20,18 +18,7 @@ const (
 )
 
 func (d DiagnosticSource) String() string {
-	switch d {
-	case HCLParsingSource:
-		return "HCL"
-	case SchemaValidationSource:
-		return "early validation"
-	case ReferenceValidationSource:
-		return "early validation"
-	case TerraformValidateSource:
-		return "terraform validate"
-	default:
-		panic(fmt.Sprintf("Unknown diagnostic source %d", d))
-	}
+	return "Terraform"
 }
 
 type DiagnosticSourceState map[DiagnosticSource]op.OpState


### PR DESCRIPTION
This PR updates the diagnostic source for all diagnostics we raise to `Terraform`. This makes the most sense from a user perspective, and we can extend this later by introducing codes for individual diagnostics.