### PR TITLE
Remove non-empty directory during test cleanup

### DIFF
--- a/internal/terraform/exec/exec_test.go
+++ b/internal/terraform/exec/exec_test.go
@@ -71,7 +71,7 @@ func newExecutor(t *testing.T) TerraformExecutor {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() {
-		if err := os.Remove(installDir); err != nil {
+		if err := os.RemoveAll(installDir); err != nil {
 			t.Fatal(err)
 		}
 	})


### PR DESCRIPTION
Terraform 1.8.2 now includes a license file next to the binary. This isn't cleaned up by hc-install (yet), so we need to remove it for now.

This should resolve all recent test failures in PRs.