### PR TITLE
deps: bump hcl-lang to `aa9b38d`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/hc-install v0.6.0
-	github.com/hashicorp/hcl-lang v0.0.0-20230907132051-3a8b43381d3e
+	github.com/hashicorp/hcl-lang v0.0.0-20230919101450-aa9b38d58c90
 	github.com/hashicorp/hcl/v2 v2.18.0
 	github.com/hashicorp/terraform-exec v0.19.0
 	github.com/hashicorp/terraform-json v0.17.1

--- a/go.sum
+++ b/go.sum
@@ -218,8 +218,8 @@ github.com/hashicorp/hc-install v0.6.0 h1:fDHnU7JNFNSQebVKYhHZ0va1bC6SrPQ8fpebsv
 github.com/hashicorp/hc-install v0.6.0/go.mod h1:10I912u3nntx9Umo1VAeYPUUuehk0aRQJYpMwbX5wQA=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/hashicorp/hcl-lang v0.0.0-20230907132051-3a8b43381d3e h1:IQnftgh21WgQDKfPsgyL5aMnNoRny6a7v2B6J6OvXNU=
-github.com/hashicorp/hcl-lang v0.0.0-20230907132051-3a8b43381d3e/go.mod h1:67DxtN9WnM5dTdDPFn79G2Azgs9b5/8yOKP5LU2XBIc=
+github.com/hashicorp/hcl-lang v0.0.0-20230919101450-aa9b38d58c90 h1:xjvAry2znjLKjs5h8YQ5SBYOkTI9cAlPxoPjThTEIuM=
+github.com/hashicorp/hcl-lang v0.0.0-20230919101450-aa9b38d58c90/go.mod h1:67DxtN9WnM5dTdDPFn79G2Azgs9b5/8yOKP5LU2XBIc=
 github.com/hashicorp/hcl/v2 v2.18.0 h1:wYnG7Lt31t2zYkcquwgKo6MWXzRUDIeIVU5naZwHLl8=
 github.com/hashicorp/hcl/v2 v2.18.0/go.mod h1:ThLC89FV4p9MPW804KVbe/cEXoQ8NZEh+JtMeeGErHE=
 github.com/hashicorp/terraform-exec v0.19.0 h1:FpqZ6n50Tk95mItTSS9BjeOVUb4eg81SpgVtZNNtFSM=


### PR DESCRIPTION
This brings in https://github.com/hashicorp/hcl-lang/pull/318

The PR is expected to be no-op for users in the context of the `main` branch but I do expect us to need to make changes in https://github.com/hashicorp/terraform-ls/pull/1368 either in an isolated PR or as part of https://github.com/hashicorp/terraform-ls/pull/1413

The hope here is we can at least keep dependency changes in `main` and keep rebasing mostly free of conflicts.