### PR TITLE
adding a refactor function - `refactor.extract.propToOutput`

### DIFF
--- a/internal/langserver/handlers/code_action.go
+++ b/internal/langserver/handlers/code_action.go
@@ -74,6 +74,21 @@ func (svc *service) textDocumentCodeAction(ctx context.Context, params lsp.CodeA
 					},
 				},
 			})
+		case ilsp.ExtractPropertyToOutput:
+			edits, err := svc.ExtractPropToOutput(ctx, params)
+			if err != nil {
+				return ca, err
+			}
+
+			ca = append(ca, lsp.CodeAction{
+				Title: "Extract Property to Output",
+				Kind:  action,
+				Edit: lsp.WorkspaceEdit{
+					Changes: map[lsp.DocumentURI][]lsp.TextEdit{
+						lsp.DocumentURI(dh.FullURI()): edits,
+					},
+				},
+			})
 		}
 	}
 

--- a/internal/langserver/handlers/extract_prop_to_output.go
+++ b/internal/langserver/handlers/extract_prop_to_output.go
@@ -1,0 +1,75 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	ilsp "github.com/hashicorp/terraform-ls/internal/lsp"
+	lsp "github.com/hashicorp/terraform-ls/internal/protocol"
+)
+
+func (svc *service) ExtractPropToOutput(ctx context.Context, params lsp.CodeActionParams) ([]lsp.TextEdit, error) {
+	var edits []lsp.TextEdit
+
+	dh := ilsp.HandleFromDocumentURI(params.TextDocument.URI)
+
+	doc, err := svc.stateStore.DocumentStore.GetDocument(dh)
+	if err != nil {
+		return edits, err
+	}
+
+	mod, err := svc.stateStore.Modules.ModuleByPath(dh.Dir.Path())
+	if err != nil {
+		return edits, err
+	}
+
+	file, ok := mod.ParsedModuleFiles.AsMap()[dh.Filename]
+	if !ok {
+		return edits, err
+	}
+
+	pos, err := ilsp.HCLPositionFromLspPosition(params.Range.Start, doc)
+	if err != nil {
+		return edits, err
+	}
+
+	blocks := file.BlocksAtPos(pos)
+	if len(blocks) > 1 {
+		return edits, fmt.Errorf("found more than one block at pos: %v", pos)
+	}
+	if len(blocks) == 0 {
+		return edits, fmt.Errorf("can not find block at position %v", pos)
+	}
+
+	attr := file.AttributeAtPos(pos)
+	if attr == nil {
+		return edits, fmt.Errorf("can not find attribute at position %v", pos)
+	}
+
+	tfAddr := append(blocks[0].Labels, attr.Name)
+
+	insertPos := lsp.Position{
+		Line:      uint32(len(doc.Lines)),
+		Character: uint32(len(doc.Lines)),
+	}
+
+	edits = append(edits, lsp.TextEdit{
+		Range: lsp.Range{
+			Start: insertPos,
+			End:   insertPos,
+		},
+		NewText: outputBlock(strings.Join(tfAddr, "_"), strings.Join(tfAddr, ".")),
+	})
+	return edits, nil
+}
+
+func outputBlock(name, tfAddr string) string {
+	f := hclwrite.NewFile()
+	b := hclwrite.NewBlock("output", []string{name})
+	b.Body().SetAttributeRaw("value", hclwrite.TokensForIdentifier(tfAddr))
+	f.Body().AppendNewline()
+	f.Body().AppendBlock(b)
+	return string(f.Bytes())
+}

--- a/internal/langserver/handlers/extract_prop_to_output_test.go
+++ b/internal/langserver/handlers/extract_prop_to_output_test.go
@@ -1,0 +1,483 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package handlers
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/creachadair/jrpc2"
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-ls/internal/langserver"
+	"github.com/hashicorp/terraform-ls/internal/langserver/session"
+	"github.com/hashicorp/terraform-ls/internal/state"
+	"github.com/hashicorp/terraform-ls/internal/terraform/exec"
+	"github.com/hashicorp/terraform-ls/internal/walker"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestLangServer_extractPropToOutput_withoutInitialization(t *testing.T) {
+	ls := langserver.NewLangServerMock(t, NewMockSession(nil))
+	stop := ls.Start(t)
+	defer stop()
+
+	ls.CallAndExpectError(t, &langserver.CallRequest{
+		Method: "textDocument/formatting",
+		ReqParams: fmt.Sprintf(`{
+		"textDocument": {
+			"version": 0,
+			"languageId": "terraform",
+			"text": "provider \"github\" {}",
+			"uri": "%s/main.tf"
+		}
+	}`, TempDir(t).URI),
+	}, session.SessionNotInitialized.Err())
+}
+
+func TestLangServer_ExtractPropToOutput_basic(t *testing.T) {
+	tmpDir := TempDir(t)
+
+	ss, err := state.NewStateStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	wc := walker.NewWalkerCollector()
+
+	ls := langserver.NewLangServerMock(t, NewMockSession(&MockSessionInput{
+		StateStore:      ss,
+		WalkerCollector: wc,
+		TerraformCalls: &exec.TerraformMockCalls{
+			PerWorkDir: map[string][]*mock.Call{
+				tmpDir.Path(): {
+					{
+						Method:        "Version",
+						Repeatability: 1,
+						Arguments: []interface{}{
+							mock.AnythingOfType(""),
+						},
+						ReturnArguments: []interface{}{
+							version.Must(version.NewVersion("0.12.0")),
+							nil,
+							nil,
+						},
+					},
+					{
+						Method:        "GetExecPath",
+						Repeatability: 1,
+						ReturnArguments: []interface{}{
+							"",
+						},
+					},
+					{
+						Method:        "Format",
+						Repeatability: 1,
+						Arguments: []interface{}{
+							mock.AnythingOfType(""),
+							[]byte("provider  \"test\"   {\n\n}\n"),
+						},
+						ReturnArguments: []interface{}{
+							[]byte("provider \"test\" {\n\n}\n"),
+							nil,
+						},
+					},
+				},
+			},
+		},
+	}))
+	stop := ls.Start(t)
+	defer stop()
+
+	ls.Call(t, &langserver.CallRequest{
+		Method: "initialize",
+		ReqParams: fmt.Sprintf(`{
+	    "capabilities": {},
+	    "rootUri": %q,
+	    "processId": 12345
+	}`, tmpDir.URI),
+	})
+	waitForWalkerPath(t, ss, wc, tmpDir)
+	ls.Notify(t, &langserver.CallRequest{
+		Method:    "initialized",
+		ReqParams: "{}",
+	})
+	ls.Call(t, &langserver.CallRequest{
+		Method: "textDocument/didOpen",
+		ReqParams: fmt.Sprintf(`{
+		"textDocument": {
+			"version": 0,
+			"languageId": "terraform",
+			"text": "provider \"test\" {}\n\nresource \"test_resource\" \"test\" {\n    name = \"testname\"\n}",
+			"uri": "%s/main.tf"
+		}
+	}`, tmpDir.URI),
+	})
+	waitForAllJobs(t, ss)
+
+	ls.CallAndExpectResponse(t, &langserver.CallRequest{
+		Method: "textDocument/codeAction",
+		ReqParams: fmt.Sprintf(`{
+  "textDocument": {
+    "uri": "%s/main.tf"
+  },
+  "range": {
+    "start": {
+      "line": 3,
+      "character": 17 
+    },
+    "end": {
+      "line": 3,
+      "character": 17
+    }
+  },
+  "context": {
+    "only": [
+      "refactor.extract.propToOut"
+    ]
+  }
+}`, tmpDir.URI),
+	}, `{
+			"jsonrpc": "2.0",
+			"id": 3,
+			"result": [
+				{
+					"range": {
+						"start": { "line": 0, "character": 0 },
+						"end": { "line": 1, "character": 0 }
+					},
+					"newText": "provider \"test\" {\n"
+				}
+			]
+		}`)
+}
+
+func TestLangServer_ExtractPropToOutput_oldVersion(t *testing.T) {
+	tmpDir := TempDir(t)
+
+	ss, err := state.NewStateStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	wc := walker.NewWalkerCollector()
+
+	ls := langserver.NewLangServerMock(t, NewMockSession(&MockSessionInput{
+		StateStore:      ss,
+		WalkerCollector: wc,
+		TerraformCalls: &exec.TerraformMockCalls{
+			PerWorkDir: map[string][]*mock.Call{
+				tmpDir.Path(): {
+					{
+						Method:        "Version",
+						Repeatability: 1,
+						Arguments: []interface{}{
+							mock.AnythingOfType(""),
+						},
+						ReturnArguments: []interface{}{
+							version.Must(version.NewVersion("0.7.6")),
+							nil,
+							nil,
+						},
+					},
+					{
+						Method:        "GetExecPath",
+						Repeatability: 1,
+						ReturnArguments: []interface{}{
+							"",
+						},
+					},
+					{
+						Method:        "Format",
+						Repeatability: 1,
+						Arguments: []interface{}{
+							mock.AnythingOfType(""),
+							[]byte("provider  \"test\"   {\n\n}\n"),
+						},
+						ReturnArguments: []interface{}{
+							nil,
+							errors.New("not implemented"),
+						},
+					},
+				},
+			},
+		},
+	}))
+	stop := ls.Start(t)
+	defer stop()
+
+	ls.Call(t, &langserver.CallRequest{
+		Method: "initialize",
+		ReqParams: fmt.Sprintf(`{
+	    "capabilities": {},
+	    "rootUri": %q,
+	    "processId": 12345
+	}`, tmpDir.URI),
+	})
+	waitForWalkerPath(t, ss, wc, tmpDir)
+
+	ls.Notify(t, &langserver.CallRequest{
+		Method:    "initialized",
+		ReqParams: "{}",
+	})
+	ls.Call(t, &langserver.CallRequest{
+		Method: "textDocument/didOpen",
+		ReqParams: fmt.Sprintf(`{
+		"textDocument": {
+			"version": 0,
+			"languageId": "terraform",
+			"text": "provider  \"test\"   {\n\n}\n",
+			"uri": "%s/main.tf"
+		}
+	}`, tmpDir.URI),
+	})
+	waitForAllJobs(t, ss)
+
+	ls.CallAndExpectError(t, &langserver.CallRequest{
+		Method: "textDocument/formatting",
+		ReqParams: fmt.Sprintf(`{
+			"textDocument": {
+				"uri": "%s/main.tf"
+			}
+		}`, tmpDir.URI),
+	}, jrpc2.SystemError.Err())
+}
+
+func TestLangServer_extractPropToOutput_variables(t *testing.T) {
+	tmpDir := TempDir(t)
+
+	ss, err := state.NewStateStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	wc := walker.NewWalkerCollector()
+
+	ls := langserver.NewLangServerMock(t, NewMockSession(&MockSessionInput{
+		StateStore:      ss,
+		WalkerCollector: wc,
+		TerraformCalls: &exec.TerraformMockCalls{
+			PerWorkDir: map[string][]*mock.Call{
+				tmpDir.Path(): {
+					{
+						Method:        "Version",
+						Repeatability: 1,
+						Arguments: []interface{}{
+							mock.AnythingOfType(""),
+						},
+						ReturnArguments: []interface{}{
+							version.Must(version.NewVersion("0.12.0")),
+							nil,
+							nil,
+						},
+					},
+					{
+						Method:        "GetExecPath",
+						Repeatability: 1,
+						ReturnArguments: []interface{}{
+							"",
+						},
+					},
+					{
+						Method:        "Format",
+						Repeatability: 1,
+						Arguments: []interface{}{
+							mock.AnythingOfType(""),
+							[]byte("test  = \"dev\""),
+						},
+						ReturnArguments: []interface{}{
+							[]byte("test = \"dev\""),
+							nil,
+						},
+					},
+				},
+			},
+		},
+	}))
+	stop := ls.Start(t)
+	defer stop()
+
+	ls.Call(t, &langserver.CallRequest{
+		Method: "initialize",
+		ReqParams: fmt.Sprintf(`{
+	    "capabilities": {},
+	    "rootUri": %q,
+	    "processId": 12345
+	}`, tmpDir.URI),
+	})
+	waitForWalkerPath(t, ss, wc, tmpDir)
+
+	ls.Notify(t, &langserver.CallRequest{
+		Method:    "initialized",
+		ReqParams: "{}",
+	})
+	ls.Call(t, &langserver.CallRequest{
+		Method: "textDocument/didOpen",
+		ReqParams: fmt.Sprintf(`{
+		"textDocument": {
+			"version": 0,
+			"languageId": "terraform-vars",
+			"text": "test  = \"dev\"",
+			"uri": "%s/terraform.tfvars"
+		}
+	}`, tmpDir.URI),
+	})
+	waitForAllJobs(t, ss)
+
+	ls.CallAndExpectResponse(t, &langserver.CallRequest{
+		Method: "textDocument/formatting",
+		ReqParams: fmt.Sprintf(`{
+			"textDocument": {
+				"uri": "%s/terraform.tfvars"
+			}
+		}`, tmpDir.URI),
+	}, `{
+			"jsonrpc": "2.0",
+			"id": 3,
+			"result": [
+				{
+					"range": {
+						"start": { "line": 0, "character": 0 },
+						"end": { "line": 0, "character": 13 }
+					},
+					"newText": "test = \"dev\""
+				}
+			]
+		}`)
+}
+
+func TestLangServer_extractPropToOutput_diffBug(t *testing.T) {
+	tmpDir := TempDir(t)
+
+	cfg := `resource "aws_lambda_function" "f" {
+  environment {
+    variables = {
+      a = "b"
+    }
+  }
+}
+`
+	formattedCfg := `resource "aws_lambda_function" "f" {
+  environment {
+    variables = {
+      a = "b"
+    }
+  }
+}
+`
+
+	ss, err := state.NewStateStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	wc := walker.NewWalkerCollector()
+
+	ls := langserver.NewLangServerMock(t, NewMockSession(&MockSessionInput{
+		StateStore:      ss,
+		WalkerCollector: wc,
+		TerraformCalls: &exec.TerraformMockCalls{
+			PerWorkDir: map[string][]*mock.Call{
+				tmpDir.Path(): {
+					{
+						Method:        "Version",
+						Repeatability: 1,
+						Arguments: []interface{}{
+							mock.AnythingOfType(""),
+						},
+						ReturnArguments: []interface{}{
+							version.Must(version.NewVersion("0.12.0")),
+							nil,
+							nil,
+						},
+					},
+					{
+						Method:        "GetExecPath",
+						Repeatability: 1,
+						ReturnArguments: []interface{}{
+							"",
+						},
+					},
+					{
+						Method:        "Format",
+						Repeatability: 1,
+						Arguments: []interface{}{
+							mock.AnythingOfType("*context.valueCtx"),
+							[]byte(cfg),
+						},
+						ReturnArguments: []interface{}{
+							[]byte(formattedCfg),
+							nil,
+						},
+					},
+				},
+			},
+		},
+	}))
+	stop := ls.Start(t)
+	defer stop()
+
+	ls.Call(t, &langserver.CallRequest{
+		Method: "initialize",
+		ReqParams: fmt.Sprintf(`{
+	    "capabilities": {},
+	    "rootUri": %q,
+	    "processId": 12345
+	}`, tmpDir.URI),
+	})
+	waitForWalkerPath(t, ss, wc, tmpDir)
+
+	ls.Notify(t, &langserver.CallRequest{
+		Method:    "initialized",
+		ReqParams: "{}",
+	})
+	ls.Call(t, &langserver.CallRequest{
+		Method: "textDocument/didOpen",
+		ReqParams: fmt.Sprintf(`{
+		"textDocument": {
+			"version": 0,
+			"languageId": "terraform",
+			"text": `+fmt.Sprintf("%q", cfg)+`,
+			"uri": "%s/main.tf"
+		}
+	}`, tmpDir.URI),
+	})
+	waitForAllJobs(t, ss)
+
+	ls.CallAndExpectResponse(t, &langserver.CallRequest{
+		Method: "textDocument/formatting",
+		ReqParams: fmt.Sprintf(`{
+			"textDocument": {
+				"uri": "%s/main.tf"
+			}
+		}`, tmpDir.URI),
+	}, `{
+			"jsonrpc": "2.0",
+			"id": 3,
+			"result": [
+				{
+					"range": {
+						"start": {
+							"line": 1,
+							"character": 0
+						},
+						"end": {
+							"line": 5,
+							"character": 0
+						}
+					},
+					"newText": "  environment {\n    variables = {\n      a = \"b\"\n"
+				},
+				{
+					"range": {
+						"start": {
+							"line": 6,
+							"character": 0
+						},
+						"end": {
+							"line": 6,
+							"character": 0
+						}
+					},
+					"newText":"  }\n"
+				}
+			]
+		}`)
+}

--- a/internal/langserver/handlers/extract_prop_to_output_test.go
+++ b/internal/langserver/handlers/extract_prop_to_output_test.go
@@ -24,15 +24,27 @@ func TestLangServer_extractPropToOutput_withoutInitialization(t *testing.T) {
 	defer stop()
 
 	ls.CallAndExpectError(t, &langserver.CallRequest{
-		Method: "textDocument/formatting",
+		Method: "textDocument/codeAction",
 		ReqParams: fmt.Sprintf(`{
-		"textDocument": {
-			"version": 0,
-			"languageId": "terraform",
-			"text": "provider \"github\" {}",
-			"uri": "%s/main.tf"
-		}
-	}`, TempDir(t).URI),
+  "textDocument": {
+    "uri": "%s/main.tf"
+  },
+  "range": {
+    "start": {
+      "line": 4,
+      "character": 17 
+    },
+    "end": {
+      "line": 4,
+      "character": 17
+    }
+  },
+  "context": {
+    "only": [
+      "refactor.extract.propToOut"
+    ]
+  }
+}`, TempDir(t).URI),
 	}, session.SessionNotInitialized.Err())
 }
 
@@ -70,18 +82,6 @@ func TestLangServer_ExtractPropToOutput_basic(t *testing.T) {
 							"",
 						},
 					},
-					{
-						Method:        "Format",
-						Repeatability: 1,
-						Arguments: []interface{}{
-							mock.AnythingOfType(""),
-							[]byte("provider  \"test\"   {\n\n}\n"),
-						},
-						ReturnArguments: []interface{}{
-							[]byte("provider \"test\" {\n\n}\n"),
-							nil,
-						},
-					},
 				},
 			},
 		},
@@ -108,7 +108,7 @@ func TestLangServer_ExtractPropToOutput_basic(t *testing.T) {
 		"textDocument": {
 			"version": 0,
 			"languageId": "terraform",
-			"text": "provider \"test\" {}\n\nresource \"test_resource\" \"test\" {\n    name = \"testname\"\n}",
+			"text": "provider \"test\"{}\n\nresource \"test_resource\" \"test\"{\n    name = \"test\"\n}",
 			"uri": "%s/main.tf"
 		}
 	}`, tmpDir.URI),
@@ -124,11 +124,11 @@ func TestLangServer_ExtractPropToOutput_basic(t *testing.T) {
   "range": {
     "start": {
       "line": 3,
-      "character": 17 
+      "character": 14 
     },
     "end": {
       "line": 3,
-      "character": 17
+      "character": 14
     }
   },
   "context": {
@@ -137,19 +137,35 @@ func TestLangServer_ExtractPropToOutput_basic(t *testing.T) {
     ]
   }
 }`, tmpDir.URI),
-	}, `{
-			"jsonrpc": "2.0",
-			"id": 3,
-			"result": [
-				{
-					"range": {
-						"start": { "line": 0, "character": 0 },
-						"end": { "line": 1, "character": 0 }
-					},
-					"newText": "provider \"test\" {\n"
-				}
-			]
-		}`)
+	}, fmt.Sprintf(`{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "result": [
+    {
+      "title": "Extract Property to Output",
+      "kind": "refactor.extract.propToOut",
+      "edit": {
+        "changes": {
+          "%s/main.tf": [
+            {
+              "range": {
+                "start": {
+                  "line": 6,
+                  "character": 6
+                },
+                "end": {
+                  "line": 6,
+                  "character": 6
+                }
+              },
+              "newText": "\noutput \"test_resource_test_name\" {\n  value = test_resource.test.name\n}\n"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}`, tmpDir.URI))
 }
 
 func TestLangServer_ExtractPropToOutput_oldVersion(t *testing.T) {
@@ -339,144 +355,6 @@ func TestLangServer_extractPropToOutput_variables(t *testing.T) {
 						"end": { "line": 0, "character": 13 }
 					},
 					"newText": "test = \"dev\""
-				}
-			]
-		}`)
-}
-
-func TestLangServer_extractPropToOutput_diffBug(t *testing.T) {
-	tmpDir := TempDir(t)
-
-	cfg := `resource "aws_lambda_function" "f" {
-  environment {
-    variables = {
-      a = "b"
-    }
-  }
-}
-`
-	formattedCfg := `resource "aws_lambda_function" "f" {
-  environment {
-    variables = {
-      a = "b"
-    }
-  }
-}
-`
-
-	ss, err := state.NewStateStore()
-	if err != nil {
-		t.Fatal(err)
-	}
-	wc := walker.NewWalkerCollector()
-
-	ls := langserver.NewLangServerMock(t, NewMockSession(&MockSessionInput{
-		StateStore:      ss,
-		WalkerCollector: wc,
-		TerraformCalls: &exec.TerraformMockCalls{
-			PerWorkDir: map[string][]*mock.Call{
-				tmpDir.Path(): {
-					{
-						Method:        "Version",
-						Repeatability: 1,
-						Arguments: []interface{}{
-							mock.AnythingOfType(""),
-						},
-						ReturnArguments: []interface{}{
-							version.Must(version.NewVersion("0.12.0")),
-							nil,
-							nil,
-						},
-					},
-					{
-						Method:        "GetExecPath",
-						Repeatability: 1,
-						ReturnArguments: []interface{}{
-							"",
-						},
-					},
-					{
-						Method:        "Format",
-						Repeatability: 1,
-						Arguments: []interface{}{
-							mock.AnythingOfType("*context.valueCtx"),
-							[]byte(cfg),
-						},
-						ReturnArguments: []interface{}{
-							[]byte(formattedCfg),
-							nil,
-						},
-					},
-				},
-			},
-		},
-	}))
-	stop := ls.Start(t)
-	defer stop()
-
-	ls.Call(t, &langserver.CallRequest{
-		Method: "initialize",
-		ReqParams: fmt.Sprintf(`{
-	    "capabilities": {},
-	    "rootUri": %q,
-	    "processId": 12345
-	}`, tmpDir.URI),
-	})
-	waitForWalkerPath(t, ss, wc, tmpDir)
-
-	ls.Notify(t, &langserver.CallRequest{
-		Method:    "initialized",
-		ReqParams: "{}",
-	})
-	ls.Call(t, &langserver.CallRequest{
-		Method: "textDocument/didOpen",
-		ReqParams: fmt.Sprintf(`{
-		"textDocument": {
-			"version": 0,
-			"languageId": "terraform",
-			"text": `+fmt.Sprintf("%q", cfg)+`,
-			"uri": "%s/main.tf"
-		}
-	}`, tmpDir.URI),
-	})
-	waitForAllJobs(t, ss)
-
-	ls.CallAndExpectResponse(t, &langserver.CallRequest{
-		Method: "textDocument/formatting",
-		ReqParams: fmt.Sprintf(`{
-			"textDocument": {
-				"uri": "%s/main.tf"
-			}
-		}`, tmpDir.URI),
-	}, `{
-			"jsonrpc": "2.0",
-			"id": 3,
-			"result": [
-				{
-					"range": {
-						"start": {
-							"line": 1,
-							"character": 0
-						},
-						"end": {
-							"line": 5,
-							"character": 0
-						}
-					},
-					"newText": "  environment {\n    variables = {\n      a = \"b\"\n"
-				},
-				{
-					"range": {
-						"start": {
-							"line": 6,
-							"character": 0
-						},
-						"end": {
-							"line": 6,
-							"character": 0
-						}
-					},
-					"newText":"  }\n"
 				}
 			]
 		}`)

--- a/internal/lsp/code_actions.go
+++ b/internal/lsp/code_actions.go
@@ -5,6 +5,7 @@ package lsp
 
 import (
 	"sort"
+	"strings"
 
 	lsp "github.com/hashicorp/terraform-ls/internal/protocol"
 )
@@ -12,31 +13,31 @@ import (
 const (
 	// SourceFormatAllTerraform is a Terraform specific format code action.
 	SourceFormatAllTerraform = "source.formatAll.terraform"
+	ExtractPropertyToOutput  = "refactor.extract.propToOut"
 )
 
 type CodeActions map[lsp.CodeActionKind]bool
 
-var (
-	// `source.*`: Source code actions apply to the entire file. They must be explicitly
-	// requested and will not show in the normal lightbulb menu. Source actions
-	// can be run on save using editor.codeActionsOnSave and are also shown in
-	// the source context menu.
-	// For action definitions, refer to: https://code.visualstudio.com/api/references/vscode-api#CodeActionKind
+// `source.*`: Source code actions apply to the entire file. They must be explicitly
+// requested and will not show in the normal lightbulb menu. Source actions
+// can be run on save using editor.codeActionsOnSave and are also shown in
+// the source context menu.
+// For action definitions, refer to: https://code.visualstudio.com/api/references/vscode-api#CodeActionKind
 
-	// `source.fixAll`: Fix all actions automatically fix errors that have a clear fix that do
-	// not require user input. They should not suppress errors or perform unsafe
-	// fixes such as generating new types or classes.
-	// ** We don't support this as terraform fmt only adjusts style**
-	// lsp.SourceFixAll: true,
+// `source.fixAll`: Fix all actions automatically fix errors that have a clear fix that do
+// not require user input. They should not suppress errors or perform unsafe
+// fixes such as generating new types or classes.
+// ** We don't support this as terraform fmt only adjusts style**
+// lsp.SourceFixAll: true,
 
-	// `source.formatAll`: Generic format code action.
-	// We do not register this for terraform to allow fine grained selection of actions.
-	// A user should be able to set `source.formatAll` to true, and source.formatAll.terraform to false to allow all
-	// files to be formatted, but not terraform files (or vice versa).
-	SupportedCodeActions = CodeActions{
-		SourceFormatAllTerraform: true,
-	}
-)
+// `source.formatAll`: Generic format code action.
+// We do not register this for terraform to allow fine grained selection of actions.
+// A user should be able to set `source.formatAll` to true, and source.formatAll.terraform to false to allow all
+// files to be formatted, but not terraform files (or vice versa).
+var SupportedCodeActions = CodeActions{
+	SourceFormatAllTerraform: true,
+	ExtractPropertyToOutput:  true,
+}
 
 func (c CodeActions) AsSlice() []lsp.CodeActionKind {
 	s := make([]lsp.CodeActionKind, 0)
@@ -54,8 +55,10 @@ func (ca CodeActions) Only(only []lsp.CodeActionKind) CodeActions {
 	wanted := make(CodeActions, 0)
 
 	for _, kind := range only {
-		if v, ok := ca[kind]; ok {
-			wanted[kind] = v
+		for n, v := range ca {
+			if strings.HasPrefix(string(n), string(kind)) {
+				wanted[n] = v
+			}
 		}
 	}
 


### PR DESCRIPTION
It's going to adding a code action to extract an existing property of a resource to a `output` block.

test
---
```
❯ go test -v ./internal/langserver/handlers -run=TestLangServer_ExtractPropToOutput           
=== RUN   TestLangServer_ExtractPropToOutput_basic
2023/12/19 14:11:53 langserver_mock.go:91: Starting mock server ...
[SERVER] 2023/12/19 14:11:53 service.go:106: Preparing new session ...
[CLIENT] 2023/12/19 14:11:53 opts.go:215: Outgoing batch: count=1, bytes=215
[SERVER] 2023/12/19 14:11:53 opts.go:215: Received request batch of size 1 (qlen=0)
[SERVER] 2023/12/19 14:11:53 opts.go:215: Dequeued request batch of length 1 (qlen=0)
[SERVER] 2023/12/19 14:11:53 rpc_logger.go:32: Incoming request for "initialize" (ID 1): {"capabilities":{},
"rootUri":"file:///var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T/terraform-ls/TestLangServer_ExtractPropTo
Output_basic","processId":12345}
[SERVER] 2023/12/19 14:11:53 scheduler.go:56: launching eval loop 0
[SERVER] 2023/12/19 14:11:53 service.go:482: started low priority scheduler
[SERVER] 2023/12/19 14:11:53 scheduler.go:56: launching eval loop 0
[SERVER] 2023/12/19 14:11:53 service.go:487: started high priority scheduler
[SERVER] 2023/12/19 14:11:53 walker_paths.go:255: walking next dir: {"file:///var/folders/73/kpm5cv3j1ps0ndg
hmrltkhdr0000gn/T/terraform-ls/TestLangServer_ExtractPropToOutput_basic"}
[SERVER] 2023/12/19 14:11:53 rpc_logger.go:53: Response to "initialize" (ID 1): {"capabilities":{"textDocume
ntSync":{"openClose":true,"change":2,"save":{}},"completionProvider":{"triggerCharacters":[".","["],"resolve
Provider":true},"hoverProvider":true,"signatureHelpProvider":{"triggerCharacters":["(",","]},"declarationPro
vider":true,"definitionProvider":true,"referencesProvider":true,"documentSymbolProvider":true,"codeActionPro
vider":{"codeActionKinds":["refactor.extract.propToOut","source.formatAll.terraform"]},"codeLensProvider":{}
,"documentLinkProvider":{},"workspaceSymbolProvider":true,"documentFormattingProvider":true,"executeCommandP
rovider":{"commands":["terraform-ls.module.callers","terraform-ls.module.calls","terraform-ls.module.provide
rs","terraform-ls.module.terraform","terraform-ls.rootmodules","terraform-ls.terraform.init","terraform-ls.t
erraform.validate"],"workDoneProgress":true},"semanticTokensProvider":{"legend":{"tokenTypes":[],"tokenModif
iers":[]}},"workspace":{"workspaceFolders":{"supported":true,"changeNotifications":"workspace/didChangeWorks
paceFolders"},"fileOperations":{}},"experimental":{"referenceCountCodeLens":false,"refreshModuleProviders":f
alse,"refreshModuleCalls":false,"refreshTerraformVersion":false}},"serverInfo":{"name":"terraform-ls","versi
on":""}}
[SERVER] 2023/12/19 14:11:53 opts.go:215: Completed 1 requests [998.584µs elapsed]
[SERVER] 2023/12/19 14:11:53 walker.go:242: walking of {file:///var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000g
n/T/terraform-ls/TestLangServer_ExtractPropToOutput_basic} finished
[CLIENT] 2023/12/19 14:11:53 opts.go:215: Received 1 responses
[SERVER] 2023/12/19 14:11:53 walker.go:156: walker: walking through {"file:///var/folders/73/kpm5cv3j1ps0ndg
hmrltkhdr0000gn/T/terraform-ls/TestLangServer_ExtractPropToOutput_basic"} finished
[CLIENT] 2023/12/19 14:11:53 opts.go:215: Completed request for ID "1"
[CLIENT] 2023/12/19 14:11:53 opts.go:215: Outgoing batch: count=1, bytes=52
[SERVER] 2023/12/19 14:11:53 opts.go:215: Received request batch of size 1 (qlen=0)
[SERVER] 2023/12/19 14:11:53 opts.go:215: Dequeued request batch of length 1 (qlen=0)
[SERVER] 2023/12/19 14:11:53 rpc_logger.go:32: Incoming notification for "initialized": {}
[SERVER] 2023/12/19 14:11:53 initialized.go:27: Client doesn't support dynamic watched files registration, p
rovider and module changes may not be reflected at runtime
[CLIENT] 2023/12/19 14:11:53 opts.go:215: Outgoing batch: count=1, bytes=340
[SERVER] 2023/12/19 14:11:53 opts.go:215: Received request batch of size 1 (qlen=0)
[SERVER] 2023/12/19 14:11:53 opts.go:215: Dequeued request batch of length 1 (qlen=0)
[SERVER] 2023/12/19 14:11:53 rpc_logger.go:32: Incoming request for "textDocument/didOpen" (ID 2): {"textDoc
ument":{"version":0,"languageId":"terraform","text":"provider \"test\"{}\n\nresource \"test_resource\" \"tes
t\"{\n    name = \"test\"\n}","uri":"file:///var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T/terraform-ls/Te
stLangServer_ExtractPropToOutput_basic/main.tf"}}
[SERVER] 2023/12/19 14:11:53 did_open.go:56: opened module: /var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T
/terraform-ls/TestLangServer_ExtractPropToOutput_basic
[SERVER] 2023/12/19 14:11:53 jobs.go:140: JOBS: Enqueueing new job "1": "OpTypeGetTerraformVersion" for {"fi
le:///var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T/terraform-ls/TestLangServer_ExtractPropToOutput_basic"
} (IsDirOpen: true, IgnoreState: false)
[SERVER] 2023/12/19 14:11:53 jobs.go:299: retrying on obj is nil
[SERVER] 2023/12/19 14:11:53 jobs.go:140: JOBS: Enqueueing new job "2": "OpTypeParseModuleConfiguration" for
 {"file:///var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T/terraform-ls/TestLangServer_ExtractPropToOutput_b
asic"} (IsDirOpen: true, IgnoreState: true)
[SERVER] 2023/12/19 14:11:53 jobs.go:299: retrying on obj is nil
[SERVER] 2023/12/19 14:11:53 jobs.go:299: retrying on obj is nil
[SERVER] 2023/12/19 14:11:53 jobs.go:140: JOBS: Enqueueing new job "3": "OpTypeLoadModuleMetadata" for {"fil
e:///var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T/terraform-ls/TestLangServer_ExtractPropToOutput_basic"}
 (IsDirOpen: true, IgnoreState: true)
[SERVER] 2023/12/19 14:11:53 jobs.go:299: retrying on obj is nil
[SERVER] 2023/12/19 14:11:53 jobs.go:140: JOBS: Enqueueing new job "4": "OpTypeGetModuleDataFromRegistry" fo
r {"file:///var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T/terraform-ls/TestLangServer_ExtractPropToOutput_
basic"} (IsDirOpen: true, IgnoreState: false)
[SERVER] 2023/12/19 14:11:53 jobs.go:299: retrying on obj is nil
[SERVER] 2023/12/19 14:11:53 jobs.go:140: JOBS: Enqueueing new job "5": "OpTypeParseVariables" for {"file://
/var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T/terraform-ls/TestLangServer_ExtractPropToOutput_basic"} (Is
DirOpen: true, IgnoreState: true)
[SERVER] 2023/12/19 14:11:53 jobs.go:140: JOBS: Enqueueing new job "6": "OpTypeSchemaVarsValidation" for {"f
ile:///var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T/terraform-ls/TestLangServer_ExtractPropToOutput_basic
"} (IsDirOpen: true, IgnoreState: true)
[SERVER] 2023/12/19 14:11:53 jobs.go:140: JOBS: Enqueueing new job "7": "OpTypeDecodeVarsReferences" for {"f
ile:///var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T/terraform-ls/TestLangServer_ExtractPropToOutput_basic
"} (IsDirOpen: true, IgnoreState: false)
[SERVER] 2023/12/19 14:11:53 jobs.go:321: JOBS: Dispatching next job "1" (scheduler prio: 1, job prio: 0, is
DirOpen: true): "OpTypeGetTerraformVersion" for {"file:///var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T/te
rraform-ls/TestLangServer_ExtractPropToOutput_basic"}
[SERVER] 2023/12/19 14:11:53 jobs.go:461: JOBS: Finishing job "1": "OpTypeGetTerraformVersion" for {"file://
/var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T/terraform-ls/TestLangServer_ExtractPropToOutput_basic"} (er
r = %!s(<nil>), deferredJobs: [])
[SERVER] 2023/12/19 14:11:53 jobs.go:321: JOBS: Dispatching next job "2" (scheduler prio: 1, job prio: 0, is
DirOpen: true): "OpTypeParseModuleConfiguration" for {"file:///var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn
/T/terraform-ls/TestLangServer_ExtractPropToOutput_basic"}
[SERVER] 2023/12/19 14:11:53 jobs.go:461: JOBS: Finishing job "2": "OpTypeParseModuleConfiguration" for {"fi
le:///var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T/terraform-ls/TestLangServer_ExtractPropToOutput_basic"
} (err = %!s(<nil>), deferredJobs: [])
[SERVER] 2023/12/19 14:11:53 jobs.go:321: JOBS: Dispatching next job "3" (scheduler prio: 1, job prio: 0, is
DirOpen: true): "OpTypeLoadModuleMetadata" for {"file:///var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T/ter
raform-ls/TestLangServer_ExtractPropToOutput_basic"}
[SERVER] 2023/12/19 14:11:53 module_calls.go:64: indexing declared module calls for "file:///var/folders/73/
kpm5cv3j1ps0ndghmrltkhdr0000gn/T/terraform-ls/TestLangServer_ExtractPropToOutput_basic": 0
[SERVER] 2023/12/19 14:11:53 jobs.go:140: JOBS: Enqueueing new job "8": "OpTypePreloadEmbeddedSchema" for {"
file:///var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T/terraform-ls/TestLangServer_ExtractPropToOutput_basi
c"} (IsDirOpen: true, IgnoreState: true)
[SERVER] 2023/12/19 14:11:53 jobs.go:140: JOBS: Enqueueing new job "9": "OpTypeSchemaModuleValidation" for {
"file:///var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T/terraform-ls/TestLangServer_ExtractPropToOutput_bas
ic"} (IsDirOpen: true, IgnoreState: true)
[SERVER] 2023/12/19 14:11:53 jobs.go:140: JOBS: Enqueueing new job "10": "OpTypeDecodeReferenceTargets" for 
{"file:///var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T/terraform-ls/TestLangServer_ExtractPropToOutput_ba
sic"} (IsDirOpen: true, IgnoreState: true)
[SERVER] 2023/12/19 14:11:53 jobs.go:140: JOBS: Enqueueing new job "11": "OpTypeDecodeReferenceOrigins" for 
{"file:///var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T/terraform-ls/TestLangServer_ExtractPropToOutput_ba
sic"} (IsDirOpen: true, IgnoreState: true)
[SERVER] 2023/12/19 14:11:53 jobs.go:140: JOBS: Enqueueing new job "12": "OpTypeReferenceValidation" for {"f
ile:///var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T/terraform-ls/TestLangServer_ExtractPropToOutput_basic
"} (IsDirOpen: true, IgnoreState: true)
[SERVER] 2023/12/19 14:11:53 jobs.go:461: JOBS: Finishing job "3": "OpTypeLoadModuleMetadata" for {"file:///
var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T/terraform-ls/TestLangServer_ExtractPropToOutput_basic"} (err
 = %!s(<nil>), deferredJobs: ["8" "10" "11"])
[SERVER] 2023/12/19 14:11:53 jobs.go:299: retrying on obj is nil
[SERVER] 2023/12/19 14:11:53 jobs.go:321: JOBS: Dispatching next job "5" (scheduler prio: 1, job prio: 0, is
DirOpen: true): "OpTypeParseVariables" for {"file:///var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T/terrafo
rm-ls/TestLangServer_ExtractPropToOutput_basic"}
[SERVER] 2023/12/19 14:11:53 jobs.go:321: JOBS: Dispatching next job "4" (scheduler prio: -1, job prio: -1, 
isDirOpen: true): "OpTypeGetModuleDataFromRegistry" for {"file:///var/folders/73/kpm5cv3j1ps0ndghmrltkhdr000
0gn/T/terraform-ls/TestLangServer_ExtractPropToOutput_basic"}
[SERVER] 2023/12/19 14:11:53 jobs.go:461: JOBS: Finishing job "4": "OpTypeGetModuleDataFromRegistry" for {"f
ile:///var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T/terraform-ls/TestLangServer_ExtractPropToOutput_basic
"} (err = %!s(<nil>), deferredJobs: [])
[SERVER] 2023/12/19 14:11:53 jobs.go:461: JOBS: Finishing job "5": "OpTypeParseVariables" for {"file:///var/
folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T/terraform-ls/TestLangServer_ExtractPropToOutput_basic"} (err = %
!s(<nil>), deferredJobs: [])
[SERVER] 2023/12/19 14:11:53 jobs.go:321: JOBS: Dispatching next job "6" (scheduler prio: 1, job prio: 0, is
DirOpen: true): "OpTypeSchemaVarsValidation" for {"file:///var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T/t
erraform-ls/TestLangServer_ExtractPropToOutput_basic"}
[SERVER] 2023/12/19 14:11:53 jobs.go:299: retrying on obj is nil
[SERVER] 2023/12/19 14:11:53 jobs.go:461: JOBS: Finishing job "6": "OpTypeSchemaVarsValidation" for {"file:/
//var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T/terraform-ls/TestLangServer_ExtractPropToOutput_basic"} (e
rr = %!s(<nil>), deferredJobs: [])
[SERVER] 2023/12/19 14:11:53 jobs.go:299: retrying on obj is nil
[SERVER] 2023/12/19 14:11:53 jobs.go:321: JOBS: Dispatching next job "7" (scheduler prio: 1, job prio: 0, is
DirOpen: true): "OpTypeDecodeVarsReferences" for {"file:///var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T/t
erraform-ls/TestLangServer_ExtractPropToOutput_basic"}
[SERVER] 2023/12/19 14:11:53 jobs.go:299: retrying on obj is nil
[SERVER] 2023/12/19 14:11:53 jobs.go:461: JOBS: Finishing job "7": "OpTypeDecodeVarsReferences" for {"file:/
//var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T/terraform-ls/TestLangServer_ExtractPropToOutput_basic"} (e
rr = %!s(<nil>), deferredJobs: [])
[SERVER] 2023/12/19 14:11:53 jobs.go:321: JOBS: Dispatching next job "8" (scheduler prio: 1, job prio: 0, is
DirOpen: true): "OpTypePreloadEmbeddedSchema" for {"file:///var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T/
terraform-ls/TestLangServer_ExtractPropToOutput_basic"}
[SERVER] 2023/12/19 14:11:53 jobs.go:299: retrying on obj is nil
[SERVER] 2023/12/19 14:11:53 module_ops.go:301: preloaded schema not available for registry.terraform.io/has
hicorp/test
[SERVER] 2023/12/19 14:11:53 jobs.go:461: JOBS: Finishing job "8": "OpTypePreloadEmbeddedSchema" for {"file:
///var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T/terraform-ls/TestLangServer_ExtractPropToOutput_basic"} (
err = %!s(<nil>), deferredJobs: [])
[SERVER] 2023/12/19 14:11:53 jobs.go:321: JOBS: Dispatching next job "10" (scheduler prio: 1, job prio: 0, i
sDirOpen: true): "OpTypeDecodeReferenceTargets" for {"file:///var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/
T/terraform-ls/TestLangServer_ExtractPropToOutput_basic"}
[SERVER] 2023/12/19 14:11:53 jobs.go:299: retrying on obj is nil
[SERVER] 2023/12/19 14:11:53 provider_schema.go:306: PSS: getting provider schema (/var/folders/73/kpm5cv3j1
ps0ndghmrltkhdr0000gn/T/terraform-ls/TestLangServer_ExtractPropToOutput_basic, registry.terraform.io/-/test,
 )
[SERVER] 2023/12/19 14:11:53 jobs.go:461: JOBS: Finishing job "10": "OpTypeDecodeReferenceTargets" for {"fil
e:///var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T/terraform-ls/TestLangServer_ExtractPropToOutput_basic"}
 (err = %!s(<nil>), deferredJobs: [])
[SERVER] 2023/12/19 14:11:53 jobs.go:299: retrying on obj is nil
[SERVER] 2023/12/19 14:11:53 jobs.go:321: JOBS: Dispatching next job "11" (scheduler prio: 1, job prio: 0, i
sDirOpen: true): "OpTypeDecodeReferenceOrigins" for {"file:///var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/
T/terraform-ls/TestLangServer_ExtractPropToOutput_basic"}
[SERVER] 2023/12/19 14:11:53 jobs.go:299: retrying on obj is nil
[SERVER] 2023/12/19 14:11:53 provider_schema.go:306: PSS: getting provider schema (/var/folders/73/kpm5cv3j1
ps0ndghmrltkhdr0000gn/T/terraform-ls/TestLangServer_ExtractPropToOutput_basic, registry.terraform.io/-/test,
 )
[SERVER] 2023/12/19 14:11:53 jobs.go:461: JOBS: Finishing job "11": "OpTypeDecodeReferenceOrigins" for {"fil
e:///var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T/terraform-ls/TestLangServer_ExtractPropToOutput_basic"}
 (err = %!s(<nil>), deferredJobs: [])
[SERVER] 2023/12/19 14:11:53 rpc_logger.go:53: Response to "textDocument/didOpen" (ID 2): null
[SERVER] 2023/12/19 14:11:53 opts.go:215: Completed 1 requests [3.817083ms elapsed]
[SERVER] 2023/12/19 14:11:53 jobs.go:299: retrying on obj is nil
[CLIENT] 2023/12/19 14:11:53 opts.go:215: Received 1 responses
[SERVER] 2023/12/19 14:11:53 jobs.go:321: JOBS: Dispatching next job "12" (scheduler prio: 1, job prio: 0, i
sDirOpen: true): "OpTypeReferenceValidation" for {"file:///var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T/t
erraform-ls/TestLangServer_ExtractPropToOutput_basic"}
[CLIENT] 2023/12/19 14:11:53 opts.go:215: Completed request for ID "2"
[SERVER] 2023/12/19 14:11:53 jobs.go:299: retrying on obj is nil
[SERVER] 2023/12/19 14:11:53 provider_schema.go:306: PSS: getting provider schema (/var/folders/73/kpm5cv3j1
ps0ndghmrltkhdr0000gn/T/terraform-ls/TestLangServer_ExtractPropToOutput_basic, registry.terraform.io/-/test,
 )
[SERVER] 2023/12/19 14:11:53 jobs.go:461: JOBS: Finishing job "12": "OpTypeReferenceValidation" for {"file:/
//var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T/terraform-ls/TestLangServer_ExtractPropToOutput_basic"} (e
rr = %!s(<nil>), deferredJobs: [])
[SERVER] 2023/12/19 14:11:53 jobs.go:299: retrying on obj is nil
[SERVER] 2023/12/19 14:11:53 jobs.go:321: JOBS: Dispatching next job "9" (scheduler prio: 1, job prio: 0, is
DirOpen: true): "OpTypeSchemaModuleValidation" for {"file:///var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T
/terraform-ls/TestLangServer_ExtractPropToOutput_basic"}
[SERVER] 2023/12/19 14:11:53 jobs.go:299: retrying on obj is nil
[SERVER] 2023/12/19 14:11:53 provider_schema.go:306: PSS: getting provider schema (/var/folders/73/kpm5cv3j1
ps0ndghmrltkhdr0000gn/T/terraform-ls/TestLangServer_ExtractPropToOutput_basic, registry.terraform.io/-/test,
 )
[SERVER] 2023/12/19 14:11:53 jobs.go:461: JOBS: Finishing job "9": "OpTypeSchemaModuleValidation" for {"file
:///var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T/terraform-ls/TestLangServer_ExtractPropToOutput_basic"} 
(err = %!s(<nil>), deferredJobs: [])
[CLIENT] 2023/12/19 14:11:53 opts.go:215: Outgoing batch: count=1, bytes=339
[SERVER] 2023/12/19 14:11:53 jobs.go:299: retrying on obj is nil
[SERVER] 2023/12/19 14:11:53 opts.go:215: Received request batch of size 1 (qlen=0)
[SERVER] 2023/12/19 14:11:53 opts.go:215: Dequeued request batch of length 1 (qlen=0)
[SERVER] 2023/12/19 14:11:53 rpc_logger.go:32: Incoming request for "textDocument/codeAction" (ID 3): {"text
Document":{"uri":"file:///var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T/terraform-ls/TestLangServer_Extrac
tPropToOutput_basic/main.tf"},"range":{"start":{"line":3,"character":14},"end":{"line":3,"character":14}},"c
ontext":{"only":["refactor.extract.propToOut"]}}
[SERVER] 2023/12/19 14:11:53 code_action.go:37: Code actions requested: "refactor.extract.propToOut"
[SERVER] 2023/12/19 14:11:53 code_action.go:46: Code actions supported: map[refactor.extract.propToOut:true]
[SERVER] 2023/12/19 14:11:53 rpc_logger.go:53: Response to "textDocument/codeAction" (ID 3): [{"title":"Extr
act Property to Output","kind":"refactor.extract.propToOut","edit":{"changes":{"file:///var/folders/73/kpm5c
v3j1ps0ndghmrltkhdr0000gn/T/terraform-ls/TestLangServer_ExtractPropToOutput_basic/main.tf":[{"range":{"start
":{"line":6,"character":6},"end":{"line":6,"character":6}},"newText":"\noutput \"test_resource_test_name\" {
\n  value = test_resource.test.name\n}\n"}]}}}]
[SERVER] 2023/12/19 14:11:53 opts.go:215: Completed 1 requests [231µs elapsed]
[CLIENT] 2023/12/19 14:11:53 opts.go:215: Received 1 responses
[CLIENT] 2023/12/19 14:11:53 opts.go:215: Completed request for ID "3"
2023/12/19 14:11:53 langserver_mock.go:77: Stopping mock server ...
[SERVER] 2023/12/19 14:11:53 opts.go:215: Server signaled to stop with err=the server has been stopped
[SERVER] 2023/12/19 14:11:53 opts.go:215: Error reading from client: the server has been stopped
[SERVER] 2023/12/19 14:11:53 service.go:568: stopping closedDirWalker for session ...
[SERVER] 2023/12/19 14:11:53 service.go:570: closedDirWalker stopped
[SERVER] 2023/12/19 14:11:53 service.go:573: stopping openDirWalker for session ...
[SERVER] 2023/12/19 14:11:53 service.go:575: openDirWalker stopped
[SERVER] 2023/12/19 14:11:53 scheduler.go:63: stopped scheduler
[SERVER] 2023/12/19 14:11:53 scheduler.go:63: stopped scheduler
--- PASS: TestLangServer_ExtractPropToOutput_basic (0.01s)
=== RUN   TestLangServer_ExtractPropToOutput_oldVersion
[SERVER] 2023/12/19 14:11:53 notifier.go:55: failed to notify a change batch: context canceled
[SERVER] 2023/12/19 14:11:53 notifier.go:48: stopping notifier: context canceled
2023/12/19 14:11:53 langserver_mock.go:91: Starting mock server ...
[SERVER] 2023/12/19 14:11:53 service.go:106: Preparing new session ...
[CLIENT] 2023/12/19 14:11:53 opts.go:215: Outgoing batch: count=1, bytes=220
[SERVER] 2023/12/19 14:11:53 opts.go:215: Received request batch of size 1 (qlen=0)
[SERVER] 2023/12/19 14:11:53 opts.go:215: Dequeued request batch of length 1 (qlen=0)
[SERVER] 2023/12/19 14:11:53 rpc_logger.go:32: Incoming request for "initialize" (ID 1): {"capabilities":{},
"rootUri":"file:///var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T/terraform-ls/TestLangServer_ExtractPropTo
Output_oldVersion","processId":12345}
[SERVER] 2023/12/19 14:11:53 scheduler.go:56: launching eval loop 0
[SERVER] 2023/12/19 14:11:53 service.go:482: started low priority scheduler
[SERVER] 2023/12/19 14:11:53 scheduler.go:56: launching eval loop 0
[SERVER] 2023/12/19 14:11:53 service.go:487: started high priority scheduler
[SERVER] 2023/12/19 14:11:53 rpc_logger.go:53: Response to "initialize" (ID 1): {"capabilities":{"textDocume
ntSync":{"openClose":true,"change":2,"save":{}},"completionProvider":{"triggerCharacters":[".","["],"resolve
Provider":true},"hoverProvider":true,"signatureHelpProvider":{"triggerCharacters":["(",","]},"declarationPro
vider":true,"definitionProvider":true,"referencesProvider":true,"documentSymbolProvider":true,"codeActionPro
vider":{"codeActionKinds":["refactor.extract.propToOut","source.formatAll.terraform"]},"codeLensProvider":{}
,"documentLinkProvider":{},"workspaceSymbolProvider":true,"documentFormattingProvider":true,"executeCommandP
rovider":{"commands":["terraform-ls.module.callers","terraform-ls.module.calls","terraform-ls.module.provide
rs","terraform-ls.module.terraform","terraform-ls.rootmodules","terraform-ls.terraform.init","terraform-ls.t
erraform.validate"],"workDoneProgress":true},"semanticTokensProvider":{"legend":{"tokenTypes":[],"tokenModif
iers":[]}},"workspace":{"workspaceFolders":{"supported":true,"changeNotifications":"workspace/didChangeWorks
paceFolders"},"fileOperations":{}},"experimental":{"referenceCountCodeLens":false,"refreshModuleProviders":f
alse,"refreshModuleCalls":false,"refreshTerraformVersion":false}},"serverInfo":{"name":"terraform-ls","versi
on":""}}
[SERVER] 2023/12/19 14:11:53 opts.go:215: Completed 1 requests [158.917µs elapsed]
[SERVER] 2023/12/19 14:11:53 walker_paths.go:255: walking next dir: {"file:///var/folders/73/kpm5cv3j1ps0ndg
hmrltkhdr0000gn/T/terraform-ls/TestLangServer_ExtractPropToOutput_oldVersion"}
[CLIENT] 2023/12/19 14:11:53 opts.go:215: Received 1 responses
[CLIENT] 2023/12/19 14:11:53 opts.go:215: Completed request for ID "1"
[SERVER] 2023/12/19 14:11:53 walker.go:242: walking of {file:///var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000g
n/T/terraform-ls/TestLangServer_ExtractPropToOutput_oldVersion} finished
[SERVER] 2023/12/19 14:11:53 walker.go:156: walker: walking through {"file:///var/folders/73/kpm5cv3j1ps0ndg
hmrltkhdr0000gn/T/terraform-ls/TestLangServer_ExtractPropToOutput_oldVersion"} finished
[CLIENT] 2023/12/19 14:11:53 opts.go:215: Outgoing batch: count=1, bytes=52
[SERVER] 2023/12/19 14:11:53 opts.go:215: Received request batch of size 1 (qlen=0)
[SERVER] 2023/12/19 14:11:53 opts.go:215: Dequeued request batch of length 1 (qlen=0)
[SERVER] 2023/12/19 14:11:53 rpc_logger.go:32: Incoming notification for "initialized": {}
[SERVER] 2023/12/19 14:11:53 initialized.go:27: Client doesn't support dynamic watched files registration, p
rovider and module changes may not be reflected at runtime
[CLIENT] 2023/12/19 14:11:53 opts.go:215: Outgoing batch: count=1, bytes=291
[SERVER] 2023/12/19 14:11:53 opts.go:215: Received request batch of size 1 (qlen=0)
[SERVER] 2023/12/19 14:11:53 opts.go:215: Dequeued request batch of length 1 (qlen=0)
[SERVER] 2023/12/19 14:11:53 rpc_logger.go:32: Incoming request for "textDocument/didOpen" (ID 2): {"textDoc
ument":{"version":0,"languageId":"terraform","text":"provider  \"test\"   {\n\n}\n","uri":"file:///var/folde
rs/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T/terraform-ls/TestLangServer_ExtractPropToOutput_oldVersion/main.tf"}}
[SERVER] 2023/12/19 14:11:53 did_open.go:56: opened module: /var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T
/terraform-ls/TestLangServer_ExtractPropToOutput_oldVersion
[SERVER] 2023/12/19 14:11:53 jobs.go:140: JOBS: Enqueueing new job "1": "OpTypeGetTerraformVersion" for {"fi
le:///var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T/terraform-ls/TestLangServer_ExtractPropToOutput_oldVer
sion"} (IsDirOpen: true, IgnoreState: false)
[SERVER] 2023/12/19 14:11:53 jobs.go:140: JOBS: Enqueueing new job "2": "OpTypeParseModuleConfiguration" for
 {"file:///var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T/terraform-ls/TestLangServer_ExtractPropToOutput_o
ldVersion"} (IsDirOpen: true, IgnoreState: true)
[SERVER] 2023/12/19 14:11:53 jobs.go:299: retrying on obj is nil
[SERVER] 2023/12/19 14:11:53 jobs.go:299: retrying on obj is nil
[SERVER] 2023/12/19 14:11:53 jobs.go:299: retrying on obj is nil
[SERVER] 2023/12/19 14:11:53 jobs.go:140: JOBS: Enqueueing new job "3": "OpTypeLoadModuleMetadata" for {"fil
e:///var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T/terraform-ls/TestLangServer_ExtractPropToOutput_oldVers
ion"} (IsDirOpen: true, IgnoreState: true)
[SERVER] 2023/12/19 14:11:53 jobs.go:299: retrying on obj is nil
[SERVER] 2023/12/19 14:11:53 jobs.go:140: JOBS: Enqueueing new job "4": "OpTypeGetModuleDataFromRegistry" fo
r {"file:///var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T/terraform-ls/TestLangServer_ExtractPropToOutput_
oldVersion"} (IsDirOpen: true, IgnoreState: false)
[SERVER] 2023/12/19 14:11:53 jobs.go:299: retrying on obj is nil
[SERVER] 2023/12/19 14:11:53 jobs.go:140: JOBS: Enqueueing new job "5": "OpTypeParseVariables" for {"file://
/var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T/terraform-ls/TestLangServer_ExtractPropToOutput_oldVersion"
} (IsDirOpen: true, IgnoreState: true)
[SERVER] 2023/12/19 14:11:53 jobs.go:140: JOBS: Enqueueing new job "6": "OpTypeSchemaVarsValidation" for {"f
ile:///var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T/terraform-ls/TestLangServer_ExtractPropToOutput_oldVe
rsion"} (IsDirOpen: true, IgnoreState: true)
[SERVER] 2023/12/19 14:11:53 jobs.go:140: JOBS: Enqueueing new job "7": "OpTypeDecodeVarsReferences" for {"f
ile:///var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T/terraform-ls/TestLangServer_ExtractPropToOutput_oldVe
rsion"} (IsDirOpen: true, IgnoreState: false)
[SERVER] 2023/12/19 14:11:53 jobs.go:321: JOBS: Dispatching next job "1" (scheduler prio: 1, job prio: 0, is
DirOpen: true): "OpTypeGetTerraformVersion" for {"file:///var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T/te
rraform-ls/TestLangServer_ExtractPropToOutput_oldVersion"}
[SERVER] 2023/12/19 14:11:53 jobs.go:461: JOBS: Finishing job "1": "OpTypeGetTerraformVersion" for {"file://
/var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T/terraform-ls/TestLangServer_ExtractPropToOutput_oldVersion"
} (err = %!s(<nil>), deferredJobs: [])
[SERVER] 2023/12/19 14:11:53 jobs.go:321: JOBS: Dispatching next job "2" (scheduler prio: 1, job prio: 0, is
DirOpen: true): "OpTypeParseModuleConfiguration" for {"file:///var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn
/T/terraform-ls/TestLangServer_ExtractPropToOutput_oldVersion"}
[SERVER] 2023/12/19 14:11:53 jobs.go:461: JOBS: Finishing job "2": "OpTypeParseModuleConfiguration" for {"fi
le:///var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T/terraform-ls/TestLangServer_ExtractPropToOutput_oldVer
sion"} (err = %!s(<nil>), deferredJobs: [])
[SERVER] 2023/12/19 14:11:53 jobs.go:321: JOBS: Dispatching next job "3" (scheduler prio: 1, job prio: 0, is
DirOpen: true): "OpTypeLoadModuleMetadata" for {"file:///var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T/ter
raform-ls/TestLangServer_ExtractPropToOutput_oldVersion"}
[SERVER] 2023/12/19 14:11:53 module_calls.go:64: indexing declared module calls for "file:///var/folders/73/
kpm5cv3j1ps0ndghmrltkhdr0000gn/T/terraform-ls/TestLangServer_ExtractPropToOutput_oldVersion": 0
[SERVER] 2023/12/19 14:11:53 jobs.go:140: JOBS: Enqueueing new job "8": "OpTypePreloadEmbeddedSchema" for {"
file:///var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T/terraform-ls/TestLangServer_ExtractPropToOutput_oldV
ersion"} (IsDirOpen: true, IgnoreState: true)
[SERVER] 2023/12/19 14:11:53 jobs.go:140: JOBS: Enqueueing new job "9": "OpTypeSchemaModuleValidation" for {
"file:///var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T/terraform-ls/TestLangServer_ExtractPropToOutput_old
Version"} (IsDirOpen: true, IgnoreState: true)
[SERVER] 2023/12/19 14:11:53 jobs.go:140: JOBS: Enqueueing new job "10": "OpTypeDecodeReferenceTargets" for 
{"file:///var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T/terraform-ls/TestLangServer_ExtractPropToOutput_ol
dVersion"} (IsDirOpen: true, IgnoreState: true)
[SERVER] 2023/12/19 14:11:53 jobs.go:140: JOBS: Enqueueing new job "11": "OpTypeDecodeReferenceOrigins" for 
{"file:///var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T/terraform-ls/TestLangServer_ExtractPropToOutput_ol
dVersion"} (IsDirOpen: true, IgnoreState: true)
[SERVER] 2023/12/19 14:11:53 jobs.go:140: JOBS: Enqueueing new job "12": "OpTypeReferenceValidation" for {"f
ile:///var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T/terraform-ls/TestLangServer_ExtractPropToOutput_oldVe
rsion"} (IsDirOpen: true, IgnoreState: true)
[SERVER] 2023/12/19 14:11:53 jobs.go:461: JOBS: Finishing job "3": "OpTypeLoadModuleMetadata" for {"file:///
var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T/terraform-ls/TestLangServer_ExtractPropToOutput_oldVersion"}
 (err = %!s(<nil>), deferredJobs: ["8" "10" "11"])
[SERVER] 2023/12/19 14:11:53 jobs.go:299: retrying on obj is nil
[SERVER] 2023/12/19 14:11:53 jobs.go:321: JOBS: Dispatching next job "5" (scheduler prio: 1, job prio: 0, is
DirOpen: true): "OpTypeParseVariables" for {"file:///var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T/terrafo
rm-ls/TestLangServer_ExtractPropToOutput_oldVersion"}
[SERVER] 2023/12/19 14:11:53 jobs.go:321: JOBS: Dispatching next job "4" (scheduler prio: -1, job prio: -1, 
isDirOpen: true): "OpTypeGetModuleDataFromRegistry" for {"file:///var/folders/73/kpm5cv3j1ps0ndghmrltkhdr000
0gn/T/terraform-ls/TestLangServer_ExtractPropToOutput_oldVersion"}
[SERVER] 2023/12/19 14:11:53 jobs.go:461: JOBS: Finishing job "4": "OpTypeGetModuleDataFromRegistry" for {"f
ile:///var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T/terraform-ls/TestLangServer_ExtractPropToOutput_oldVe
rsion"} (err = %!s(<nil>), deferredJobs: [])
[SERVER] 2023/12/19 14:11:53 jobs.go:461: JOBS: Finishing job "5": "OpTypeParseVariables" for {"file:///var/
folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T/terraform-ls/TestLangServer_ExtractPropToOutput_oldVersion"} (er
r = %!s(<nil>), deferredJobs: [])
[SERVER] 2023/12/19 14:11:53 jobs.go:299: retrying on obj is nil
[SERVER] 2023/12/19 14:11:53 jobs.go:299: retrying on obj is nil
[SERVER] 2023/12/19 14:11:53 jobs.go:321: JOBS: Dispatching next job "6" (scheduler prio: 1, job prio: 0, is
DirOpen: true): "OpTypeSchemaVarsValidation" for {"file:///var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T/t
erraform-ls/TestLangServer_ExtractPropToOutput_oldVersion"}
[SERVER] 2023/12/19 14:11:53 jobs.go:461: JOBS: Finishing job "6": "OpTypeSchemaVarsValidation" for {"file:/
//var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T/terraform-ls/TestLangServer_ExtractPropToOutput_oldVersion
"} (err = %!s(<nil>), deferredJobs: [])
[SERVER] 2023/12/19 14:11:53 jobs.go:299: retrying on obj is nil
[SERVER] 2023/12/19 14:11:53 jobs.go:321: JOBS: Dispatching next job "7" (scheduler prio: 1, job prio: 0, is
DirOpen: true): "OpTypeDecodeVarsReferences" for {"file:///var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T/t
erraform-ls/TestLangServer_ExtractPropToOutput_oldVersion"}
[SERVER] 2023/12/19 14:11:53 jobs.go:299: retrying on obj is nil
[SERVER] 2023/12/19 14:11:53 jobs.go:461: JOBS: Finishing job "7": "OpTypeDecodeVarsReferences" for {"file:/
//var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T/terraform-ls/TestLangServer_ExtractPropToOutput_oldVersion
"} (err = %!s(<nil>), deferredJobs: [])
[SERVER] 2023/12/19 14:11:53 jobs.go:299: retrying on obj is nil
[SERVER] 2023/12/19 14:11:53 jobs.go:321: JOBS: Dispatching next job "8" (scheduler prio: 1, job prio: 0, is
DirOpen: true): "OpTypePreloadEmbeddedSchema" for {"file:///var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T/
terraform-ls/TestLangServer_ExtractPropToOutput_oldVersion"}
[SERVER] 2023/12/19 14:11:53 module_ops.go:301: preloaded schema not available for registry.terraform.io/has
hicorp/test
[SERVER] 2023/12/19 14:11:53 jobs.go:299: retrying on obj is nil
[SERVER] 2023/12/19 14:11:53 jobs.go:461: JOBS: Finishing job "8": "OpTypePreloadEmbeddedSchema" for {"file:
///var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T/terraform-ls/TestLangServer_ExtractPropToOutput_oldVersio
n"} (err = %!s(<nil>), deferredJobs: [])
[SERVER] 2023/12/19 14:11:53 jobs.go:299: retrying on obj is nil
[SERVER] 2023/12/19 14:11:53 jobs.go:321: JOBS: Dispatching next job "10" (scheduler prio: 1, job prio: 0, i
sDirOpen: true): "OpTypeDecodeReferenceTargets" for {"file:///var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/
T/terraform-ls/TestLangServer_ExtractPropToOutput_oldVersion"}
[SERVER] 2023/12/19 14:11:53 provider_schema.go:306: PSS: getting provider schema (/var/folders/73/kpm5cv3j1
ps0ndghmrltkhdr0000gn/T/terraform-ls/TestLangServer_ExtractPropToOutput_oldVersion, registry.terraform.io/-/
test, )
[SERVER] 2023/12/19 14:11:53 jobs.go:461: JOBS: Finishing job "10": "OpTypeDecodeReferenceTargets" for {"fil
e:///var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T/terraform-ls/TestLangServer_ExtractPropToOutput_oldVers
ion"} (err = %!s(<nil>), deferredJobs: [])
[SERVER] 2023/12/19 14:11:53 jobs.go:299: retrying on obj is nil
[SERVER] 2023/12/19 14:11:53 jobs.go:321: JOBS: Dispatching next job "11" (scheduler prio: 1, job prio: 0, i
sDirOpen: true): "OpTypeDecodeReferenceOrigins" for {"file:///var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/
T/terraform-ls/TestLangServer_ExtractPropToOutput_oldVersion"}
[SERVER] 2023/12/19 14:11:53 jobs.go:299: retrying on obj is nil
[SERVER] 2023/12/19 14:11:53 provider_schema.go:306: PSS: getting provider schema (/var/folders/73/kpm5cv3j1
ps0ndghmrltkhdr0000gn/T/terraform-ls/TestLangServer_ExtractPropToOutput_oldVersion, registry.terraform.io/-/
test, )
[SERVER] 2023/12/19 14:11:53 jobs.go:461: JOBS: Finishing job "11": "OpTypeDecodeReferenceOrigins" for {"fil
e:///var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T/terraform-ls/TestLangServer_ExtractPropToOutput_oldVers
ion"} (err = %!s(<nil>), deferredJobs: [])
[SERVER] 2023/12/19 14:11:53 rpc_logger.go:53: Response to "textDocument/didOpen" (ID 2): null
[SERVER] 2023/12/19 14:11:53 opts.go:215: Completed 1 requests [2.5155ms elapsed]
[SERVER] 2023/12/19 14:11:53 jobs.go:321: JOBS: Dispatching next job "12" (scheduler prio: 1, job prio: 0, i
sDirOpen: true): "OpTypeReferenceValidation" for {"file:///var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T/t
erraform-ls/TestLangServer_ExtractPropToOutput_oldVersion"}
[CLIENT] 2023/12/19 14:11:53 opts.go:215: Received 1 responses
[SERVER] 2023/12/19 14:11:53 jobs.go:299: retrying on obj is nil
[CLIENT] 2023/12/19 14:11:53 opts.go:215: Completed request for ID "2"
[SERVER] 2023/12/19 14:11:53 provider_schema.go:306: PSS: getting provider schema (/var/folders/73/kpm5cv3j1
ps0ndghmrltkhdr0000gn/T/terraform-ls/TestLangServer_ExtractPropToOutput_oldVersion, registry.terraform.io/-/
test, )
[SERVER] 2023/12/19 14:11:53 jobs.go:461: JOBS: Finishing job "12": "OpTypeReferenceValidation" for {"file:/
//var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T/terraform-ls/TestLangServer_ExtractPropToOutput_oldVersion
"} (err = %!s(<nil>), deferredJobs: [])
[SERVER] 2023/12/19 14:11:53 jobs.go:299: retrying on obj is nil
[SERVER] 2023/12/19 14:11:53 jobs.go:321: JOBS: Dispatching next job "9" (scheduler prio: 1, job prio: 0, is
DirOpen: true): "OpTypeSchemaModuleValidation" for {"file:///var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T
/terraform-ls/TestLangServer_ExtractPropToOutput_oldVersion"}
[SERVER] 2023/12/19 14:11:53 jobs.go:299: retrying on obj is nil
[SERVER] 2023/12/19 14:11:53 provider_schema.go:306: PSS: getting provider schema (/var/folders/73/kpm5cv3j1
ps0ndghmrltkhdr0000gn/T/terraform-ls/TestLangServer_ExtractPropToOutput_oldVersion, registry.terraform.io/-/
test, )
[SERVER] 2023/12/19 14:11:53 jobs.go:461: JOBS: Finishing job "9": "OpTypeSchemaModuleValidation" for {"file
:///var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T/terraform-ls/TestLangServer_ExtractPropToOutput_oldVersi
on"} (err = %!s(<nil>), deferredJobs: [])
[SERVER] 2023/12/19 14:11:53 jobs.go:299: retrying on obj is nil
[CLIENT] 2023/12/19 14:11:53 opts.go:215: Outgoing batch: count=1, bytes=218
[SERVER] 2023/12/19 14:11:53 opts.go:215: Received request batch of size 1 (qlen=0)
[SERVER] 2023/12/19 14:11:53 opts.go:215: Dequeued request batch of length 1 (qlen=0)
[SERVER] 2023/12/19 14:11:53 rpc_logger.go:32: Incoming request for "textDocument/formatting" (ID 3): {"text
Document":{"uri":"file:///var/folders/73/kpm5cv3j1ps0ndghmrltkhdr0000gn/T/terraform-ls/TestLangServer_Extrac
tPropToOutput_oldVersion/main.tf"}}
[SERVER] 2023/12/19 14:11:53 formatting.go:45: formatting document via ""
[SERVER] 2023/12/19 14:11:53 formatting.go:50: Failed 'terraform fmt' in 47.375µs
[SERVER] 2023/12/19 14:11:53 rpc_logger.go:48: Error for "textDocument/formatting" (ID 3): [-32098] not impl
emented
[SERVER] 2023/12/19 14:11:53 opts.go:215: Completed 1 requests [186.833µs elapsed]
[CLIENT] 2023/12/19 14:11:53 opts.go:215: Received 1 responses
[CLIENT] 2023/12/19 14:11:53 opts.go:215: Completed request for ID "3"
2023/12/19 14:11:53 langserver_mock.go:77: Stopping mock server ...
[SERVER] 2023/12/19 14:11:53 opts.go:215: Server signaled to stop with err=the server has been stopped
[SERVER] 2023/12/19 14:11:53 opts.go:215: Error reading from client: the server has been stopped
[SERVER] 2023/12/19 14:11:53 service.go:568: stopping closedDirWalker for session ...
[SERVER] 2023/12/19 14:11:53 service.go:570: closedDirWalker stopped
[SERVER] 2023/12/19 14:11:53 service.go:573: stopping openDirWalker for session ...
[SERVER] 2023/12/19 14:11:53 service.go:575: openDirWalker stopped
[SERVER] 2023/12/19 14:11:53 scheduler.go:63: stopped scheduler
[SERVER] 2023/12/19 14:11:53 scheduler.go:63: stopped scheduler
--- PASS: TestLangServer_ExtractPropToOutput_oldVersion (0.01s)
PASS
[SERVER] 2023/12/19 14:11:53 notifier.go:55: failed to notify a change batch: context canceled
[SERVER] 2023/12/19 14:11:53 notifier.go:48: stopping notifier: context canceled
ok      github.com/hashicorp/terraform-ls/internal/langserver/handlers  0.025s
```

As description in https://github.com/hashicorp/terraform-ls/issues/1525, I'm trying to add some code actions.
Thanks in advance for any suggestion and insight.