### PR TITLE
context: Replace `RPCContextData` with `DocumentContext`

### DIFF
--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -20,15 +20,17 @@ func (k *contextKey) String() string {
 	return k.Name
 }
 
-type RPCContextData struct {
-	Method string
-	URI    string
+type Document struct {
+	Method     string
+	LanguageID string
+	URI        string
 }
 
-func (rpcc RPCContextData) Copy() RPCContextData {
-	return RPCContextData{
-		Method: rpcc.Method,
-		URI:    rpcc.URI,
+func (rpcc Document) Copy() Document {
+	return Document{
+		Method:     rpcc.Method,
+		LanguageID: rpcc.LanguageID,
+		URI:        rpcc.URI,
 	}
 }
 
@@ -42,8 +44,7 @@ var (
 	ctxLsVersion            = &contextKey{"language server version"}
 	ctxProgressToken        = &contextKey{"progress token"}
 	ctxExperimentalFeatures = &contextKey{"experimental features"}
-	ctxRPCContext           = &contextKey{"rpc context"}
-	ctxLanguageId           = &contextKey{"language ID"}
+	ctxDocumentContext      = &contextKey{"rpc context"}
 	ctxValidationOptions    = &contextKey{"validation options"}
 )
 
@@ -181,28 +182,16 @@ func ExperimentalFeatures(ctx context.Context) (settings.ExperimentalFeatures, e
 	return *expFeatures, nil
 }
 
-func WithRPCContext(ctx context.Context, rpcc RPCContextData) context.Context {
-	return context.WithValue(ctx, ctxRPCContext, rpcc)
+func WithDocumentContext(ctx context.Context, rpcc Document) context.Context {
+	return context.WithValue(ctx, ctxDocumentContext, rpcc)
 }
 
-func RPCContext(ctx context.Context) RPCContextData {
-	return ctx.Value(ctxRPCContext).(RPCContextData)
+func DocumentContext(ctx context.Context) Document {
+	return ctx.Value(ctxDocumentContext).(Document)
 }
 
-func (ctxData RPCContextData) IsDidChangeRequest() bool {
+func (ctxData Document) IsDidChangeRequest() bool {
 	return ctxData.Method == "textDocument/didChange"
-}
-
-func WithLanguageId(ctx context.Context, languageId string) context.Context {
-	return context.WithValue(ctx, ctxLanguageId, languageId)
-}
-
-func IsLanguageId(ctx context.Context, expectedLangId string) bool {
-	langId, ok := ctx.Value(ctxLanguageId).(string)
-	if !ok {
-		return false
-	}
-	return langId == expectedLangId
 }
 
 func WithValidationOptions(ctx context.Context, validationOptions *settings.ValidationOptions) context.Context {

--- a/internal/decoder/decoder_test.go
+++ b/internal/decoder/decoder_test.go
@@ -61,7 +61,7 @@ func TestDecoder_CodeLensesForFile_concurrencyBug(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{})
+		ctx = lsctx.WithDocumentContext(ctx, lsctx.Document{})
 		err = module.ParseModuleConfiguration(ctx, mapFs, ss.Modules, dirName)
 		if err != nil {
 			t.Error(err)

--- a/internal/langserver/handlers/did_change.go
+++ b/internal/langserver/handlers/did_change.go
@@ -29,7 +29,9 @@ func (svc *service) TextDocumentDidChange(ctx context.Context, params lsp.DidCha
 		return err
 	}
 
-	ctx = lsctx.WithLanguageId(ctx, doc.LanguageID)
+	docCtx := lsctx.DocumentContext(ctx)
+	docCtx.LanguageID = doc.LanguageID
+	ctx = lsctx.WithDocumentContext(ctx, docCtx)
 
 	newVersion := int(p.TextDocument.Version)
 

--- a/internal/langserver/handlers/did_open.go
+++ b/internal/langserver/handlers/did_open.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 
 	"github.com/creachadair/jrpc2"
-	lsctx "github.com/hashicorp/terraform-ls/internal/context"
 	"github.com/hashicorp/terraform-ls/internal/document"
 	lsp "github.com/hashicorp/terraform-ls/internal/protocol"
 	"github.com/hashicorp/terraform-ls/internal/state"
@@ -37,8 +36,6 @@ func (svc *service) TextDocumentDidOpen(ctx context.Context, params lsp.DidOpenT
 	if err != nil {
 		return err
 	}
-
-	ctx = lsctx.WithLanguageId(ctx, params.TextDocument.LanguageID)
 
 	mod, err := svc.modStore.ModuleByPath(dh.Dir.Path())
 	if err != nil {

--- a/internal/langserver/handlers/initialize.go
+++ b/internal/langserver/handlers/initialize.go
@@ -166,7 +166,7 @@ func (svc *service) Initialize(ctx context.Context, params lsp.InitializeParams)
 	// passing the request context here
 	// Static user-provided paths take precedence over dynamic discovery
 	walkerCtx := context.Background()
-	walkerCtx = lsctx.WithRPCContext(walkerCtx, lsctx.RPCContext(ctx))
+	walkerCtx = lsctx.WithDocumentContext(walkerCtx, lsctx.DocumentContext(ctx))
 
 	err = svc.closedDirWalker.StartWalking(walkerCtx)
 	if err != nil {

--- a/internal/langserver/handlers/service.go
+++ b/internal/langserver/handlers/service.go
@@ -614,7 +614,8 @@ func handle(ctx context.Context, req *jrpc2.Request, fn interface{}) (interface{
 	// We could capture all parameters here but for now we just
 	// opportunistically track the most important ones only.
 	type t struct {
-		URI string `json:"uri,omitempty"`
+		URI        string `json:"uri,omitempty"`
+		LanguageID string `json:"languageId,omitempty"`
 	}
 	type p struct {
 		TextDocument t      `json:"textDocument,omitempty"`
@@ -641,9 +642,10 @@ func handle(ctx context.Context, req *jrpc2.Request, fn interface{}) (interface{
 		trace.WithAttributes(attrs...))
 	defer span.End()
 
-	ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{
-		Method: req.Method(),
-		URI:    uri,
+	ctx = lsctx.WithDocumentContext(ctx, lsctx.Document{
+		Method:     req.Method(),
+		LanguageID: params.TextDocument.LanguageID,
+		URI:        uri,
 	})
 
 	result, err := rpch.New(fn)(ctx, req)

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -31,7 +31,7 @@ func TestScheduler_withIgnoreExistingState(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	ctx := context.Background()
-	ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{})
+	ctx = lsctx.WithDocumentContext(ctx, lsctx.Document{})
 
 	s := NewScheduler(ss.JobStore, 1, job.LowPriority)
 	s.SetLogger(testLogger())
@@ -94,7 +94,7 @@ func TestScheduler_closedOnly(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	ctx := context.Background()
-	ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{})
+	ctx = lsctx.WithDocumentContext(ctx, lsctx.Document{})
 
 	s := NewScheduler(ss.JobStore, 2, job.LowPriority)
 	s.SetLogger(testLogger())
@@ -157,7 +157,7 @@ func TestScheduler_closedAndOpen(t *testing.T) {
 			dirPath := filepath.Join(tmpDir, fmt.Sprintf("folder-x-%d", i))
 
 			ctx := context.Background()
-			ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{})
+			ctx = lsctx.WithDocumentContext(ctx, lsctx.Document{})
 			newId, err := ss.JobStore.EnqueueJob(ctx, job.Job{
 				Func: func(c context.Context) error {
 					atomic.AddInt64(&closedJobsExecuted, 1)
@@ -184,7 +184,7 @@ func TestScheduler_closedAndOpen(t *testing.T) {
 			dirPath := filepath.Join(tmpDir, fmt.Sprintf("folder-y-%d", i))
 
 			ctx := context.Background()
-			ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{})
+			ctx = lsctx.WithDocumentContext(ctx, lsctx.Document{})
 			newId, err := ss.JobStore.EnqueueJob(ctx, job.Job{
 				Func: func(c context.Context) error {
 					atomic.AddInt64(&openJobsExecuted, 1)
@@ -269,7 +269,7 @@ func BenchmarkScheduler_EnqueueAndWaitForJob_closedOnly(b *testing.B) {
 
 	tmpDir := b.TempDir()
 	ctx := context.Background()
-	ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{})
+	ctx = lsctx.WithDocumentContext(ctx, lsctx.Document{})
 
 	s := NewScheduler(ss.JobStore, 1, job.LowPriority)
 	s.Start(ctx)
@@ -311,7 +311,7 @@ func TestScheduler_defer(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	ctx := context.Background()
-	ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{})
+	ctx = lsctx.WithDocumentContext(ctx, lsctx.Document{})
 
 	s := NewScheduler(ss.JobStore, 2, job.LowPriority)
 	s.SetLogger(testLogger())
@@ -401,7 +401,7 @@ func TestScheduler_dependsOn(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	ctx := context.Background()
-	ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{})
+	ctx = lsctx.WithDocumentContext(ctx, lsctx.Document{})
 
 	s := NewScheduler(ss.JobStore, 2, job.LowPriority)
 	s.SetLogger(testLogger())

--- a/internal/state/jobs_test.go
+++ b/internal/state/jobs_test.go
@@ -28,7 +28,7 @@ func TestJobStore_EnqueueJob(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{})
+	ctx = lsctx.WithDocumentContext(ctx, lsctx.Document{})
 	id1, err := ss.JobStore.EnqueueJob(ctx, job.Job{
 		Func: func(ctx context.Context) error {
 			return nil
@@ -83,7 +83,7 @@ func TestJobStore_EnqueueJob_openDir(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{})
+	ctx = lsctx.WithDocumentContext(ctx, lsctx.Document{})
 	id, err := ss.JobStore.EnqueueJob(ctx, job.Job{
 		Func: func(ctx context.Context) error {
 			return nil
@@ -162,7 +162,7 @@ func TestJobStore_EnqueueJob_verify(t *testing.T) {
 
 	jobCount := 50
 	ctx := context.Background()
-	ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{})
+	ctx = lsctx.WithDocumentContext(ctx, lsctx.Document{})
 
 	for i := 0; i < jobCount; i++ {
 		i := i
@@ -221,7 +221,7 @@ func TestJobStore_DequeueJobsForDir(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{})
+	ctx = lsctx.WithDocumentContext(ctx, lsctx.Document{})
 	firstDir := document.DirHandleFromPath("/test-1")
 	_, err = ss.JobStore.EnqueueJob(ctx, job.Job{
 		Func: func(ctx context.Context) error {
@@ -266,7 +266,7 @@ func TestJobStore_AwaitNextJob_closedOnly(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{})
+	ctx = lsctx.WithDocumentContext(ctx, lsctx.Document{})
 	firstDir := document.DirHandleFromPath("/test-1")
 	id1, err := ss.JobStore.EnqueueJob(ctx, job.Job{
 		Func: func(ctx context.Context) error {
@@ -330,7 +330,7 @@ func TestJobStore_AwaitNextJob_openOnly(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{})
+	ctx = lsctx.WithDocumentContext(ctx, lsctx.Document{})
 	firstDir := document.DirHandleFromPath("/test-1")
 	_, err = ss.JobStore.EnqueueJob(ctx, job.Job{
 		Func: func(ctx context.Context) error {
@@ -394,7 +394,7 @@ func TestJobStore_AwaitNextJob_highPriority(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{})
+	ctx = lsctx.WithDocumentContext(ctx, lsctx.Document{})
 	firstDir := document.DirHandleFromPath("/test-1")
 	id1, err := ss.JobStore.EnqueueJob(ctx, job.Job{
 		Func: func(ctx context.Context) error {
@@ -476,7 +476,7 @@ func TestJobStore_AwaitNextJob_lowPriority(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{})
+	ctx = lsctx.WithDocumentContext(ctx, lsctx.Document{})
 	firstDir := document.DirHandleFromPath("/test-1")
 	id1, err := ss.JobStore.EnqueueJob(ctx, job.Job{
 		Func: func(ctx context.Context) error {
@@ -573,7 +573,7 @@ func TestJobStore_WaitForJobs(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{})
+	ctx = lsctx.WithDocumentContext(ctx, lsctx.Document{})
 	id1, err := ss.JobStore.EnqueueJob(ctx, job.Job{
 		Func: func(ctx context.Context) error {
 			return nil
@@ -615,7 +615,7 @@ func TestJobStore_FinishJob_basic(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{})
+	ctx = lsctx.WithDocumentContext(ctx, lsctx.Document{})
 	id1, err := ss.JobStore.EnqueueJob(ctx, job.Job{
 		Func: func(ctx context.Context) error {
 			return nil
@@ -677,7 +677,7 @@ func TestJobStore_FinishJob_defer(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{})
+	ctx = lsctx.WithDocumentContext(ctx, lsctx.Document{})
 	id1, err := ss.JobStore.EnqueueJob(ctx, job.Job{
 		Func: func(ctx context.Context) error {
 			return nil
@@ -731,7 +731,7 @@ func TestJobStore_FinishJob_dependsOn(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{})
+	ctx = lsctx.WithDocumentContext(ctx, lsctx.Document{})
 	parentId, err := ss.JobStore.EnqueueJob(ctx, job.Job{
 		Func: func(ctx context.Context) error {
 			return nil

--- a/internal/state/module_changes_test.go
+++ b/internal/state/module_changes_test.go
@@ -97,7 +97,7 @@ func TestModuleChanges_AwaitNextChangeBatch_maxTimespan(t *testing.T) {
 	modHandle := document.DirHandleFromPath(modPath)
 
 	ctx := context.Background()
-	ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{})
+	ctx = lsctx.WithDocumentContext(ctx, lsctx.Document{})
 	_, err = ss.JobStore.EnqueueJob(ctx, job.Job{
 		Func: func(ctx context.Context) error {
 			return nil

--- a/internal/terraform/module/module_ops.go
+++ b/internal/terraform/module/module_ops.go
@@ -388,9 +388,9 @@ func ParseModuleConfiguration(ctx context.Context, fs ReadOnlyFS, modStore *stat
 
 	var files ast.ModFiles
 	var diags ast.ModDiags
-	rpcContext := lsctx.RPCContext(ctx)
+	rpcContext := lsctx.DocumentContext(ctx)
 	// Only parse the file that's being changed/opened, unless this is 1st-time parsing
-	if mod.ModuleDiagnosticsState[ast.HCLParsingSource] == op.OpStateLoaded && rpcContext.IsDidChangeRequest() && lsctx.IsLanguageId(ctx, ilsp.Terraform.String()) {
+	if mod.ModuleDiagnosticsState[ast.HCLParsingSource] == op.OpStateLoaded && rpcContext.IsDidChangeRequest() && rpcContext.LanguageID == ilsp.Terraform.String() {
 		// the file has already been parsed, so only examine this file and not the whole module
 		err = modStore.SetModuleDiagnosticsState(modPath, ast.HCLParsingSource, op.OpStateLoading)
 		if err != nil {
@@ -798,8 +798,8 @@ func SchemaModuleValidation(ctx context.Context, modStore *state.ModuleStore, sc
 	}
 
 	var rErr error
-	rpcContext := lsctx.RPCContext(ctx)
-	if rpcContext.Method == "textDocument/didChange" && lsctx.IsLanguageId(ctx, ilsp.Terraform.String()) {
+	rpcContext := lsctx.DocumentContext(ctx)
+	if rpcContext.Method == "textDocument/didChange" && rpcContext.LanguageID == ilsp.Terraform.String() {
 		filename := path.Base(rpcContext.URI)
 		// We only revalidate a single file that changed
 		var fileDiags hcl.Diagnostics
@@ -867,8 +867,8 @@ func SchemaVariablesValidation(ctx context.Context, modStore *state.ModuleStore,
 	}
 
 	var rErr error
-	rpcContext := lsctx.RPCContext(ctx)
-	if rpcContext.Method == "textDocument/didChange" && lsctx.IsLanguageId(ctx, ilsp.Tfvars.String()) {
+	rpcContext := lsctx.DocumentContext(ctx)
+	if rpcContext.Method == "textDocument/didChange" && rpcContext.LanguageID == ilsp.Tfvars.String() {
 		filename := path.Base(rpcContext.URI)
 		// We only revalidate a single file that changed
 		var fileDiags hcl.Diagnostics

--- a/internal/terraform/module/module_ops_test.go
+++ b/internal/terraform/module/module_ops_test.go
@@ -60,7 +60,7 @@ func TestGetModuleDataFromRegistry_singleModule(t *testing.T) {
 	}
 
 	fs := filesystem.NewFilesystem(ss.DocumentStore)
-	ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{})
+	ctx = lsctx.WithDocumentContext(ctx, lsctx.Document{})
 	err = ParseModuleConfiguration(ctx, fs, ss.Modules, modPath)
 	if err != nil {
 		t.Fatal(err)
@@ -133,7 +133,7 @@ func TestGetModuleDataFromRegistry_moduleNotFound(t *testing.T) {
 	}
 
 	fs := filesystem.NewFilesystem(ss.DocumentStore)
-	ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{})
+	ctx = lsctx.WithDocumentContext(ctx, lsctx.Document{})
 	err = ParseModuleConfiguration(ctx, fs, ss.Modules, modPath)
 	if err != nil {
 		t.Fatal(err)
@@ -234,7 +234,7 @@ func TestGetModuleDataFromRegistry_apiTimeout(t *testing.T) {
 	}
 
 	fs := filesystem.NewFilesystem(ss.DocumentStore)
-	ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{})
+	ctx = lsctx.WithDocumentContext(ctx, lsctx.Document{})
 	err = ParseModuleConfiguration(ctx, fs, ss.Modules, modPath)
 	if err != nil {
 		t.Fatal(err)
@@ -529,7 +529,7 @@ func TestParseProviderVersions_multipleVersions(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{})
+	ctx = lsctx.WithDocumentContext(ctx, lsctx.Document{})
 	err = ParseModuleConfiguration(ctx, fs, ss.Modules, modPathFirst)
 	if err != nil {
 		t.Fatal(err)
@@ -699,7 +699,7 @@ func TestPreloadEmbeddedSchema_basic(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{})
+	ctx = lsctx.WithDocumentContext(ctx, lsctx.Document{})
 	err = ParseModuleConfiguration(ctx, cfgFS, ss.Modules, modPath)
 	if err != nil {
 		t.Fatal(err)
@@ -770,7 +770,7 @@ func TestPreloadEmbeddedSchema_unknownProviderOnly(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{})
+	ctx = lsctx.WithDocumentContext(ctx, lsctx.Document{})
 	err = ParseModuleConfiguration(ctx, cfgFS, ss.Modules, modPath)
 	if err != nil {
 		t.Fatal(err)
@@ -834,7 +834,7 @@ func TestPreloadEmbeddedSchema_idempotency(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{})
+	ctx = lsctx.WithDocumentContext(ctx, lsctx.Document{})
 	err = ParseModuleConfiguration(ctx, cfgFS, ss.Modules, modPath)
 	if err != nil {
 		t.Fatal(err)
@@ -914,7 +914,7 @@ func TestPreloadEmbeddedSchema_raceCondition(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{})
+	ctx = lsctx.WithDocumentContext(ctx, lsctx.Document{})
 	err = ParseModuleConfiguration(ctx, cfgFS, ss.Modules, modPath)
 	if err != nil {
 		t.Fatal(err)
@@ -963,7 +963,7 @@ func TestParseModuleConfiguration(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{})
+	ctx = lsctx.WithDocumentContext(ctx, lsctx.Document{})
 	err = ParseModuleConfiguration(ctx, testFs, ss.Modules, singleFileModulePath)
 	if err != nil {
 		t.Fatal(err)
@@ -982,12 +982,12 @@ func TestParseModuleConfiguration(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	x := lsctx.RPCContextData{
-		Method: "textDocument/didChange",
-		URI:    uri.FromPath(fooURI),
+	x := lsctx.Document{
+		Method:     "textDocument/didChange",
+		LanguageID: ilsp.Terraform.String(),
+		URI:        uri.FromPath(fooURI),
 	}
-	ctx = lsctx.WithLanguageId(ctx, ilsp.Terraform.String())
-	ctx = lsctx.WithRPCContext(ctx, x)
+	ctx = lsctx.WithDocumentContext(ctx, x)
 	err = ParseModuleConfiguration(ctx, testFs, ss.Modules, singleFileModulePath)
 	if err != nil {
 		t.Fatal(err)
@@ -1038,7 +1038,7 @@ func TestParseModuleConfiguration_ignore_tfvars(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{})
+	ctx = lsctx.WithDocumentContext(ctx, lsctx.Document{})
 	err = ParseModuleConfiguration(ctx, testFs, ss.Modules, singleFileModulePath)
 	if err != nil {
 		t.Fatal(err)
@@ -1057,10 +1057,11 @@ func TestParseModuleConfiguration_ignore_tfvars(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ctx = lsctx.WithLanguageId(ctx, ilsp.Tfvars.String())
-	ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{
-		Method: "textDocument/didChange",
-		URI:    uri.FromPath(fooURI),
+
+	ctx = lsctx.WithDocumentContext(ctx, lsctx.Document{
+		Method:     "textDocument/didChange",
+		LanguageID: ilsp.Tfvars.String(),
+		URI:        uri.FromPath(fooURI),
 	})
 	err = ParseModuleConfiguration(ctx, testFs, ss.Modules, singleFileModulePath)
 	if err != nil {
@@ -1143,11 +1144,11 @@ func TestSchemaModuleValidation_FullModule(t *testing.T) {
 	}
 
 	fs := filesystem.NewFilesystem(ss.DocumentStore)
-	ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{
-		Method: "textDocument/didOpen",
-		URI:    "file:///test/variables.tf",
+	ctx = lsctx.WithDocumentContext(ctx, lsctx.Document{
+		Method:     "textDocument/didOpen",
+		LanguageID: ilsp.Terraform.String(),
+		URI:        "file:///test/variables.tf",
 	})
-	ctx = lsctx.WithLanguageId(ctx, ilsp.Terraform.String())
 	err = ParseModuleConfiguration(ctx, fs, ss.Modules, modPath)
 	if err != nil {
 		t.Fatal(err)
@@ -1188,11 +1189,11 @@ func TestSchemaModuleValidation_SingleFile(t *testing.T) {
 	}
 
 	fs := filesystem.NewFilesystem(ss.DocumentStore)
-	ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{
-		Method: "textDocument/didChange",
-		URI:    "file:///test/variables.tf",
+	ctx = lsctx.WithDocumentContext(ctx, lsctx.Document{
+		Method:     "textDocument/didChange",
+		LanguageID: ilsp.Terraform.String(),
+		URI:        "file:///test/variables.tf",
 	})
-	ctx = lsctx.WithLanguageId(ctx, ilsp.Terraform.String())
 	err = ParseModuleConfiguration(ctx, fs, ss.Modules, modPath)
 	if err != nil {
 		t.Fatal(err)
@@ -1233,11 +1234,11 @@ func TestSchemaVarsValidation_FullModule(t *testing.T) {
 	}
 
 	fs := filesystem.NewFilesystem(ss.DocumentStore)
-	ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{
-		Method: "textDocument/didOpen",
-		URI:    "file:///test/terraform.tfvars",
+	ctx = lsctx.WithDocumentContext(ctx, lsctx.Document{
+		Method:     "textDocument/didOpen",
+		LanguageID: ilsp.Tfvars.String(),
+		URI:        "file:///test/terraform.tfvars",
 	})
-	ctx = lsctx.WithLanguageId(ctx, ilsp.Tfvars.String())
 	err = ParseModuleConfiguration(ctx, fs, ss.Modules, modPath)
 	if err != nil {
 		t.Fatal(err)
@@ -1286,11 +1287,11 @@ func TestSchemaVarsValidation_SingleFile(t *testing.T) {
 	}
 
 	fs := filesystem.NewFilesystem(ss.DocumentStore)
-	ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{
-		Method: "textDocument/didChange",
-		URI:    "file:///test/terraform.tfvars",
+	ctx = lsctx.WithDocumentContext(ctx, lsctx.Document{
+		Method:     "textDocument/didChange",
+		LanguageID: ilsp.Tfvars.String(),
+		URI:        "file:///test/terraform.tfvars",
 	})
-	ctx = lsctx.WithLanguageId(ctx, ilsp.Tfvars.String())
 	err = ParseModuleConfiguration(ctx, fs, ss.Modules, modPath)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/walker/walker_test.go
+++ b/internal/walker/walker_test.go
@@ -56,7 +56,7 @@ func TestWalker_basic(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{})
+	ctx = lsctx.WithDocumentContext(ctx, lsctx.Document{})
 	err = w.StartWalking(ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -401,7 +401,7 @@ func TestWalker_complexModules(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			ctx = lsctx.WithRPCContext(ctx, lsctx.RPCContextData{})
+			ctx = lsctx.WithDocumentContext(ctx, lsctx.Document{})
 			err = w.StartWalking(ctx)
 			if err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
This ensures that we propagate the language ID between job scheduling and execution, which in turn enables https://github.com/hashicorp/terraform-ls/pull/1404 at runtime (and not just in unit tests).

While I am labelling this as a bug, it's a bug that was never surfaced to the user in a release, so it does not need to be mentioned in the Changelog AFAICT.