### PR TITLE
docs: Link to .github/CONTRIBUTING.md in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ is through a client represented by an IDE, or a plugin of an IDE.
 
 Please follow the [relevant guide for your IDE](./docs/USAGE.md).
 
+## Contributing
+
+Please refer to [.github/CONTRIBUTING.md](.github/CONTRIBUTING.md) for more information on how to contribute to this project.
+
 ## Credits
 
 - [Martin Atkins](https://github.com/apparentlymart) - particularly the virtual filesystem


### PR DESCRIPTION
I looked for this file in the root and in `docs/` initially but didn't think of the 
`.github` directory. I only learned this doc existed when Daniel happened to pull 
it up when doing the most recent patch release 😄

It is linked here due to being in that directory:
<img width="919" alt="image" src="https://github.com/hashicorp/terraform-ls/assets/1112056/30e76087-d53c-4bd9-a008-9ac109bbadcb">

But that only is visible when creating a PR and it doesn't seem to be in this list in the sidebar:
<img width="341" alt="image" src="https://github.com/hashicorp/terraform-ls/assets/1112056/654a1151-b6e1-40d7-972d-6515cccea089">
