### PR TITLE
Update ParseModuleConfiguration to only parse changed file

### DIFF
--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -199,3 +199,7 @@ func IsLanguageId(ctx context.Context, expectedLangId string) bool {
 	}
 	return langId == expectedLangId
 }
+
+func (ctxData RPCContextData) IsDidChangeRequest() bool {
+	return ctxData.Method == "textDocument/didChange"
+}

--- a/internal/decoder/decoder_test.go
+++ b/internal/decoder/decoder_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/hashicorp/hcl-lang/decoder"
 	"github.com/hashicorp/hcl-lang/lang"
+	lsctx "github.com/hashicorp/terraform-ls/internal/context"
 	idecoder "github.com/hashicorp/terraform-ls/internal/decoder"
 	"github.com/hashicorp/terraform-ls/internal/state"
 	"github.com/hashicorp/terraform-ls/internal/terraform/module"
@@ -60,6 +61,7 @@ func TestDecoder_CodeLensesForFile_concurrencyBug(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
+		ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{})
 		err = module.ParseModuleConfiguration(ctx, mapFs, ss.Modules, dirName)
 		if err != nil {
 			t.Error(err)

--- a/internal/terraform/ast/module.go
+++ b/internal/terraform/ast/module.go
@@ -55,6 +55,14 @@ func (mf ModFiles) AsMap() map[string]*hcl.File {
 	return m
 }
 
+func (mf ModFiles) Copy() ModFiles {
+	m := make(ModFiles, len(mf))
+	for name, file := range mf {
+		m[name] = file
+	}
+	return m
+}
+
 type ModDiags map[ModFilename]hcl.Diagnostics
 
 func ModDiagsFromMap(m map[string]hcl.Diagnostics) ModDiags {
@@ -79,6 +87,14 @@ func (md ModDiags) AsMap() map[string]hcl.Diagnostics {
 	m := make(map[string]hcl.Diagnostics, len(md))
 	for name, diags := range md {
 		m[string(name)] = diags
+	}
+	return m
+}
+
+func (md ModDiags) Copy() ModDiags {
+	m := make(ModDiags, len(md))
+	for name, diags := range md {
+		m[name] = diags
 	}
 	return m
 }

--- a/internal/terraform/module/module_ops.go
+++ b/internal/terraform/module/module_ops.go
@@ -372,7 +372,7 @@ func ParseModuleConfiguration(ctx context.Context, fs ReadOnlyFS, modStore *stat
 	var diags ast.ModDiags
 	rpcContext := lsctx.RPCContext(ctx)
 	// Only parse the file that's being changed/opened, unless this is 1st-time parsing
-	if mod.ModuleParsingState == op.OpStateLoaded && rpcContext.IsDidChangeRequest() {
+	if mod.ModuleParsingState == op.OpStateLoaded && rpcContext.IsDidChangeRequest() && lsctx.IsLanguageId(ctx, ilsp.Terraform.String()) {
 		// the file has already been parsed, so only examine this file and not the whole module
 		filePath, err := uri.PathFromURI(rpcContext.URI)
 		if err != nil {

--- a/internal/terraform/module/module_ops.go
+++ b/internal/terraform/module/module_ops.go
@@ -374,6 +374,11 @@ func ParseModuleConfiguration(ctx context.Context, fs ReadOnlyFS, modStore *stat
 	// Only parse the file that's being changed/opened, unless this is 1st-time parsing
 	if mod.ModuleParsingState == op.OpStateLoaded && rpcContext.IsDidChangeRequest() && lsctx.IsLanguageId(ctx, ilsp.Terraform.String()) {
 		// the file has already been parsed, so only examine this file and not the whole module
+		err = modStore.SetModuleParsingState(modPath, op.OpStateLoading)
+		if err != nil {
+			return err
+		}
+
 		filePath, err := uri.PathFromURI(rpcContext.URI)
 		if err != nil {
 			return err
@@ -393,6 +398,11 @@ func ParseModuleConfiguration(ctx context.Context, fs ReadOnlyFS, modStore *stat
 		diags = existingDiags
 	} else {
 		// this is the first time file is opened so parse the whole module
+		err = modStore.SetModuleParsingState(modPath, op.OpStateLoading)
+		if err != nil {
+			return err
+		}
+
 		files, diags, err = parser.ParseModuleFiles(fs, modPath)
 	}
 

--- a/internal/terraform/module/module_ops.go
+++ b/internal/terraform/module/module_ops.go
@@ -410,11 +410,6 @@ func ParseModuleConfiguration(ctx context.Context, fs ReadOnlyFS, modStore *stat
 		return err
 	}
 
-	err = modStore.SetModuleParsingState(modPath, op.OpStateLoading)
-	if err != nil {
-		return err
-	}
-
 	sErr := modStore.UpdateParsedModuleFiles(modPath, files, err)
 	if sErr != nil {
 		return sErr

--- a/internal/terraform/module/module_ops.go
+++ b/internal/terraform/module/module_ops.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"io/fs"
 	"log"
+	"path/filepath"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
@@ -373,9 +374,13 @@ func ParseModuleConfiguration(ctx context.Context, fs ReadOnlyFS, modStore *stat
 	// Only parse the file that's being changed/opened, unless this is 1st-time parsing
 	if mod.ModuleParsingState == op.OpStateLoaded && rpcContext.IsDidChangeRequest() {
 		// the file has already been parsed, so only examine this file and not the whole module
-		fileName, _ := uri.PathFromURI(rpcContext.URI)
+		filePath, err := uri.PathFromURI(rpcContext.URI)
+		if err != nil {
+			return err
+		}
+		fileName := filepath.Base(filePath)
 
-		f, fDiags, err := parser.ParseModuleFile(fs, fileName)
+		f, fDiags, err := parser.ParseModuleFile(fs, filePath)
 		if err != nil {
 			return err
 		}

--- a/internal/terraform/module/module_ops_test.go
+++ b/internal/terraform/module/module_ops_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/hashicorp/terraform-ls/internal/document"
 	"github.com/hashicorp/terraform-ls/internal/filesystem"
 	"github.com/hashicorp/terraform-ls/internal/job"
+	ilsp "github.com/hashicorp/terraform-ls/internal/lsp"
 	"github.com/hashicorp/terraform-ls/internal/registry"
 	"github.com/hashicorp/terraform-ls/internal/state"
 	"github.com/hashicorp/terraform-ls/internal/terraform/exec"
@@ -981,6 +982,7 @@ func TestParseModuleConfiguration(t *testing.T) {
 		Method: "textDocument/didChange",
 		URI:    uri.FromPath(fooURI),
 	}
+	ctx = lsctx.WithLanguageId(ctx, ilsp.Terraform.String())
 	ctx = lsctx.WithRPCContext(ctx, x)
 	err = ParseModuleConfiguration(ctx, testFs, ss.Modules, singleFileModulePath)
 	if err != nil {

--- a/internal/terraform/module/module_ops_test.go
+++ b/internal/terraform/module/module_ops_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/hcl-lang/lang"
 	tfjson "github.com/hashicorp/terraform-json"
+	lsctx "github.com/hashicorp/terraform-ls/internal/context"
 	"github.com/hashicorp/terraform-ls/internal/document"
 	"github.com/hashicorp/terraform-ls/internal/filesystem"
 	"github.com/hashicorp/terraform-ls/internal/job"
@@ -56,6 +57,7 @@ func TestGetModuleDataFromRegistry_singleModule(t *testing.T) {
 	}
 
 	fs := filesystem.NewFilesystem(ss.DocumentStore)
+	ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{})
 	err = ParseModuleConfiguration(ctx, fs, ss.Modules, modPath)
 	if err != nil {
 		t.Fatal(err)
@@ -128,6 +130,7 @@ func TestGetModuleDataFromRegistry_moduleNotFound(t *testing.T) {
 	}
 
 	fs := filesystem.NewFilesystem(ss.DocumentStore)
+	ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{})
 	err = ParseModuleConfiguration(ctx, fs, ss.Modules, modPath)
 	if err != nil {
 		t.Fatal(err)
@@ -228,6 +231,7 @@ func TestGetModuleDataFromRegistry_apiTimeout(t *testing.T) {
 	}
 
 	fs := filesystem.NewFilesystem(ss.DocumentStore)
+	ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{})
 	err = ParseModuleConfiguration(ctx, fs, ss.Modules, modPath)
 	if err != nil {
 		t.Fatal(err)
@@ -522,6 +526,7 @@ func TestParseProviderVersions_multipleVersions(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{})
 	err = ParseModuleConfiguration(ctx, fs, ss.Modules, modPathFirst)
 	if err != nil {
 		t.Fatal(err)
@@ -691,6 +696,7 @@ func TestPreloadEmbeddedSchema_basic(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{})
 	err = ParseModuleConfiguration(ctx, cfgFS, ss.Modules, modPath)
 	if err != nil {
 		t.Fatal(err)
@@ -761,6 +767,7 @@ func TestPreloadEmbeddedSchema_unknownProviderOnly(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{})
 	err = ParseModuleConfiguration(ctx, cfgFS, ss.Modules, modPath)
 	if err != nil {
 		t.Fatal(err)
@@ -824,6 +831,7 @@ func TestPreloadEmbeddedSchema_idempotency(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{})
 	err = ParseModuleConfiguration(ctx, cfgFS, ss.Modules, modPath)
 	if err != nil {
 		t.Fatal(err)
@@ -903,6 +911,7 @@ func TestPreloadEmbeddedSchema_raceCondition(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{})
 	err = ParseModuleConfiguration(ctx, cfgFS, ss.Modules, modPath)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/terraform/module/testdata/single-file-change-module/bar.tf
+++ b/internal/terraform/module/testdata/single-file-change-module/bar.tf
@@ -1,0 +1,3 @@
+variable "another" {
+  
+}

--- a/internal/terraform/module/testdata/single-file-change-module/example.tfvars
+++ b/internal/terraform/module/testdata/single-file-change-module/example.tfvars
@@ -1,0 +1,3 @@
+variable "image_id" {
+  type = string
+}

--- a/internal/terraform/module/testdata/single-file-change-module/foo.tf
+++ b/internal/terraform/module/testdata/single-file-change-module/foo.tf
@@ -5,4 +5,4 @@ variable "gogo" {
 
 variable "awesome" {
 
-}
+

--- a/internal/terraform/module/testdata/single-file-change-module/foo.tf
+++ b/internal/terraform/module/testdata/single-file-change-module/foo.tf
@@ -1,0 +1,3 @@
+variable "gogo" {
+
+}

--- a/internal/terraform/module/testdata/single-file-change-module/foo.tf
+++ b/internal/terraform/module/testdata/single-file-change-module/foo.tf
@@ -1,3 +1,8 @@
 variable "gogo" {
 
 }
+
+
+variable "awesome" {
+
+}

--- a/internal/terraform/module/testdata/single-file-change-module/main.tf
+++ b/internal/terraform/module/testdata/single-file-change-module/main.tf
@@ -1,3 +1,3 @@
 variable "wakka" {
   
-}
+

--- a/internal/terraform/module/testdata/single-file-change-module/main.tf
+++ b/internal/terraform/module/testdata/single-file-change-module/main.tf
@@ -1,0 +1,3 @@
+variable "wakka" {
+  
+}

--- a/internal/terraform/parser/module.go
+++ b/internal/terraform/parser/module.go
@@ -52,3 +52,26 @@ func ParseModuleFiles(fs FS, modPath string) (ast.ModFiles, ast.ModDiags, error)
 
 	return files, diags, nil
 }
+
+func ParseModuleFile(fs FS, fileName string) (ast.ModFiles, ast.ModDiags, error) {
+	files := make(ast.ModFiles, 0)
+	diags := make(ast.ModDiags, 0)
+
+	src, err := fs.ReadFile(fileName)
+	if err != nil {
+		// If a file isn't accessible, return
+		return nil, nil, err
+	}
+
+	name := filepath.Base((fileName))
+	filename := ast.ModFilename(name)
+
+	f, pDiags := parseFile(src, filename)
+
+	diags[filename] = pDiags
+	if f != nil {
+		files[filename] = f
+	}
+
+	return files, diags, nil
+}

--- a/internal/terraform/parser/module.go
+++ b/internal/terraform/parser/module.go
@@ -54,14 +54,14 @@ func ParseModuleFiles(fs FS, modPath string) (ast.ModFiles, ast.ModDiags, error)
 	return files, diags, nil
 }
 
-func ParseModuleFile(fs FS, fileName string) (*hcl.File, hcl.Diagnostics, error) {
-	src, err := fs.ReadFile(fileName)
+func ParseModuleFile(fs FS, filePath string) (*hcl.File, hcl.Diagnostics, error) {
+	src, err := fs.ReadFile(filePath)
 	if err != nil {
 		// If a file isn't accessible, return
 		return nil, nil, err
 	}
 
-	name := filepath.Base((fileName))
+	name := filepath.Base(filePath)
 	filename := ast.ModFilename(name)
 
 	f, pDiags := parseFile(src, filename)

--- a/internal/terraform/parser/module.go
+++ b/internal/terraform/parser/module.go
@@ -6,6 +6,7 @@ package parser
 import (
 	"path/filepath"
 
+	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/terraform-ls/internal/terraform/ast"
 )
 
@@ -53,10 +54,7 @@ func ParseModuleFiles(fs FS, modPath string) (ast.ModFiles, ast.ModDiags, error)
 	return files, diags, nil
 }
 
-func ParseModuleFile(fs FS, fileName string) (ast.ModFiles, ast.ModDiags, error) {
-	files := make(ast.ModFiles, 0)
-	diags := make(ast.ModDiags, 0)
-
+func ParseModuleFile(fs FS, fileName string) (*hcl.File, hcl.Diagnostics, error) {
 	src, err := fs.ReadFile(fileName)
 	if err != nil {
 		// If a file isn't accessible, return
@@ -68,10 +66,5 @@ func ParseModuleFile(fs FS, fileName string) (ast.ModFiles, ast.ModDiags, error)
 
 	f, pDiags := parseFile(src, filename)
 
-	diags[filename] = pDiags
-	if f != nil {
-		files[filename] = f
-	}
-
-	return files, diags, nil
+	return f, pDiags, nil
 }


### PR DESCRIPTION
This modifies ParseModuleConfiguration to only parse changed file if file already parsed and this is a didChange request.

Previously ParseModuleConfiguration would reparse not only the changed file but also the module containing the changed file.

Now ParseModuleConfiguration detects if the file has previously been parsed and the request is from a didChange event. If both are true, then it only parses the changed file and skips re-parsing the entire module. If this is false, it falls back to the previous behavior of re-parsing the entire module including the changed file.