### PR TITLE
Resolve version correctly for backend schema

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/hashicorp/terraform-exec v0.19.0
 	github.com/hashicorp/terraform-json v0.17.1
 	github.com/hashicorp/terraform-registry-address v0.2.2
-	github.com/hashicorp/terraform-schema v0.0.0-20231006123128-72331e948317
+	github.com/hashicorp/terraform-schema v0.0.0-20231010111619-c5aaaecd335e
 	github.com/mcuadros/go-defaults v1.2.0
 	github.com/mh-cbon/go-fmt-fail v0.0.0-20160815164508-67765b3fbcb5
 	github.com/mitchellh/cli v1.1.5

--- a/go.sum
+++ b/go.sum
@@ -228,8 +228,8 @@ github.com/hashicorp/terraform-json v0.17.1 h1:eMfvh/uWggKmY7Pmb3T85u86E2EQg6EQH
 github.com/hashicorp/terraform-json v0.17.1/go.mod h1:Huy6zt6euxaY9knPAFKjUITn8QxUFIe9VuSzb4zn/0o=
 github.com/hashicorp/terraform-registry-address v0.2.2 h1:lPQBg403El8PPicg/qONZJDC6YlgCVbWDtNmmZKtBno=
 github.com/hashicorp/terraform-registry-address v0.2.2/go.mod h1:LtwNbCihUoUZ3RYriyS2wF/lGPB6gF9ICLRtuDk7hSo=
-github.com/hashicorp/terraform-schema v0.0.0-20231006123128-72331e948317 h1:iErld30gWHZaDapPblnXIh7UpMtemzEfthRby+ub3O4=
-github.com/hashicorp/terraform-schema v0.0.0-20231006123128-72331e948317/go.mod h1:e2ZdWyv2u1YQN1xZ6jhOps3KZNuK88Sf+39pvlmnqIc=
+github.com/hashicorp/terraform-schema v0.0.0-20231010111619-c5aaaecd335e h1:Q9ydKXzO6X54Pubzp223BuRgEdGZv7MoL16VX5oFXew=
+github.com/hashicorp/terraform-schema v0.0.0-20231010111619-c5aaaecd335e/go.mod h1:iPIBxz1xXSnq6UiCMtIJiRh4TIRkh39jXDUj5rzhJHc=
 github.com/hashicorp/terraform-svchost v0.1.1 h1:EZZimZ1GxdqFRinZ1tpJwVxxt49xc/S52uzrw4x0jKQ=
 github.com/hashicorp/terraform-svchost v0.1.1/go.mod h1:mNsjQfZyf/Jhz35v6/0LWcv26+X7JPS+buii2c9/ctc=
 github.com/hexops/autogold v1.3.1 h1:YgxF9OHWbEIUjhDbpnLhgVsjUDsiHDTyDfy2lrfdlzo=


### PR DESCRIPTION
This is to address:
 - https://github.com/hashicorp/vscode-terraform/issues/1580

Depends on:

 - https://github.com/hashicorp/terraform-schema/pull/275

--- 

This PR changes the meaning of the _version_ in the snippet of code being changed. Previously it referred to the discovered/installed Terraform version, whether or not we had the schema for it. With this patch, the meaning changes to "language/schema version".

In practice though it remains the same for the likely majority of cases (any stable version between `0.12` and `1.6`) but not for the other cases, where we fall back on either 0.12.0 or latest known version (currently 1.6.0).

Importantly, this does _not_ impact the discovered/installed version we persist and make available, e.g. here

![2023-10-10 11 26 34](https://github.com/hashicorp/terraform-ls/assets/287584/ea254c1e-0a03-4c1c-abd4-5de78d83d908)

Also, the new logic inside `ResolveVersion` reflects the way we handled various edge cases in the previous implementation, as shown in the attached test in https://github.com/hashicorp/terraform-schema/pull/275