### PR TITLE
Pass Terraform version to functions merger

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/hashicorp/terraform-exec v0.20.0
 	github.com/hashicorp/terraform-json v0.21.0
 	github.com/hashicorp/terraform-registry-address v0.2.3
-	github.com/hashicorp/terraform-schema v0.0.0-20240326154150-560df6bbc4dc
+	github.com/hashicorp/terraform-schema v0.0.0-20240327170238-ec799b9b2e3e
 	github.com/mcuadros/go-defaults v1.2.0
 	github.com/mh-cbon/go-fmt-fail v0.0.0-20160815164508-67765b3fbcb5
 	github.com/mitchellh/cli v1.1.5

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/hashicorp/terraform-exec v0.20.0
 	github.com/hashicorp/terraform-json v0.21.0
 	github.com/hashicorp/terraform-registry-address v0.2.3
-	github.com/hashicorp/terraform-schema v0.0.0-20240327170238-ec799b9b2e3e
+	github.com/hashicorp/terraform-schema v0.0.0-20240403100825-364ac130f15a
 	github.com/mcuadros/go-defaults v1.2.0
 	github.com/mh-cbon/go-fmt-fail v0.0.0-20160815164508-67765b3fbcb5
 	github.com/mitchellh/cli v1.1.5

--- a/go.sum
+++ b/go.sum
@@ -230,8 +230,8 @@ github.com/hashicorp/terraform-json v0.21.0 h1:9NQxbLNqPbEMze+S6+YluEdXgJmhQykRy
 github.com/hashicorp/terraform-json v0.21.0/go.mod h1:qdeBs11ovMzo5puhrRibdD6d2Dq6TyE/28JiU4tIQxk=
 github.com/hashicorp/terraform-registry-address v0.2.3 h1:2TAiKJ1A3MAkZlH1YI/aTVcLZRu7JseiXNRHbOAyoTI=
 github.com/hashicorp/terraform-registry-address v0.2.3/go.mod h1:lFHA76T8jfQteVfT7caREqguFrW3c4MFSPhZB7HHgUM=
-github.com/hashicorp/terraform-schema v0.0.0-20240326154150-560df6bbc4dc h1:d80NP3l4Y3rgtyljXeFUnoExfppUoqy2bk0fV6bBudA=
-github.com/hashicorp/terraform-schema v0.0.0-20240326154150-560df6bbc4dc/go.mod h1:NuD9aPdZD2FFmT+56jkwDMAO/lX9qPPK7pkhB+umAaw=
+github.com/hashicorp/terraform-schema v0.0.0-20240327170238-ec799b9b2e3e h1:g+UMcdebPp4/Oc9V8WHgYlbe9GBGsti9VUxHKXy2AFs=
+github.com/hashicorp/terraform-schema v0.0.0-20240327170238-ec799b9b2e3e/go.mod h1:NuD9aPdZD2FFmT+56jkwDMAO/lX9qPPK7pkhB+umAaw=
 github.com/hashicorp/terraform-svchost v0.1.1 h1:EZZimZ1GxdqFRinZ1tpJwVxxt49xc/S52uzrw4x0jKQ=
 github.com/hashicorp/terraform-svchost v0.1.1/go.mod h1:mNsjQfZyf/Jhz35v6/0LWcv26+X7JPS+buii2c9/ctc=
 github.com/hexops/autogold v1.3.1 h1:YgxF9OHWbEIUjhDbpnLhgVsjUDsiHDTyDfy2lrfdlzo=

--- a/go.sum
+++ b/go.sum
@@ -230,8 +230,8 @@ github.com/hashicorp/terraform-json v0.21.0 h1:9NQxbLNqPbEMze+S6+YluEdXgJmhQykRy
 github.com/hashicorp/terraform-json v0.21.0/go.mod h1:qdeBs11ovMzo5puhrRibdD6d2Dq6TyE/28JiU4tIQxk=
 github.com/hashicorp/terraform-registry-address v0.2.3 h1:2TAiKJ1A3MAkZlH1YI/aTVcLZRu7JseiXNRHbOAyoTI=
 github.com/hashicorp/terraform-registry-address v0.2.3/go.mod h1:lFHA76T8jfQteVfT7caREqguFrW3c4MFSPhZB7HHgUM=
-github.com/hashicorp/terraform-schema v0.0.0-20240327170238-ec799b9b2e3e h1:g+UMcdebPp4/Oc9V8WHgYlbe9GBGsti9VUxHKXy2AFs=
-github.com/hashicorp/terraform-schema v0.0.0-20240327170238-ec799b9b2e3e/go.mod h1:NuD9aPdZD2FFmT+56jkwDMAO/lX9qPPK7pkhB+umAaw=
+github.com/hashicorp/terraform-schema v0.0.0-20240403100825-364ac130f15a h1:LEF+NZZbvtKebSrr99Gl211iAmd/QQkbyhHUkSnpKxY=
+github.com/hashicorp/terraform-schema v0.0.0-20240403100825-364ac130f15a/go.mod h1:NuD9aPdZD2FFmT+56jkwDMAO/lX9qPPK7pkhB+umAaw=
 github.com/hashicorp/terraform-svchost v0.1.1 h1:EZZimZ1GxdqFRinZ1tpJwVxxt49xc/S52uzrw4x0jKQ=
 github.com/hashicorp/terraform-svchost v0.1.1/go.mod h1:mNsjQfZyf/Jhz35v6/0LWcv26+X7JPS+buii2c9/ctc=
 github.com/hexops/autogold v1.3.1 h1:YgxF9OHWbEIUjhDbpnLhgVsjUDsiHDTyDfy2lrfdlzo=

--- a/internal/decoder/functions.go
+++ b/internal/decoder/functions.go
@@ -15,6 +15,7 @@ func functionsForModule(mod *state.Module, schemaReader state.SchemaReader) (map
 	resolvedVersion := tfschema.ResolveVersion(mod.TerraformVersion, mod.Meta.CoreRequirements)
 	sm := tfschema.NewFunctionsMerger(mustFunctionsForVersion(resolvedVersion))
 	sm.SetSchemaReader(schemaReader)
+	sm.SetTerraformVersion(resolvedVersion)
 
 	meta := &tfmodule.Meta{
 		Path:                 mod.Path,


### PR DESCRIPTION
* Depends on https://github.com/hashicorp/terraform-schema/pull/336
* Closes https://github.com/hashicorp/terraform-ls/issues/1671

---

Prior to this PR, we would always merge any provider-defined functions included in a schema with the Terraform core functions. Even if the Terraform version doesn't support them yet.