### PR TITLE
Revert "Alert on wsl.localhost Path (#1522)"

### DIFF
--- a/internal/uri/uri.go
+++ b/internal/uri/uri.go
@@ -206,13 +206,5 @@ func IsWSLURI(uri string) bool {
 		return false
 	}
 
-	if u.Scheme == "file" && u.Host == "wsl$" {
-		return true
-	}
-
-	if u.Scheme == "file" && u.Host == "wsl.localhost" {
-		return true
-	}
-
-	return false
+	return u.Scheme == "file" && u.Host == "wsl$"
 }

--- a/internal/uri/uri_test.go
+++ b/internal/uri/uri_test.go
@@ -194,11 +194,6 @@ func TestIsWSLURI(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "Localhost WSL file path should return true",
-			uri:  `file://wsl.localhost/Ubuntu/home/james/foo`,
-			want: true,
-		},
-		{
 			name: "Regular file path should return false",
 			uri:  `file://C:/foo/james/foo`,
 			want: false,


### PR DESCRIPTION
This reverts commit a5ff862d4afdad2415b346aba9c3e52f127b1ce1.

There have been several reports from users about problems with this change: https://github.com/hashicorp/terraform-ls/issues/1585, so we are rolling it back for now.