### PR TITLE
Bump hcl-lang to `d90dc4d` & terraform-schema to `72025f5`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/hc-install v0.6.4
-	github.com/hashicorp/hcl-lang v0.0.0-20240326153306-49d737897778
+	github.com/hashicorp/hcl-lang v0.0.0-20240409100755-d90dc4d98974
 	github.com/hashicorp/hcl/v2 v2.20.1
 	github.com/hashicorp/terraform-exec v0.20.0
 	github.com/hashicorp/terraform-json v0.21.0

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/hashicorp/terraform-exec v0.20.0
 	github.com/hashicorp/terraform-json v0.21.0
 	github.com/hashicorp/terraform-registry-address v0.2.3
-	github.com/hashicorp/terraform-schema v0.0.0-20240403100825-364ac130f15a
+	github.com/hashicorp/terraform-schema v0.0.0-20240410082006-72025f55ec83
 	github.com/mcuadros/go-defaults v1.2.0
 	github.com/mh-cbon/go-fmt-fail v0.0.0-20160815164508-67765b3fbcb5
 	github.com/mitchellh/cli v1.1.5

--- a/go.sum
+++ b/go.sum
@@ -220,8 +220,8 @@ github.com/hashicorp/hc-install v0.6.4 h1:QLqlM56/+SIIGvGcfFiwMY3z5WGXT066suo/v9
 github.com/hashicorp/hc-install v0.6.4/go.mod h1:05LWLy8TD842OtgcfBbOT0WMoInBMUSHjmDx10zuBIA=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/hashicorp/hcl-lang v0.0.0-20240326153306-49d737897778 h1:Yw/5Lno+YiOAEQQ6krRpiJ4lCv+x0k7Q6/SxH5AIsus=
-github.com/hashicorp/hcl-lang v0.0.0-20240326153306-49d737897778/go.mod h1:2Vwxuf2nQi/095HYVqo0kWhlBLKhwEi/jTf5TxB61MI=
+github.com/hashicorp/hcl-lang v0.0.0-20240409100755-d90dc4d98974 h1:T/rmkniroBWQmwW01KE2Jz+4B0n05wFKA3rTeDkgprs=
+github.com/hashicorp/hcl-lang v0.0.0-20240409100755-d90dc4d98974/go.mod h1:1WWZdjoT1kup4X+3z3R0qKJsEyynAyLI7JeZeT6RivI=
 github.com/hashicorp/hcl/v2 v2.20.1 h1:M6hgdyz7HYt1UN9e61j+qKJBqR3orTWbI1HKBJEdxtc=
 github.com/hashicorp/hcl/v2 v2.20.1/go.mod h1:TZDqQ4kNKCbh1iJp99FdPiUaVDDUPivbqxZulxDYqL4=
 github.com/hashicorp/terraform-exec v0.20.0 h1:DIZnPsqzPGuUnq6cH8jWcPunBfY+C+M8JyYF3vpnuEo=

--- a/go.sum
+++ b/go.sum
@@ -230,8 +230,8 @@ github.com/hashicorp/terraform-json v0.21.0 h1:9NQxbLNqPbEMze+S6+YluEdXgJmhQykRy
 github.com/hashicorp/terraform-json v0.21.0/go.mod h1:qdeBs11ovMzo5puhrRibdD6d2Dq6TyE/28JiU4tIQxk=
 github.com/hashicorp/terraform-registry-address v0.2.3 h1:2TAiKJ1A3MAkZlH1YI/aTVcLZRu7JseiXNRHbOAyoTI=
 github.com/hashicorp/terraform-registry-address v0.2.3/go.mod h1:lFHA76T8jfQteVfT7caREqguFrW3c4MFSPhZB7HHgUM=
-github.com/hashicorp/terraform-schema v0.0.0-20240403100825-364ac130f15a h1:LEF+NZZbvtKebSrr99Gl211iAmd/QQkbyhHUkSnpKxY=
-github.com/hashicorp/terraform-schema v0.0.0-20240403100825-364ac130f15a/go.mod h1:NuD9aPdZD2FFmT+56jkwDMAO/lX9qPPK7pkhB+umAaw=
+github.com/hashicorp/terraform-schema v0.0.0-20240410082006-72025f55ec83 h1:xVdBi5eitpzO7EtYzwxED0aMMFApoXlGPynJq2Ic8JM=
+github.com/hashicorp/terraform-schema v0.0.0-20240410082006-72025f55ec83/go.mod h1:8TYkGp/ICDK7kpbJeinNoNc8MiCBG/JmEqH1Ok+RKs8=
 github.com/hashicorp/terraform-svchost v0.1.1 h1:EZZimZ1GxdqFRinZ1tpJwVxxt49xc/S52uzrw4x0jKQ=
 github.com/hashicorp/terraform-svchost v0.1.1/go.mod h1:mNsjQfZyf/Jhz35v6/0LWcv26+X7JPS+buii2c9/ctc=
 github.com/hexops/autogold v1.3.1 h1:YgxF9OHWbEIUjhDbpnLhgVsjUDsiHDTyDfy2lrfdlzo=


### PR DESCRIPTION
This brings in the latest changes to

terraform-schema:
* https://github.com/hashicorp/terraform-schema/pull/337
* https://github.com/hashicorp/terraform-schema/pull/340
* https://github.com/hashicorp/terraform-schema/pull/338
* https://github.com/hashicorp/terraform-schema/pull/336

hcl-lang:
* none