### PR TITLE
deps: Bump terraform-schema to `7b256e6c65f9`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/hashicorp/terraform-exec v0.19.0
 	github.com/hashicorp/terraform-json v0.17.1
 	github.com/hashicorp/terraform-registry-address v0.2.2
-	github.com/hashicorp/terraform-schema v0.0.0-20230908130940-b39f3de08c04
+	github.com/hashicorp/terraform-schema v0.0.0-20230929090311-7b256e6c65f9
 	github.com/mh-cbon/go-fmt-fail v0.0.0-20160815164508-67765b3fbcb5
 	github.com/mitchellh/cli v1.1.5
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -228,8 +228,8 @@ github.com/hashicorp/terraform-json v0.17.1 h1:eMfvh/uWggKmY7Pmb3T85u86E2EQg6EQH
 github.com/hashicorp/terraform-json v0.17.1/go.mod h1:Huy6zt6euxaY9knPAFKjUITn8QxUFIe9VuSzb4zn/0o=
 github.com/hashicorp/terraform-registry-address v0.2.2 h1:lPQBg403El8PPicg/qONZJDC6YlgCVbWDtNmmZKtBno=
 github.com/hashicorp/terraform-registry-address v0.2.2/go.mod h1:LtwNbCihUoUZ3RYriyS2wF/lGPB6gF9ICLRtuDk7hSo=
-github.com/hashicorp/terraform-schema v0.0.0-20230908130940-b39f3de08c04 h1:3Kemwg4PV/HGrACFEthhiLBF6vmZFT34HFHNIUDx19s=
-github.com/hashicorp/terraform-schema v0.0.0-20230908130940-b39f3de08c04/go.mod h1:yxWEW1URl7wekbnH7OEoiwtb7CNYPVeguOv8LwHh0UI=
+github.com/hashicorp/terraform-schema v0.0.0-20230929090311-7b256e6c65f9 h1:GHUh3aw3xny2pZZAkc/8N+Iu2tEk1JNRksDyOg5eQVU=
+github.com/hashicorp/terraform-schema v0.0.0-20230929090311-7b256e6c65f9/go.mod h1:yxWEW1URl7wekbnH7OEoiwtb7CNYPVeguOv8LwHh0UI=
 github.com/hashicorp/terraform-svchost v0.1.1 h1:EZZimZ1GxdqFRinZ1tpJwVxxt49xc/S52uzrw4x0jKQ=
 github.com/hashicorp/terraform-svchost v0.1.1/go.mod h1:mNsjQfZyf/Jhz35v6/0LWcv26+X7JPS+buii2c9/ctc=
 github.com/hexops/autogold v1.3.1 h1:YgxF9OHWbEIUjhDbpnLhgVsjUDsiHDTyDfy2lrfdlzo=

--- a/internal/langserver/handlers/complete_test.go
+++ b/internal/langserver/handlers/complete_test.go
@@ -537,6 +537,26 @@ func TestModuleCompletion_withValidData_tooNewVersion(t *testing.T) {
 						}
 					},
 					{
+						"label": "nullable",
+						"kind": 10,
+						"detail": "optional, bool",
+						"documentation": "Specifies whether null is a valid value for this variable",
+						"insertTextFormat": 1,
+						"textEdit": {
+							"range": {
+								"start": {
+									"line": 1,
+									"character": 0
+								},
+								"end": {
+									"line": 1,
+									"character": 0
+								}
+							},
+							"newText": "nullable"
+						}
+					},
+					{
 						"label": "sensitive",
 						"kind": 10,
 						"detail": "optional, bool",


### PR DESCRIPTION
This brings in the following changes related to the upcoming 1.6 release:

 - https://github.com/hashicorp/terraform-schema/pull/257
 - https://github.com/hashicorp/terraform-schema/pull/260
 - https://github.com/hashicorp/terraform-schema/pull/261
 - https://github.com/hashicorp/terraform-schema/pull/262
 - https://github.com/hashicorp/terraform-schema/pull/263
 - https://github.com/hashicorp/terraform-schema/pull/265
 - https://github.com/hashicorp/terraform-schema/pull/266
 - https://github.com/hashicorp/terraform-schema/pull/267