### PR TITLE
fix: continue running jobs even if loading metadata fails

### DIFF
--- a/internal/indexer/document_change.go
+++ b/internal/indexer/document_change.go
@@ -109,8 +109,9 @@ func (idx *Indexer) decodeModule(ctx context.Context, modHandle document.DirHand
 		Defer: func(ctx context.Context, jobErr error) (job.IDs, error) {
 			ids := make(job.IDs, 0)
 			if jobErr != nil {
-				return ids, jobErr
+				idx.logger.Printf("loading module metadata returned error: %s", jobErr)
 			}
+
 			modCalls, mcErr := idx.decodeDeclaredModuleCalls(ctx, modHandle, ignoreState)
 			if mcErr != nil {
 				idx.logger.Printf("decoding declared module calls for %q failed: %s", modHandle.URI, mcErr)


### PR DESCRIPTION
Prior to this patch we would skip running a number of jobs, including validation if loading metadata has failed.

Loading metadata can fail for example because `variable` block is incomplete. The `earlydecoder` should already provide partially decoded configuration anyway and hence enable the later validation, so we should not be blocking other jobs based on the failure here as we'd block useful diagnostics.

Similar to my other patch, this shouldn't need to be mentioned in the Changelog, since we have not yet exposed this bug to end users since we have not released validation yet.

## Before

![Screenshot 2023-10-02 at 18 07 32](https://github.com/hashicorp/terraform-ls/assets/287584/691ad27f-f12f-4151-9fa0-fd180e157caa)

## After

![Screenshot 2023-10-02 at 18 07 10](https://github.com/hashicorp/terraform-ls/assets/287584/c7ff51d3-11f7-43cc-b9ef-0715ff32bf3a)
