### PR TITLE
Remove outdated LSP comparison from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,24 +46,3 @@ Please refer to [.github/CONTRIBUTING.md](.github/CONTRIBUTING.md) for more info
 The server will collect data only if the _client_ requests it during initialization. Telemetry is opt-in by default.
 
 [Read more about telemetry](./docs/telemetry.md).
-
-## `terraform-ls` VS `terraform-lsp`
-
-Both HashiCorp and [the maintainer](https://github.com/juliosueiras) of [`terraform-lsp`](https://github.com/juliosueiras/terraform-lsp)
-expressed interest in collaborating on a language server and are working
-towards a _long-term_ goal of a single stable and feature-complete implementation.
-
-For the time being both projects continue to exist, giving users the choice:
-
-- `terraform-ls` providing
-  - overall stability (by relying only on public APIs)
-  - compatibility with any provider and any Terraform `>=0.12.0`
-  - currently less features
-    - due to project being younger and relying on public APIs which may not
-      offer the same functionality yet
-
-- `terraform-lsp` providing
-  - currently more features
-  - compatibility with a single particular Terraform (`0.12.20` at time of writing)
-    - configs designed for other `0.12` versions may work, but interpretation may be inaccurate
-  - less stability (due to reliance on Terraform's own internal packages)


### PR DESCRIPTION
The comparison to terraform-lsp has been outdated for a long time