### PR TITLE
early validation - bump `hcl-lang` and reflect upstream changes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/hc-install v0.6.0
-	github.com/hashicorp/hcl-lang v0.0.0-20230907132051-3a8b43381d3e
+	github.com/hashicorp/hcl-lang v0.0.0-20230919101450-aa9b38d58c90
 	github.com/hashicorp/hcl/v2 v2.18.0
 	github.com/hashicorp/terraform-exec v0.19.0
 	github.com/hashicorp/terraform-json v0.17.1

--- a/go.sum
+++ b/go.sum
@@ -218,8 +218,8 @@ github.com/hashicorp/hc-install v0.6.0 h1:fDHnU7JNFNSQebVKYhHZ0va1bC6SrPQ8fpebsv
 github.com/hashicorp/hc-install v0.6.0/go.mod h1:10I912u3nntx9Umo1VAeYPUUuehk0aRQJYpMwbX5wQA=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/hashicorp/hcl-lang v0.0.0-20230907132051-3a8b43381d3e h1:IQnftgh21WgQDKfPsgyL5aMnNoRny6a7v2B6J6OvXNU=
-github.com/hashicorp/hcl-lang v0.0.0-20230907132051-3a8b43381d3e/go.mod h1:67DxtN9WnM5dTdDPFn79G2Azgs9b5/8yOKP5LU2XBIc=
+github.com/hashicorp/hcl-lang v0.0.0-20230919101450-aa9b38d58c90 h1:xjvAry2znjLKjs5h8YQ5SBYOkTI9cAlPxoPjThTEIuM=
+github.com/hashicorp/hcl-lang v0.0.0-20230919101450-aa9b38d58c90/go.mod h1:67DxtN9WnM5dTdDPFn79G2Azgs9b5/8yOKP5LU2XBIc=
 github.com/hashicorp/hcl/v2 v2.18.0 h1:wYnG7Lt31t2zYkcquwgKo6MWXzRUDIeIVU5naZwHLl8=
 github.com/hashicorp/hcl/v2 v2.18.0/go.mod h1:ThLC89FV4p9MPW804KVbe/cEXoQ8NZEh+JtMeeGErHE=
 github.com/hashicorp/terraform-exec v0.19.0 h1:FpqZ6n50Tk95mItTSS9BjeOVUb4eg81SpgVtZNNtFSM=

--- a/internal/decoder/decoder.go
+++ b/internal/decoder/decoder.go
@@ -30,6 +30,7 @@ func modulePathContext(mod *state.Module, schemaReader state.SchemaReader, modRe
 		ReferenceTargets: make(reference.Targets, 0),
 		Files:            make(map[string]*hcl.File, 0),
 		Functions:        coreFunctions(mod),
+		Validators:       moduleValidators,
 	}
 
 	for _, origin := range mod.RefOrigins {

--- a/internal/decoder/validators.go
+++ b/internal/decoder/validators.go
@@ -1,0 +1,19 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package decoder
+
+import (
+	"github.com/hashicorp/hcl-lang/validator"
+)
+
+var moduleValidators = []validator.Validator{
+	validator.BlockLabelsLength{},
+	validator.DeprecatedAttribute{},
+	validator.DeprecatedBlock{},
+	validator.MaxBlocks{},
+	validator.MinBlocks{},
+	validator.MissingRequiredAttribute{},
+	validator.UnexpectedAttribute{},
+	validator.UnexpectedBlock{},
+}


### PR DESCRIPTION
This is another attempt to keep diffs small and resolve conflicts early.

We made some changes in https://github.com/hashicorp/hcl-lang/pull/318 and while cherry-picking the dependency bump to the feature branch, I'm also making updates to keep things working as before.