### PR TITLE
Fix LS panic on missing symbols in client capabilities 

### DIFF
--- a/internal/langserver/handlers/workspace_symbol_test.go
+++ b/internal/langserver/handlers/workspace_symbol_test.go
@@ -161,3 +161,141 @@ func TestLangServer_workspace_symbol_basic(t *testing.T) {
 		]
 	}`, tmpDir.URI))
 }
+
+func TestLangServer_workspace_symbol_missing(t *testing.T) {
+	tmpDir := TempDir(t)
+	InitPluginCache(t, tmpDir.Path())
+
+	ss, err := state.NewStateStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	wc := walker.NewWalkerCollector()
+
+	ls := langserver.NewLangServerMock(t, NewMockSession(&MockSessionInput{
+		TerraformCalls: &exec.TerraformMockCalls{
+			PerWorkDir: map[string][]*mock.Call{
+				tmpDir.Path(): validTfMockCalls(),
+			},
+		},
+		StateStore:      ss,
+		WalkerCollector: wc,
+	}))
+	stop := ls.Start(t)
+	defer stop()
+
+	ls.Call(t, &langserver.CallRequest{
+		Method: "initialize",
+		ReqParams: fmt.Sprintf(`{
+		"capabilities": {
+			"workspace": {
+				"symbol": {
+				}
+			}
+		},
+		"rootUri": %q,
+		"processId": 12345
+	}`, tmpDir.URI)})
+	waitForWalkerPath(t, ss, wc, tmpDir)
+	ls.Notify(t, &langserver.CallRequest{
+		Method:    "initialized",
+		ReqParams: "{}",
+	})
+	ls.Call(t, &langserver.CallRequest{
+		Method: "textDocument/didOpen",
+		ReqParams: fmt.Sprintf(`{
+		"textDocument": {
+			"version": 0,
+			"languageId": "terraform",
+			"text": "provider \"github\" {}",
+			"uri": "%s/first.tf"
+		}
+	}`, tmpDir.URI)})
+	ls.Call(t, &langserver.CallRequest{
+		Method: "textDocument/didOpen",
+		ReqParams: fmt.Sprintf(`{
+		"textDocument": {
+			"version": 0,
+			"languageId": "terraform",
+			"text": "provider \"google\" {}",
+			"uri": "%s/second.tf"
+		}
+	}`, tmpDir.URI)})
+	ls.Call(t, &langserver.CallRequest{
+		Method: "textDocument/didOpen",
+		ReqParams: fmt.Sprintf(`{
+		"textDocument": {
+			"version": 0,
+			"languageId": "terraform",
+			"text": "myblock \"custom\" {}",
+			"uri": "%s/blah/third.tf"
+		}
+	}`, tmpDir.URI)})
+	waitForAllJobs(t, ss)
+
+	ls.CallAndExpectResponse(t, &langserver.CallRequest{
+		Method: "workspace/symbol",
+		ReqParams: `{
+		"query": ""
+	}`}, fmt.Sprintf(`{
+		"jsonrpc": "2.0",
+		"id": 5,
+		"result": [
+			{
+				"location": {
+					"uri": "%s/first.tf",
+					"range": {
+						"start": {"line": 0, "character": 0},
+						"end": {"line": 0, "character": 20}
+					}
+				},
+				"name": "provider \"github\"",
+				"kind": 5
+			},
+			{
+				"location": {
+					"uri": "%s/second.tf",
+					"range": {
+						"start": {"line": 0, "character": 0},
+						"end": {"line": 0, "character": 20}
+					}
+				},
+				"name": "provider \"google\"",
+				"kind": 5
+			},
+			{
+				"location": {
+					"uri": "%s/blah/third.tf",
+					"range": {
+						"start": {"line": 0, "character": 0},
+						"end": {"line": 0, "character": 19}
+					}
+				},
+				"name": "myblock \"custom\"",
+				"kind": 5
+			}
+		]
+	}`, tmpDir.URI, tmpDir.URI, tmpDir.URI))
+
+	ls.CallAndExpectResponse(t, &langserver.CallRequest{
+		Method: "workspace/symbol",
+		ReqParams: `{
+		"query": "myb"
+	}`}, fmt.Sprintf(`{
+		"jsonrpc": "2.0",
+		"id": 6,
+		"result": [
+			{
+				"location": {
+					"uri": "%s/blah/third.tf",
+					"range": {
+						"start": {"line": 0, "character": 0},
+						"end": {"line": 0, "character": 19}
+					}
+				},
+				"name": "myblock \"custom\"",
+				"kind": 5
+			}
+		]
+	}`, tmpDir.URI))
+}


### PR DESCRIPTION
This PR fixes two server panics related to symbols. The first one occurs when supported symbols are not part of the [TextDocumentClientCapabilities](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocumentClientCapabilities) sent by the client. The second is when supported symbols are missing from the [workspace specific client capabilities](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#clientCapabilities).

In both cases, we now fall back to the list of symbols supported by the initial version of the protocol.

Closes https://github.com/hashicorp/terraform-ls/issues/1349