### PR TITLE
Update ParseVariables for single files

### DIFF
--- a/internal/terraform/ast/variables.go
+++ b/internal/terraform/ast/variables.go
@@ -52,9 +52,9 @@ func VarsFilesFromMap(m map[string]*hcl.File) VarsFiles {
 	return mf
 }
 
-func (mf VarsFiles) Copy() VarsFiles {
-	m := make(VarsFiles, len(mf))
-	for name, file := range mf {
+func (vf VarsFiles) Copy() VarsFiles {
+	m := make(VarsFiles, len(vf))
+	for name, file := range vf {
 		m[name] = file
 	}
 	return m
@@ -70,9 +70,9 @@ func VarsDiagsFromMap(m map[string]hcl.Diagnostics) VarsDiags {
 	return mf
 }
 
-func (mf VarsDiags) Copy() VarsDiags {
-	m := make(VarsDiags, len(mf))
-	for name, file := range mf {
+func (vd VarsDiags) Copy() VarsDiags {
+	m := make(VarsDiags, len(vd))
+	for name, file := range vd {
 		m[name] = file
 	}
 	return m

--- a/internal/terraform/ast/variables.go
+++ b/internal/terraform/ast/variables.go
@@ -52,6 +52,14 @@ func VarsFilesFromMap(m map[string]*hcl.File) VarsFiles {
 	return mf
 }
 
+func (mf VarsFiles) Copy() VarsFiles {
+	m := make(VarsFiles, len(mf))
+	for name, file := range mf {
+		m[name] = file
+	}
+	return m
+}
+
 type VarsDiags map[VarsFilename]hcl.Diagnostics
 
 func VarsDiagsFromMap(m map[string]hcl.Diagnostics) VarsDiags {
@@ -60,6 +68,14 @@ func VarsDiagsFromMap(m map[string]hcl.Diagnostics) VarsDiags {
 		mf[VarsFilename(name)] = file
 	}
 	return mf
+}
+
+func (mf VarsDiags) Copy() VarsDiags {
+	m := make(VarsDiags, len(mf))
+	for name, file := range mf {
+		m[name] = file
+	}
+	return m
 }
 
 func (vd VarsDiags) AutoloadedOnly() VarsDiags {

--- a/internal/terraform/module/module_ops.go
+++ b/internal/terraform/module/module_ops.go
@@ -465,7 +465,7 @@ func ParseVariables(ctx context.Context, fs ReadOnlyFS, modStore *state.ModuleSt
 	var diags ast.VarsDiags
 	rpcContext := lsctx.DocumentContext(ctx)
 	// Only parse the file that's being changed/opened, unless this is 1st-time parsing
-	if mod.ModuleDiagnosticsState[ast.HCLParsingSource] == op.OpStateLoaded && rpcContext.IsDidChangeRequest() && rpcContext.LanguageID == ilsp.Terraform.String() {
+	if mod.ModuleDiagnosticsState[ast.HCLParsingSource] == op.OpStateLoaded && rpcContext.IsDidChangeRequest() && rpcContext.LanguageID == ilsp.Tfvars.String() {
 		// the file has already been parsed, so only examine this file and not the whole module
 		err = modStore.SetVarsDiagnosticsState(modPath, ast.HCLParsingSource, op.OpStateLoading)
 		if err != nil {

--- a/internal/terraform/module/module_ops.go
+++ b/internal/terraform/module/module_ops.go
@@ -477,7 +477,7 @@ func ParseVariables(ctx context.Context, fs ReadOnlyFS, modStore *state.ModuleSt
 		}
 		fileName := filepath.Base(filePath)
 
-		f, vdiags, err := parser.ParseVariableFile(fs, filePath)
+		f, vDiags, err := parser.ParseVariableFile(fs, filePath)
 		if err != nil {
 			return err
 		}
@@ -492,7 +492,7 @@ func ParseVariables(ctx context.Context, fs ReadOnlyFS, modStore *state.ModuleSt
 		} else {
 			existingDiags = existingDiags.Copy()
 		}
-		existingDiags[ast.VarsFilename(fileName)] = vdiags
+		existingDiags[ast.VarsFilename(fileName)] = vDiags
 		diags = existingDiags
 	} else {
 		// this is the first time file is opened so parse the whole module

--- a/internal/terraform/module/module_ops.go
+++ b/internal/terraform/module/module_ops.go
@@ -463,9 +463,9 @@ func ParseVariables(ctx context.Context, fs ReadOnlyFS, modStore *state.ModuleSt
 
 	var files ast.VarsFiles
 	var diags ast.VarsDiags
-	rpcContext := lsctx.RPCContext(ctx)
+	rpcContext := lsctx.DocumentContext(ctx)
 	// Only parse the file that's being changed/opened, unless this is 1st-time parsing
-	if mod.ModuleDiagnosticsState[ast.HCLParsingSource] == op.OpStateLoaded && rpcContext.IsDidChangeRequest() && lsctx.IsLanguageId(ctx, ilsp.Tfvars.String()) {
+	if mod.ModuleDiagnosticsState[ast.HCLParsingSource] == op.OpStateLoaded && rpcContext.IsDidChangeRequest() && rpcContext.LanguageID == ilsp.Terraform.String() {
 		// the file has already been parsed, so only examine this file and not the whole module
 		err = modStore.SetVarsDiagnosticsState(modPath, ast.HCLParsingSource, op.OpStateLoading)
 		if err != nil {

--- a/internal/terraform/module/module_ops_test.go
+++ b/internal/terraform/module/module_ops_test.go
@@ -1110,8 +1110,7 @@ func TestParseVariables(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ctx = lsctx.WithLanguageId(ctx, ilsp.Tfvars.String())
-	ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{})
+	ctx = lsctx.WithDocumentContext(ctx, lsctx.Document{})
 	err = ParseModuleConfiguration(ctx, testFs, ss.Modules, singleFileModulePath)
 	if err != nil {
 		t.Fatal(err)
@@ -1131,15 +1130,14 @@ func TestParseVariables(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	rpcData := lsctx.RPCContextData{
-		Method: "textDocument/didChange",
-		URI:    uri.FromPath(fileURI),
-	}
 
 	// ignore job state
 	ctx = job.WithIgnoreState(ctx, true)
-	ctx = lsctx.WithLanguageId(ctx, ilsp.Tfvars.String())
-	ctx = lsctx.WithRPCContext(ctx, rpcData)
+
+	ctx = lsctx.WithDocumentContext(ctx, lsctx.Document{
+		Method: "textDocument/didChange",
+		URI:    uri.FromPath(fileURI),
+	})
 	err = ParseVariables(ctx, testFs, ss.Modules, singleFileModulePath)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/terraform/module/module_ops_test.go
+++ b/internal/terraform/module/module_ops_test.go
@@ -1135,9 +1135,9 @@ func TestParseVariables(t *testing.T) {
 		t.Fatal(err)
 	}
 	ctx = lsctx.WithDocumentContext(ctx, lsctx.Document{
-		Method: "textDocument/didChange",
+		Method:     "textDocument/didChange",
 		LanguageID: ilsp.Tfvars.String(),
-		URI:    uri.FromPath(fileURI),
+		URI:        uri.FromPath(fileURI),
 	})
 	err = ParseVariables(ctx, testFs, ss.Modules, singleFileModulePath)
 	if err != nil {

--- a/internal/terraform/module/module_ops_test.go
+++ b/internal/terraform/module/module_ops_test.go
@@ -14,7 +14,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
-	"reflect"
 	"sync"
 	"testing"
 	"testing/fstest"
@@ -1162,14 +1161,12 @@ func TestParseVariables(t *testing.T) {
 		t.Fatal("diags should mismatch")
 	}
 
-	// diags should change for example.tfvars
-	if diff := cmp.Diff(beforeDiags[ast.VarsFilename("example.tfvars")][0], afterDiags[ast.VarsFilename("example.tfvars")][0], ctydebug.CmpOptions); diff != "" {
-		t.Fatalf("diags should mismatch: %s", diff)
+	if before.ParsedVarsFiles["nochange.tfvars"] != after.ParsedVarsFiles["nochange.tfvars"] {
+		t.Fatal("unchanged file should match")
 	}
 
-	// diags should change for example.tfvars
-	if reflect.DeepEqual(beforeDiags[ast.VarsFilename("example.tfvars")][0], afterDiags[ast.VarsFilename("example.tfvars")][0]) == false {
-		t.Fatalf("diags should mismatch")
+	if beforeDiags[ast.VarsFilename("nochange.tfvars")][0] != afterDiags[ast.VarsFilename("nochange.tfvars")][0] {
+		t.Fatal("diags should match for unchanged file")
 	}
 }
 

--- a/internal/terraform/module/module_ops_test.go
+++ b/internal/terraform/module/module_ops_test.go
@@ -1129,14 +1129,14 @@ func TestParseVariables(t *testing.T) {
 	ctx = job.WithIgnoreState(ctx, true)
 
 	// say we're coming from did_change request
-	fileURI, err := filepath.Abs(filepath.Join(singleFileModulePath, "example.tfvars"))
+	filePath, err := filepath.Abs(filepath.Join(singleFileModulePath, "example.tfvars"))
 	if err != nil {
 		t.Fatal(err)
 	}
 	ctx = lsctx.WithDocumentContext(ctx, lsctx.Document{
 		Method:     "textDocument/didChange",
 		LanguageID: ilsp.Tfvars.String(),
-		URI:        uri.FromPath(fileURI),
+		URI:        uri.FromPath(filePath),
 	})
 	err = ParseVariables(ctx, testFs, ss.Modules, singleFileModulePath)
 	if err != nil {
@@ -1368,14 +1368,14 @@ func TestSchemaVarsValidation_SingleFile(t *testing.T) {
 	}
 
 	fs := filesystem.NewFilesystem(ss.DocumentStore)
-	fooURI, err := filepath.Abs(filepath.Join(modPath, "terraform.tfvars"))
+	filePath, err := filepath.Abs(filepath.Join(modPath, "terraform.tfvars"))
 	if err != nil {
 		t.Fatal(err)
 	}
 	ctx = lsctx.WithDocumentContext(ctx, lsctx.Document{
 		Method:     "textDocument/didChange",
 		LanguageID: ilsp.Tfvars.String(),
-		URI:        uri.FromPath(fooURI),
+		URI:        uri.FromPath(filePath),
 	})
 	err = ParseModuleConfiguration(ctx, fs, ss.Modules, modPath)
 	if err != nil {

--- a/internal/terraform/module/module_ops_test.go
+++ b/internal/terraform/module/module_ops_test.go
@@ -1366,6 +1366,7 @@ func TestSchemaVarsValidation_SingleFile(t *testing.T) {
 	}
 	ctx = lsctx.WithDocumentContext(ctx, lsctx.Document{
 		Method: "textDocument/didChange",
+		LanguageID: ilsp.Tfvars.String(),
 		URI:    uri.FromPath(fooURI),
 	})
 	err = ParseModuleConfiguration(ctx, fs, ss.Modules, modPath)

--- a/internal/terraform/module/module_ops_test.go
+++ b/internal/terraform/module/module_ops_test.go
@@ -1134,6 +1134,7 @@ func TestParseVariables(t *testing.T) {
 	x := lsctx.RPCContextData{
 		Method: "textDocument/didChange",
 		URI:    uri.FromPath(fooURI),
+		// URI:    "file:///test/example.tfvars",
 	}
 
 	// ignore job state
@@ -1366,10 +1367,13 @@ func TestSchemaVarsValidation_SingleFile(t *testing.T) {
 	}
 
 	fs := filesystem.NewFilesystem(ss.DocumentStore)
+	fooURI, err := filepath.Abs(filepath.Join(modPath, "terraform.tfvars"))
+	if err != nil {
+		t.Fatal(err)
+	}
 	ctx = lsctx.WithDocumentContext(ctx, lsctx.Document{
-		Method:     "textDocument/didChange",
-		LanguageID: ilsp.Tfvars.String(),
-		URI:        "file:///test/terraform.tfvars",
+		Method: "textDocument/didChange",
+		URI:    uri.FromPath(fooURI),
 	})
 	err = ParseModuleConfiguration(ctx, fs, ss.Modules, modPath)
 	if err != nil {

--- a/internal/terraform/module/module_ops_test.go
+++ b/internal/terraform/module/module_ops_test.go
@@ -1365,9 +1365,9 @@ func TestSchemaVarsValidation_SingleFile(t *testing.T) {
 		t.Fatal(err)
 	}
 	ctx = lsctx.WithDocumentContext(ctx, lsctx.Document{
-		Method: "textDocument/didChange",
+		Method:     "textDocument/didChange",
 		LanguageID: ilsp.Tfvars.String(),
-		URI:    uri.FromPath(fooURI),
+		URI:        uri.FromPath(fooURI),
 	})
 	err = ParseModuleConfiguration(ctx, fs, ss.Modules, modPath)
 	if err != nil {

--- a/internal/terraform/module/module_ops_test.go
+++ b/internal/terraform/module/module_ops_test.go
@@ -1127,20 +1127,19 @@ func TestParseVariables(t *testing.T) {
 	}
 
 	// say we're coming from did_change request
-	fooURI, err := filepath.Abs(filepath.Join(singleFileModulePath, "example.tfvars"))
+	fileURI, err := filepath.Abs(filepath.Join(singleFileModulePath, "example.tfvars"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	x := lsctx.RPCContextData{
+	rpcData := lsctx.RPCContextData{
 		Method: "textDocument/didChange",
-		URI:    uri.FromPath(fooURI),
-		// URI:    "file:///test/example.tfvars",
+		URI:    uri.FromPath(fileURI),
 	}
 
 	// ignore job state
 	ctx = job.WithIgnoreState(ctx, true)
 	ctx = lsctx.WithLanguageId(ctx, ilsp.Tfvars.String())
-	ctx = lsctx.WithRPCContext(ctx, x)
+	ctx = lsctx.WithRPCContext(ctx, rpcData)
 	err = ParseVariables(ctx, testFs, ss.Modules, singleFileModulePath)
 	if err != nil {
 		t.Fatal(err)
@@ -1156,15 +1155,11 @@ func TestParseVariables(t *testing.T) {
 		t.Fatal("file should mismatch")
 	}
 
-	b := before.VarsDiagnostics[ast.HCLParsingSource]
-	ex := b[ast.VarsFilename("example.tfvars")]
+	beforeDiags := before.VarsDiagnostics[ast.HCLParsingSource]
+	afterDiags := after.VarsDiagnostics[ast.HCLParsingSource]
 
-	a := after.VarsDiagnostics[ast.HCLParsingSource]
-	exA := a[ast.VarsFilename("example.tfvars")]
-
-	// // diags should change for example.tfvars
-	if ex[0] == exA[0] {
-		// if before.VarsDiagnostics["example.tfvars"][0] == after.VarsDiagnostics["example.tfvars"][0] {
+	// diags should change for example.tfvars
+	if beforeDiags[ast.VarsFilename("example.tfvars")][0] == afterDiags[ast.VarsFilename("example.tfvars")][0] {
 		t.Fatal("diags should mismatch")
 	}
 }

--- a/internal/terraform/module/testdata/single-file-change-module/example.tfvars
+++ b/internal/terraform/module/testdata/single-file-change-module/example.tfvars
@@ -1,3 +1,6 @@
 variable "image_id" {
   type = string
 }
+
+# this is supposed to generate a diagnostic
+lalalalal "goo"

--- a/internal/terraform/module/testdata/single-file-change-module/nochange.tfvars
+++ b/internal/terraform/module/testdata/single-file-change-module/nochange.tfvars
@@ -1,3 +1,3 @@
 variable "no_change_id" {
   type = string
-}
+

--- a/internal/terraform/module/testdata/single-file-change-module/nochange.tfvars
+++ b/internal/terraform/module/testdata/single-file-change-module/nochange.tfvars
@@ -1,0 +1,3 @@
+variable "no_change_id" {
+  type = string
+}

--- a/internal/terraform/parser/variables.go
+++ b/internal/terraform/parser/variables.go
@@ -6,6 +6,7 @@ package parser
 import (
 	"path/filepath"
 
+	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/terraform-ls/internal/terraform/ast"
 )
 
@@ -47,4 +48,18 @@ func ParseVariableFiles(fs FS, modPath string) (ast.VarsFiles, ast.VarsDiags, er
 	}
 
 	return files, diags, nil
+}
+
+func ParseVariableFile(fs FS, filePath string) (*hcl.File, hcl.Diagnostics, error) {
+	src, err := fs.ReadFile(filePath)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	name := filepath.Base(filePath)
+	filename := ast.VarsFilename(name)
+
+	f, pDiags := parseFile(src, filename)
+
+	return f, pDiags, nil
 }


### PR DESCRIPTION
Modifies ParsedVarsFiles to only re-parse the single tfvars file which is being changed, if the job was scheduled as part of `textDocument/didChange` request.

This is a follow up to https://github.com/hashicorp/terraform-ls/pull/1404 which updated the parsing job for terraform files.
