### PR TITLE
Alert on wsl.localhost Path

### DIFF
--- a/internal/uri/uri.go
+++ b/internal/uri/uri.go
@@ -206,5 +206,13 @@ func IsWSLURI(uri string) bool {
 		return false
 	}
 
-	return u.Scheme == "file" && u.Host == "wsl$"
+	if u.Scheme == "file" && u.Host == "wsl$" {
+		return true
+	}
+
+	if u.Scheme == "file" && u.Host == "wsl.localhost" {
+		return true
+	}
+
+	return false
 }

--- a/internal/uri/uri_test.go
+++ b/internal/uri/uri_test.go
@@ -194,6 +194,11 @@ func TestIsWSLURI(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "Localhost WSL file path should return true",
+			uri:  `file://wsl.localhost/Ubuntu/home/james/foo`,
+			want: true,
+		},
+		{
 			name: "Regular file path should return false",
 			uri:  `file://C:/foo/james/foo`,
 			want: false,


### PR DESCRIPTION
This adds path detection for network WSL paths to warn the user to open the path in WSL instead.

A user can open a WSL path directly using the network mount path, which results in opening inside the host VS Code instance instead of inside the WSL instance. This is a problem for terraform-ls, which can't resolve the network paths correctly.  