### PR TITLE
Remove token from delete-artifact action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -174,4 +174,3 @@ jobs:
       - uses: geekyeggo/delete-artifact@24928e75e6e6590170563b8ddae9fac674508aa1 # v5.0.0
         with:
           name: provider-schema-data
-          token: ${{ github.token }}


### PR DESCRIPTION
After the update to version 5.0.0, `token` is no longer required.

See:
* https://github.com/hashicorp/terraform-ls/actions/runs/8630067975/job/23655731728#step:2:1
* https://github.com/geekyeggo/delete-artifact/releases/tag/v5.0.0