### PR TITLE
fix: Work around 'unreliable' input data for Registry modules

### DIFF
--- a/internal/registry/module.go
+++ b/internal/registry/module.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/http/httptrace"
 	"sort"
+	"time"
 
 	"github.com/hashicorp/go-version"
 	tfaddr "github.com/hashicorp/terraform-registry-address"
@@ -21,8 +22,9 @@ import (
 )
 
 type ModuleResponse struct {
-	Version string     `json:"version"`
-	Root    ModuleRoot `json:"root"`
+	Version     string     `json:"version"`
+	PublishedAt time.Time  `json:"published_at"`
+	Root        ModuleRoot `json:"root"`
 }
 
 type ModuleRoot struct {

--- a/internal/registry/module_test.go
+++ b/internal/registry/module_test.go
@@ -47,7 +47,8 @@ func TestGetModuleData(t *testing.T) {
 		t.Fatal(err)
 	}
 	expectedData := &ModuleResponse{
-		Version: "0.0.8",
+		Version:     "0.0.8",
+		PublishedAt: time.Date(2021, time.August, 5, 0, 26, 33, 501756000, time.UTC),
 		Root: ModuleRoot{
 			Inputs: []Input{
 				{

--- a/internal/terraform/module/module_ops_mock_responses.go
+++ b/internal/terraform/module/module_ops_mock_responses.go
@@ -3,6 +3,13 @@
 
 package module
 
+import (
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/hcl-lang/lang"
+	tfregistry "github.com/hashicorp/terraform-schema/registry"
+	"github.com/zclconf/go-cty/cty"
+)
+
 // puppetModuleVersionsMockResponse represents response from https://registry.terraform.io/v1/modules/puppetlabs/deployment/ec/versions
 var puppetModuleVersionsMockResponse = `{
   "modules": [
@@ -270,3 +277,215 @@ var puppetModuleDataMockResponse = `{
     "0.0.8"
   ]
 }`
+
+// labelNullModuleVersionsMockResponse represents response for
+// versions of module that suffers from "unreliable" input data, as described in
+// https://github.com/hashicorp/vscode-terraform/issues/1582
+// It is a shortened response from https://registry.terraform.io/v1/modules/cloudposse/label/null/versions
+var labelNullModuleVersionsMockResponse = `{
+  "modules": [
+    {
+      "source": "cloudposse/label/null",
+      "versions": [
+        {
+          "version": "0.25.0",
+          "root": {
+            "providers": [],
+            "dependencies": []
+          },
+          "submodules": []
+        },
+        {
+          "version": "0.26.0",
+          "root": {
+            "providers": [],
+            "dependencies": []
+          },
+          "submodules": []
+        }
+      ]
+    }
+  ]
+}`
+
+// labelNullModuleDataOldMockResponse represents response for
+// a module that suffers from "unreliable" input data, as described in
+// https://github.com/hashicorp/vscode-terraform/issues/1582
+// It is a shortened response from https://registry.terraform.io/v1/modules/cloudposse/label/null/0.25.0
+var labelNullModuleDataOldMockResponse = `{
+  "id": "cloudposse/label/null/0.25.0",
+  "owner": "osterman",
+  "namespace": "cloudposse",
+  "name": "label",
+  "version": "0.25.0",
+  "provider": "null",
+  "provider_logo_url": "/images/providers/generic.svg?2",
+  "description": "Terraform Module to define a consistent naming convention by (namespace, stage, name, [attributes])",
+  "source": "https://github.com/cloudposse/terraform-null-label",
+  "tag": "0.25.0",
+  "published_at": "2021-08-25T17:47:04.039843Z",
+  "downloads": 52863192,
+  "verified": false,
+  "root": {
+    "path": "",
+    "name": "label",
+    "empty": false,
+    "inputs": [
+      {
+        "name": "environment",
+        "type": "string",
+        "default": "",
+        "required": true
+      },
+      {
+        "name": "label_order",
+        "type": "list(string)",
+        "default": "",
+        "required": true
+      },
+      {
+        "name": "descriptor_formats",
+        "type": "any",
+        "default": "{}",
+        "required": false
+      }
+    ],
+    "outputs": [
+      {
+        "name": "id"
+      }
+    ],
+    "dependencies": [],
+    "provider_dependencies": [],
+    "resources": []
+  },
+  "submodules": [],
+  "examples": [],
+  "providers": [
+    "null",
+    "terraform"
+  ],
+  "versions": [
+    "0.25.0",
+    "0.26.0"
+  ]
+}`
+
+// labelNullModuleDataOldMockResponse represents response for
+// a module that does NOT suffer from "unreliable" input data,
+// as described in https://github.com/hashicorp/vscode-terraform/issues/1582
+// This is for comparison with the unreliable input data.
+var labelNullModuleDataNewMockResponse = `{
+  "id": "cloudposse/label/null/0.26.0",
+  "owner": "osterman",
+  "namespace": "cloudposse",
+  "name": "label",
+  "version": "0.26.0",
+  "provider": "null",
+  "provider_logo_url": "/images/providers/generic.svg?2",
+  "description": "Terraform Module to define a consistent naming convention by (namespace, stage, name, [attributes])",
+  "source": "https://github.com/cloudposse/terraform-null-label",
+  "tag": "0.26.0",
+  "published_at": "2023-10-11T10:47:04.039843Z",
+  "downloads": 10000,
+  "verified": false,
+  "root": {
+    "path": "",
+    "name": "label",
+    "empty": false,
+    "inputs": [
+      {
+        "name": "environment",
+        "type": "string",
+        "default": "",
+        "required": true
+      },
+      {
+        "name": "label_order",
+        "type": "list(string)",
+        "default": "null",
+        "required": false
+      },
+      {
+        "name": "descriptor_formats",
+        "type": "any",
+        "default": "{}",
+        "required": false
+      }
+    ],
+    "outputs": [
+      {
+        "name": "id"
+      }
+    ],
+    "dependencies": [],
+    "provider_dependencies": [],
+    "resources": []
+  },
+  "submodules": [],
+  "examples": [],
+  "providers": [
+    "null",
+    "terraform"
+  ],
+  "versions": [
+    "0.25.0",
+    "0.26.0"
+  ]
+}`
+
+var labelNullExpectedOldModuleData = &tfregistry.ModuleData{
+	Version: version.Must(version.NewVersion("0.25.0")),
+	Inputs: []tfregistry.Input{
+		{
+			Name:        "environment",
+			Type:        cty.String,
+			Description: lang.Markdown(""),
+		},
+		{
+			Name:        "label_order",
+			Type:        cty.DynamicPseudoType,
+			Description: lang.Markdown(""),
+		},
+		{
+			Name:        "descriptor_formats",
+			Type:        cty.DynamicPseudoType,
+			Description: lang.Markdown(""),
+		},
+	},
+	Outputs: []tfregistry.Output{
+		{
+			Name:        "id",
+			Description: lang.Markdown(""),
+		},
+	},
+}
+
+var labelNullExpectedNewModuleData = &tfregistry.ModuleData{
+	Version: version.Must(version.NewVersion("0.26.0")),
+	Inputs: []tfregistry.Input{
+		{
+			Name:        "environment",
+			Type:        cty.String,
+			Description: lang.Markdown(""),
+			Required:    true,
+		},
+		{
+			Name:        "label_order",
+			Type:        cty.DynamicPseudoType,
+			Description: lang.Markdown(""),
+			Default:     cty.NullVal(cty.DynamicPseudoType),
+		},
+		{
+			Name:        "descriptor_formats",
+			Type:        cty.DynamicPseudoType,
+			Description: lang.Markdown(""),
+		},
+	},
+	Outputs: []tfregistry.Output{
+		{
+			Name:        "id",
+			Description: lang.Markdown(""),
+		},
+	},
+}

--- a/internal/terraform/module/module_ops_mock_responses.go
+++ b/internal/terraform/module/module_ops_mock_responses.go
@@ -3,8 +3,8 @@
 
 package module
 
-// moduleVersionsMockResponse represents response from https://registry.terraform.io/v1/modules/puppetlabs/deployment/ec/versions
-var moduleVersionsMockResponse = `{
+// puppetModuleVersionsMockResponse represents response from https://registry.terraform.io/v1/modules/puppetlabs/deployment/ec/versions
+var puppetModuleVersionsMockResponse = `{
   "modules": [
     {
       "source": "puppetlabs/deployment/ec",
@@ -140,8 +140,8 @@ var moduleVersionsMockResponse = `{
   ]
 }`
 
-// moduleDataMockResponse represents response from https://registry.terraform.io/v1/modules/puppetlabs/deployment/ec/0.0.8
-var moduleDataMockResponse = `{
+// puppetModuleDataMockResponse represents response from https://registry.terraform.io/v1/modules/puppetlabs/deployment/ec/0.0.8
+var puppetModuleDataMockResponse = `{
   "id": "puppetlabs/deployment/ec/0.0.8",
   "owner": "mattkirby",
   "namespace": "puppetlabs",

--- a/internal/terraform/module/module_ops_test.go
+++ b/internal/terraform/module/module_ops_test.go
@@ -74,11 +74,11 @@ func TestGetModuleDataFromRegistry_singleModule(t *testing.T) {
 	regClient := registry.NewClient()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.RequestURI == "/v1/modules/puppetlabs/deployment/ec/versions" {
-			w.Write([]byte(moduleVersionsMockResponse))
+			w.Write([]byte(puppetModuleVersionsMockResponse))
 			return
 		}
 		if r.RequestURI == "/v1/modules/puppetlabs/deployment/ec/0.0.8" {
-			w.Write([]byte(moduleDataMockResponse))
+			w.Write([]byte(puppetModuleDataMockResponse))
 			return
 		}
 		http.Error(w, fmt.Sprintf("unexpected request: %q", r.RequestURI), 400)
@@ -147,11 +147,11 @@ func TestGetModuleDataFromRegistry_moduleNotFound(t *testing.T) {
 	regClient := registry.NewClient()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.RequestURI == "/v1/modules/puppetlabs/deployment/ec/versions" {
-			w.Write([]byte(moduleVersionsMockResponse))
+			w.Write([]byte(puppetModuleVersionsMockResponse))
 			return
 		}
 		if r.RequestURI == "/v1/modules/puppetlabs/deployment/ec/0.0.8" {
-			w.Write([]byte(moduleDataMockResponse))
+			w.Write([]byte(puppetModuleDataMockResponse))
 			return
 		}
 		if r.RequestURI == "/v1/modules/terraform-aws-modules/eks/aws/versions" {
@@ -249,11 +249,11 @@ func TestGetModuleDataFromRegistry_apiTimeout(t *testing.T) {
 	regClient.Timeout = 500 * time.Millisecond
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.RequestURI == "/v1/modules/puppetlabs/deployment/ec/versions" {
-			w.Write([]byte(moduleVersionsMockResponse))
+			w.Write([]byte(puppetModuleVersionsMockResponse))
 			return
 		}
 		if r.RequestURI == "/v1/modules/puppetlabs/deployment/ec/0.0.8" {
-			w.Write([]byte(moduleDataMockResponse))
+			w.Write([]byte(puppetModuleDataMockResponse))
 			return
 		}
 		if r.RequestURI == "/v1/modules/terraform-aws-modules/eks/aws/versions" {

--- a/internal/terraform/module/testdata/unreliable-inputs-module/main.tf
+++ b/internal/terraform/module/testdata/unreliable-inputs-module/main.tf
@@ -1,0 +1,11 @@
+module "label" {
+  source  = "cloudposse/label/null"
+  version = "0.25.0"
+
+}
+
+module "label_two" {
+  source  = "cloudposse/label/null"
+  version = "0.26.0"
+
+}


### PR DESCRIPTION
As discovered in https://github.com/hashicorp/vscode-terraform/issues/1582 it turns out that we assume inputs in some modules as required, when they are actually not.

 - Why? - Because we use data from the Registry API, which (incorrectly) indicates some inputs as required.
 - Which ones? - Modules which have "nullable" inputs (variables with `default = null`)
 - Why? - Because the Registry API did not recognise "nullable" inputs at the time of ingesting the module.
 - Can't the Registry fix this? - The Registry already recognises "nullable" inputs since 19th August 2022.
 - Can't the Registry fix the data then? - This was considered but it involves potentially a _lot_ of modules and module versions, so this is a non-trivial task, esp. given that this would involve basically re-ingesting the modules/versions.

So this ^ is why we're taking a more pragmatic approach and basically treat any _required_ inputs as _optional_ for any modules which we know were published prior to the date when the Registry implemented support for "nullable" inputs.

Importantly, this does not impact recently published modules and module versions. Those will continue to have inputs reflected as-is.