### PR TITLE
Introduce `RPCContext` to aid more fine-grained & efficient processing

### DIFF
--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -20,6 +20,18 @@ func (k *contextKey) String() string {
 	return k.Name
 }
 
+type RPCContextData struct {
+	Method string
+	URI    string
+}
+
+func (rpcc RPCContextData) Copy() RPCContextData {
+	return RPCContextData{
+		Method: rpcc.Method,
+		URI:    rpcc.URI,
+	}
+}
+
 var (
 	ctxTfExecPath           = &contextKey{"terraform executable path"}
 	ctxTfExecLogPath        = &contextKey{"terraform executor log path"}
@@ -30,6 +42,7 @@ var (
 	ctxLsVersion            = &contextKey{"language server version"}
 	ctxProgressToken        = &contextKey{"progress token"}
 	ctxExperimentalFeatures = &contextKey{"experimental features"}
+	ctxRPCContext           = &contextKey{"rpc context"}
 )
 
 func missingContextErr(ctxKey *contextKey) *MissingContextErr {
@@ -164,4 +177,12 @@ func ExperimentalFeatures(ctx context.Context) (settings.ExperimentalFeatures, e
 		return settings.ExperimentalFeatures{}, missingContextErr(ctxExperimentalFeatures)
 	}
 	return *expFeatures, nil
+}
+
+func WithRPCContext(ctx context.Context, rpcc RPCContextData) context.Context {
+	return context.WithValue(ctx, ctxRPCContext, rpcc)
+}
+
+func RPCContext(ctx context.Context) RPCContextData {
+	return ctx.Value(ctxRPCContext).(RPCContextData)
 }

--- a/internal/langserver/handlers/initialize.go
+++ b/internal/langserver/handlers/initialize.go
@@ -164,6 +164,8 @@ func (svc *service) Initialize(ctx context.Context, params lsp.InitializeParams)
 	// passing the request context here
 	// Static user-provided paths take precedence over dynamic discovery
 	walkerCtx := context.Background()
+	walkerCtx = lsctx.WithRPCContext(walkerCtx, lsctx.RPCContext(ctx))
+
 	err = svc.closedDirWalker.StartWalking(walkerCtx)
 	if err != nil {
 		return serverCaps, fmt.Errorf("failed to start closedDirWalker: %w", err)

--- a/internal/langserver/handlers/service.go
+++ b/internal/langserver/handlers/service.go
@@ -606,23 +606,38 @@ func handle(ctx context.Context, req *jrpc2.Request, fn interface{}) (interface{
 
 	// We could capture all parameters here but for now we just
 	// opportunistically track the most important ones only.
+	type t struct {
+		URI string `json:"uri,omitempty"`
+	}
 	type p struct {
-		URI     string `json:"uri,omitempty"`
-		RootURI string `json:"rootUri,omitempty"`
+		TextDocument t      `json:"textDocument,omitempty"`
+		RootURI      string `json:"rootUri,omitempty"`
 	}
 	params := p{}
 	err := req.UnmarshalParams(&params)
-	if err == nil {
-		attrs = append(attrs, attribute.KeyValue{
-			Key:   attribute.Key("URI"),
-			Value: attribute.StringValue(string(params.URI)),
-		})
+	if err != nil {
+		return nil, err
 	}
+
+	uri := params.TextDocument.URI
+	if params.RootURI != "" {
+		uri = params.RootURI
+	}
+
+	attrs = append(attrs, attribute.KeyValue{
+		Key:   attribute.Key("URI"),
+		Value: attribute.StringValue(uri),
+	})
 
 	tracer := otel.Tracer(tracerName)
 	ctx, span := tracer.Start(ctx, "rpc:"+req.Method(),
 		trace.WithAttributes(attrs...))
 	defer span.End()
+
+	ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{
+		Method: req.Method(),
+		URI:    uri,
+	})
 
 	result, err := rpch.New(fn)(ctx, req)
 	if ctx.Err() != nil && errors.Is(ctx.Err(), context.Canceled) {

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	lsctx "github.com/hashicorp/terraform-ls/internal/context"
 	"github.com/hashicorp/terraform-ls/internal/document"
 	"github.com/hashicorp/terraform-ls/internal/job"
 	"github.com/hashicorp/terraform-ls/internal/state"
@@ -30,6 +31,7 @@ func TestScheduler_withIgnoreExistingState(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	ctx := context.Background()
+	ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{})
 
 	s := NewScheduler(ss.JobStore, 1, job.LowPriority)
 	s.SetLogger(testLogger())
@@ -92,6 +94,7 @@ func TestScheduler_closedOnly(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	ctx := context.Background()
+	ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{})
 
 	s := NewScheduler(ss.JobStore, 2, job.LowPriority)
 	s.SetLogger(testLogger())
@@ -154,6 +157,7 @@ func TestScheduler_closedAndOpen(t *testing.T) {
 			dirPath := filepath.Join(tmpDir, fmt.Sprintf("folder-x-%d", i))
 
 			ctx := context.Background()
+			ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{})
 			newId, err := ss.JobStore.EnqueueJob(ctx, job.Job{
 				Func: func(c context.Context) error {
 					atomic.AddInt64(&closedJobsExecuted, 1)
@@ -180,6 +184,7 @@ func TestScheduler_closedAndOpen(t *testing.T) {
 			dirPath := filepath.Join(tmpDir, fmt.Sprintf("folder-y-%d", i))
 
 			ctx := context.Background()
+			ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{})
 			newId, err := ss.JobStore.EnqueueJob(ctx, job.Job{
 				Func: func(c context.Context) error {
 					atomic.AddInt64(&openJobsExecuted, 1)
@@ -264,6 +269,7 @@ func BenchmarkScheduler_EnqueueAndWaitForJob_closedOnly(b *testing.B) {
 
 	tmpDir := b.TempDir()
 	ctx := context.Background()
+	ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{})
 
 	s := NewScheduler(ss.JobStore, 1, job.LowPriority)
 	s.Start(ctx)
@@ -305,6 +311,7 @@ func TestScheduler_defer(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	ctx := context.Background()
+	ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{})
 
 	s := NewScheduler(ss.JobStore, 2, job.LowPriority)
 	s.SetLogger(testLogger())
@@ -394,6 +401,7 @@ func TestScheduler_dependsOn(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	ctx := context.Background()
+	ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{})
 
 	s := NewScheduler(ss.JobStore, 2, job.LowPriority)
 	s.SetLogger(testLogger())

--- a/internal/state/jobs_test.go
+++ b/internal/state/jobs_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	lsctx "github.com/hashicorp/terraform-ls/internal/context"
 	"github.com/hashicorp/terraform-ls/internal/document"
 	"github.com/hashicorp/terraform-ls/internal/job"
 )
@@ -27,6 +28,7 @@ func TestJobStore_EnqueueJob(t *testing.T) {
 	}
 
 	ctx := context.Background()
+	ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{})
 	id1, err := ss.JobStore.EnqueueJob(ctx, job.Job{
 		Func: func(ctx context.Context) error {
 			return nil
@@ -81,6 +83,7 @@ func TestJobStore_EnqueueJob_openDir(t *testing.T) {
 	}
 
 	ctx := context.Background()
+	ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{})
 	id, err := ss.JobStore.EnqueueJob(ctx, job.Job{
 		Func: func(ctx context.Context) error {
 			return nil
@@ -159,6 +162,7 @@ func TestJobStore_EnqueueJob_verify(t *testing.T) {
 
 	jobCount := 50
 	ctx := context.Background()
+	ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{})
 
 	for i := 0; i < jobCount; i++ {
 		i := i
@@ -217,6 +221,7 @@ func TestJobStore_DequeueJobsForDir(t *testing.T) {
 	}
 
 	ctx := context.Background()
+	ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{})
 	firstDir := document.DirHandleFromPath("/test-1")
 	_, err = ss.JobStore.EnqueueJob(ctx, job.Job{
 		Func: func(ctx context.Context) error {
@@ -261,6 +266,7 @@ func TestJobStore_AwaitNextJob_closedOnly(t *testing.T) {
 	}
 
 	ctx := context.Background()
+	ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{})
 	firstDir := document.DirHandleFromPath("/test-1")
 	id1, err := ss.JobStore.EnqueueJob(ctx, job.Job{
 		Func: func(ctx context.Context) error {
@@ -324,6 +330,7 @@ func TestJobStore_AwaitNextJob_openOnly(t *testing.T) {
 	}
 
 	ctx := context.Background()
+	ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{})
 	firstDir := document.DirHandleFromPath("/test-1")
 	_, err = ss.JobStore.EnqueueJob(ctx, job.Job{
 		Func: func(ctx context.Context) error {
@@ -387,6 +394,7 @@ func TestJobStore_AwaitNextJob_highPriority(t *testing.T) {
 	}
 
 	ctx := context.Background()
+	ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{})
 	firstDir := document.DirHandleFromPath("/test-1")
 	id1, err := ss.JobStore.EnqueueJob(ctx, job.Job{
 		Func: func(ctx context.Context) error {
@@ -468,6 +476,7 @@ func TestJobStore_AwaitNextJob_lowPriority(t *testing.T) {
 	}
 
 	ctx := context.Background()
+	ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{})
 	firstDir := document.DirHandleFromPath("/test-1")
 	id1, err := ss.JobStore.EnqueueJob(ctx, job.Job{
 		Func: func(ctx context.Context) error {
@@ -564,6 +573,7 @@ func TestJobStore_WaitForJobs(t *testing.T) {
 	}
 
 	ctx := context.Background()
+	ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{})
 	id1, err := ss.JobStore.EnqueueJob(ctx, job.Job{
 		Func: func(ctx context.Context) error {
 			return nil
@@ -605,6 +615,7 @@ func TestJobStore_FinishJob_basic(t *testing.T) {
 	}
 
 	ctx := context.Background()
+	ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{})
 	id1, err := ss.JobStore.EnqueueJob(ctx, job.Job{
 		Func: func(ctx context.Context) error {
 			return nil
@@ -666,6 +677,7 @@ func TestJobStore_FinishJob_defer(t *testing.T) {
 	}
 
 	ctx := context.Background()
+	ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{})
 	id1, err := ss.JobStore.EnqueueJob(ctx, job.Job{
 		Func: func(ctx context.Context) error {
 			return nil
@@ -719,6 +731,7 @@ func TestJobStore_FinishJob_dependsOn(t *testing.T) {
 	}
 
 	ctx := context.Background()
+	ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{})
 	parentId, err := ss.JobStore.EnqueueJob(ctx, job.Job{
 		Func: func(ctx context.Context) error {
 			return nil

--- a/internal/state/module_changes_test.go
+++ b/internal/state/module_changes_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/go-version"
+	lsctx "github.com/hashicorp/terraform-ls/internal/context"
 	"github.com/hashicorp/terraform-ls/internal/document"
 	"github.com/hashicorp/terraform-ls/internal/job"
 	tfaddr "github.com/hashicorp/terraform-registry-address"
@@ -96,6 +97,7 @@ func TestModuleChanges_AwaitNextChangeBatch_maxTimespan(t *testing.T) {
 	modHandle := document.DirHandleFromPath(modPath)
 
 	ctx := context.Background()
+	ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{})
 	_, err = ss.JobStore.EnqueueJob(ctx, job.Job{
 		Func: func(ctx context.Context) error {
 			return nil

--- a/internal/walker/walker_test.go
+++ b/internal/walker/walker_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/go-version"
 	tfjson "github.com/hashicorp/terraform-json"
+	lsctx "github.com/hashicorp/terraform-ls/internal/context"
 	"github.com/hashicorp/terraform-ls/internal/document"
 	"github.com/hashicorp/terraform-ls/internal/filesystem"
 	"github.com/hashicorp/terraform-ls/internal/indexer"
@@ -55,6 +56,7 @@ func TestWalker_basic(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{})
 	err = w.StartWalking(ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -399,6 +401,7 @@ func TestWalker_complexModules(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+			ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{})
 			err = w.StartWalking(ctx)
 			if err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
This is to decouple a small part of https://github.com/hashicorp/terraform-ls/pull/1368 in order to help us make some more performance improvements unrelated to validation, specifically to avoid re-parsing _all_ files on `didOpen` and `didChange` and only parse the one which is being changed.

For end-users, this PR is expected to be no-op.