### PR TITLE
settings: Fix option name to `enableEarlyValidation`

### DIFF
--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -20,7 +20,7 @@ type ExperimentalFeatures struct {
 }
 
 type ValidationOptions struct {
-	EnableEnhancedValidation bool `mapstructure:"earlyValidation" default:"true"`
+	EnableEnhancedValidation bool `mapstructure:"enableEarlyValidation" default:"true"`
 }
 
 type Indexing struct {


### PR DESCRIPTION
This is already (correctly) reflected in https://github.com/hashicorp/vscode-terraform/pull/1554 so no changes needed there.

This PR also should not need a Changelog entry since we never introduced the bug to a released version.