### PR TITLE
Remove getting provider schema log line

### DIFF
--- a/internal/state/provider_schema.go
+++ b/internal/state/provider_schema.go
@@ -303,7 +303,6 @@ func providerAddrEquals(a, b tfaddr.Provider) bool {
 }
 
 func (s *ProviderSchemaStore) ProviderSchema(modPath string, addr tfaddr.Provider, vc version.Constraints) (*tfschema.ProviderSchema, error) {
-	s.logger.Printf("PSS: getting provider schema (%s, %s, %s)", modPath, addr, vc)
 	txn := s.db.Txn(false)
 
 	it, err := txn.Get(s.tableName, "id_prefix", addr)


### PR DESCRIPTION
This PR removes the log line for accessing a provider schema in memory. We do this a lot and it causes a lot of noise in the log output.

It's also confusing because it might imply that there is an intensive operation involved, such as an HTTP request, which is not the case.