### PR TITLE
github: Grant `actions: write` permission

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  actions: write
+
 env:
   PKG_NAME: "terraform-ls"
 


### PR DESCRIPTION
As discovered by @sarahethompson the new v4 version of the action we use now _requires_ this permission.

Not providing the permission leads to those artifacts to _not_ be deleted, which in turn trips up other workflows related to CRT which then attempt to upload these artifacts just because they are in the same path. CRT does not currently have path allowlist to ignore such artifacts but there is an internal feature request.

This is surfaced as the following error:

> `Error: -15T08:59:29.463Z [ERROR] bob: Failed to download workflow artifact: org=hashicorp repo=terraform-ls error="mkdir .bob/artifacts/registry.terraform.io/1password: permission denied"`

In retrospect it does make sense that in order to delete an artifact, one needs write permission of some kind. It is puzzling that this behaviour (requirement of permissions) is dependent on versions.

https://github.com/GeekyEggo/delete-artifact?tab=readme-ov-file#-usage