### PR TITLE
fix option name (early -> enhanced)

### DIFF
--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -20,7 +20,7 @@ type ExperimentalFeatures struct {
 }
 
 type ValidationOptions struct {
-	EnableEnhancedValidation bool `mapstructure:"enableEarlyValidation" default:"true"`
+	EnableEnhancedValidation bool `mapstructure:"enableEnhancedValidation" default:"true"`
 }
 
 type Indexing struct {


### PR DESCRIPTION
This is slightly embarrassing in the context of https://github.com/hashicorp/terraform-ls/pull/1434 but it's _now_ correct, as confirmed via https://github.com/hashicorp/vscode-terraform/pull/1554