### PR TITLE
Revert "Use Terraform 1.8-rc1 for bundling schemas (#1669)"

### DIFF
--- a/internal/schemas/gen/gen.go
+++ b/internal/schemas/gen/gen.go
@@ -114,11 +114,9 @@ func gen() error {
 	i := hcinstall.NewInstaller()
 	execPath, err := i.Ensure(ctx, []src.Source{
 		&releases.LatestVersion{
-			Product:    product.Terraform,
-			InstallDir: installDir,
-			// TODO! Update after 1.8 GA
-			// Constraints: terraformVersion,
-			IncludePrereleases: true,
+			Product:     product.Terraform,
+			InstallDir:  installDir,
+			Constraints: terraformVersion,
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
This reverts commit 42c083a91a471cb14416b7c1f1095a44854ee6f9.

With the imminent release of Terraform 1.8 this change is no longer needed.