### PR TITLE
docs: document schema bundling in CONTRIBUTING.md

### DIFF
--- a/.changes/unreleased/INTERNAL-20240614-105429.yaml
+++ b/.changes/unreleased/INTERNAL-20240614-105429.yaml
@@ -1,0 +1,6 @@
+kind: INTERNAL
+body: Document schema bundling in CONTRIBUTING.md
+time: 2024-06-14T10:54:29.627322+02:00
+custom:
+    Issue: "1736"
+    Repository: terraform-ls

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -85,6 +85,18 @@ go test ./internal/terraform/exec/...
 go test ./langserver
 ```
 
+### Bundled schemas
+
+The language server ships with bundled provider schemas of all official HashiCorp and partner providers to allow completions for common providers without the need to initialize a Terraform project first.
+These schemas are not checked into version control and are automatically fetched and bundled when the language server is built in CI.
+
+To generate these locally, run
+```bash
+go generate ./internal/schemas
+```
+
+The generated schemas can then be found in `internal/schemas/data`.
+
 ## External Dependencies
 
 Terraform uses [Go Modules]((https://blog.golang.org/using-go-modules))


### PR DESCRIPTION
I was looking for the command to generate them the other day and couldn't find it (it's in the Github workflows but I didn't look there 😅)