### PR TITLE
github: Pass token explicitly to delete-artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -173,3 +173,4 @@ jobs:
       - uses: geekyeggo/delete-artifact@9d15d164b1dcd538ff1b1a2984bc2c0240986c3b # v4.0.0
         with:
           name: provider-schema-data
+          token: ${{ github.token }}


### PR DESCRIPTION
In spite of documentation saying the following

> ... requires a permissive [GITHUB_TOKEN](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token), or a PAT with read and write access to actions.

which would imply that it just automatically reads that default `GITHUB_TOKEN`, we continue to see the following error:

> Error: Error: Parameter token or opts.auth is required

This is probably because [the action declares `token` as `required: true`](https://github.com/GeekyEggo/delete-artifact/blob/3f83cd6bfd1bb806746002ab8b59cc6f76f1740f/action.yml#L7) while also providing default. I don't understand how this is even valid combination on GitHub's side but we suspect this edge case is the root cause of the confusing behaviour.