### PR TITLE
Use Terraform 1.8-rc1 for bundling schemas

### DIFF
--- a/internal/schemas/gen/gen.go
+++ b/internal/schemas/gen/gen.go
@@ -114,9 +114,11 @@ func gen() error {
 	i := hcinstall.NewInstaller()
 	execPath, err := i.Ensure(ctx, []src.Source{
 		&releases.LatestVersion{
-			Product:     product.Terraform,
-			InstallDir:  installDir,
-			Constraints: terraformVersion,
+			Product:    product.Terraform,
+			InstallDir: installDir,
+			// TODO! Update after 1.8 GA
+			// Constraints: terraformVersion,
+			IncludePrereleases: true,
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
This is a temporary change to allow us to bundle provider schemas that include provider-defined functions.

It should be reverted after the Terraform 1.8 GA release.