### PR TITLE
Update early validation setting to `enabled` by default

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/hashicorp/terraform-json v0.17.1
 	github.com/hashicorp/terraform-registry-address v0.2.2
 	github.com/hashicorp/terraform-schema v0.0.0-20230929090311-7b256e6c65f9
+	github.com/mcuadros/go-defaults v1.2.0
 	github.com/mh-cbon/go-fmt-fail v0.0.0-20160815164508-67765b3fbcb5
 	github.com/mitchellh/cli v1.1.5
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -289,6 +289,8 @@ github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.14 h1:+xnbZSEeDbOIg5/mE6JF0w6n9duR1l3/WmbinWVwUuU=
 github.com/mattn/go-runewidth v0.0.14/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
+github.com/mcuadros/go-defaults v1.2.0 h1:FODb8WSf0uGaY8elWJAkoLL0Ri6AlZ1bFlenk56oZtc=
+github.com/mcuadros/go-defaults v1.2.0/go.mod h1:WEZtHEVIGYVDqkKSWBdWKUVdRyKlMfulPaGDWIVeCWY=
 github.com/mh-cbon/go-fmt-fail v0.0.0-20160815164508-67765b3fbcb5 h1:shw+DWUaHIyW64Tv30ASCbC6QO6fLy+M5SJb5pJVEI4=
 github.com/mh-cbon/go-fmt-fail v0.0.0-20160815164508-67765b3fbcb5/go.mod h1:nHPoxaBUc5CDAMIv0MNmn5PBjWbTs9BI/eh30/n0U6g=
 github.com/mitchellh/cli v1.1.5 h1:OxRIeJXpAMztws/XHlN2vu6imG5Dpq+j61AzAX5fLng=

--- a/internal/indexer/document_change.go
+++ b/internal/indexer/document_change.go
@@ -54,7 +54,7 @@ func (idx *Indexer) DocumentChanged(ctx context.Context, modHandle document.DirH
 		return ids, err
 	}
 
-	if validationOptions.EarlyValidation {
+	if validationOptions.EnableEnhancedValidation {
 		_, err = idx.jobStore.EnqueueJob(ctx, job.Job{
 			Dir: modHandle,
 			Func: func(ctx context.Context) error {
@@ -132,7 +132,7 @@ func (idx *Indexer) decodeModule(ctx context.Context, modHandle document.DirHand
 			}
 			ids = append(ids, eSchemaId)
 
-			if validationOptions.EarlyValidation {
+			if validationOptions.EnableEnhancedValidation {
 				_, err = idx.jobStore.EnqueueJob(ctx, job.Job{
 					Dir: modHandle,
 					Func: func(ctx context.Context) error {
@@ -175,7 +175,7 @@ func (idx *Indexer) decodeModule(ctx context.Context, modHandle document.DirHand
 			}
 			ids = append(ids, refOriginsId)
 
-			if validationOptions.EarlyValidation {
+			if validationOptions.EnableEnhancedValidation {
 				_, err = idx.jobStore.EnqueueJob(ctx, job.Job{
 					Dir: modHandle,
 					Func: func(ctx context.Context) error {

--- a/internal/indexer/document_open.go
+++ b/internal/indexer/document_open.go
@@ -78,7 +78,7 @@ func (idx *Indexer) DocumentOpened(ctx context.Context, modHandle document.DirHa
 		return ids, err
 	}
 
-	if validationOptions.EarlyValidation {
+	if validationOptions.EnableEnhancedValidation {
 		_, err = idx.jobStore.EnqueueJob(ctx, job.Job{
 			Dir: modHandle,
 			Func: func(ctx context.Context) error {

--- a/internal/langserver/handlers/initialize.go
+++ b/internal/langserver/handlers/initialize.go
@@ -220,7 +220,7 @@ func getTelemetryProperties(out *settings.DecodedOptions) map[string]interface{}
 	properties["options.terraform.path"] = len(out.Options.Terraform.Path) > 0
 	properties["options.terraform.timeout"] = out.Options.Terraform.Timeout
 	properties["options.terraform.logFilePath"] = len(out.Options.Terraform.LogFilePath) > 0
-	properties["options.validation.earlyValidation"] = out.Options.Validation.EarlyValidation
+	properties["options.validation.earlyValidation"] = out.Options.Validation.EnableEnhancedValidation
 
 	return properties
 }

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-ls/internal/terraform/datadir"
+	"github.com/mcuadros/go-defaults"
 	"github.com/mitchellh/mapstructure"
 )
 
@@ -19,7 +20,7 @@ type ExperimentalFeatures struct {
 }
 
 type ValidationOptions struct {
-	EnableEnhancedValidation bool `mapstructure:"earlyValidation"`
+	EnableEnhancedValidation bool `mapstructure:"earlyValidation" default:"true"`
 }
 
 type Indexing struct {
@@ -91,7 +92,12 @@ type DecodedOptions struct {
 
 func DecodeOptions(input interface{}) (*DecodedOptions, error) {
 	var md mapstructure.Metadata
-	var options Options
+	options := new(Options)
+
+	// We explicitly set the defaults here before decoding the options.
+	// If we were to supply a zero value of a type via our input,
+	// setting the default afterwards would override it.
+	defaults.SetDefaults(options)
 
 	config := &mapstructure.DecoderConfig{
 		Metadata: &md,
@@ -107,7 +113,7 @@ func DecodeOptions(input interface{}) (*DecodedOptions, error) {
 	}
 
 	return &DecodedOptions{
-		Options:    &options,
+		Options:    options,
 		UnusedKeys: md.Unused,
 	}, nil
 }

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -19,7 +19,7 @@ type ExperimentalFeatures struct {
 }
 
 type ValidationOptions struct {
-	EarlyValidation bool `mapstructure:"earlyValidation"`
+	EnableEnhancedValidation bool `mapstructure:"earlyValidation"`
 }
 
 type Indexing struct {


### PR DESCRIPTION
This PR renames and enables the early validation setting by default. We use https://github.com/mcuadros/go-defaults to set a default value.

We could also rename the JSON `earlyValidation` key if we wanted, but in case that case we would need to update https://github.com/hashicorp/vscode-terraform/pull/1554 as well 