### PR TITLE
Add linterOptions to settings

### DIFF
--- a/internal/langserver/handlers/initialize.go
+++ b/internal/langserver/handlers/initialize.go
@@ -205,6 +205,10 @@ func getTelemetryProperties(out *settings.DecodedOptions) map[string]interface{}
 		"options.terraform.timeout":                       "",
 		"options.terraform.logFilePath":                   false,
 		"options.validation.earlyValidation":              false,
+		"options.linters.tflint.path":                     false,
+		"options.linters.tflint.configPath":               false,
+		"options.linters.tflint.lintOnSave":               false,
+		"options.linters.tflint.timeout":                  "",
 		"root_uri":                                        "dir",
 		"lsVersion":                                       "",
 	}
@@ -221,6 +225,10 @@ func getTelemetryProperties(out *settings.DecodedOptions) map[string]interface{}
 	properties["options.terraform.timeout"] = out.Options.Terraform.Timeout
 	properties["options.terraform.logFilePath"] = len(out.Options.Terraform.LogFilePath) > 0
 	properties["options.validation.earlyValidation"] = out.Options.Validation.EnableEnhancedValidation
+	properties["options.linters.tflint.path"] = len(out.Options.Linters.TFLint.Path) > 0
+	properties["options.linters.tflint.configPath"] = len(out.Options.Linters.TFLint.ConfigPath) > 0
+	properties["options.linters.tflint.lintOnSave"] = out.Options.Linters.TFLint.LintOnSave
+	properties["options.linters.tflint.timeout"] = out.Options.Linters.TFLint.Timeout
 
 	return properties
 }

--- a/internal/settings/settings_test.go
+++ b/internal/settings/settings_test.go
@@ -107,3 +107,21 @@ func TestValidate_relativePath(t *testing.T) {
 		t.Fatal("expected decoding of relative path to result in error")
 	}
 }
+
+func TestValidate_linterOptions(t *testing.T) {
+	out, err := DecodeOptions(map[string]interface{}{
+		"linters": map[string]interface{}{
+			"tflint": map[string]interface{}{
+				"path": "relative/path",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result := out.Options.Validate()
+	if result == nil {
+		t.Fatal("expected decoding of relative path to result in error")
+	}
+}


### PR DESCRIPTION
Part of https://github.com/hashicorp/terraform-ls/issues/334
Fixes https://github.com/hashicorp/terraform-ls/issues/855

This PR adds `linterOptions` to the language server settings. This includes the following TFLint configs, which I plan to use in subsequent PRs:

- `options.linters.tflint.path`
- `options.linters.tflint.configPath`
- `options.linters.tflint.lintOnSave`
- `options.linters.tflint.timeout`

Please note that this change differs from that proposed in #855 in the following points:

- The `binaryPath` has been changed to `path` to match `options.terraform.path`.
- The `binaryFlags` is not supported. TFLint has multiple flags, and I'm not yet sure if they can be safely passed through terraform-ls.
  - However, since `--config` is likely to be needed at an early stage, only `configPath` is supported.
- The `timeout` is added. Because TFLint rules can be extended, it is necessary to set a timeout to ensure completion.
- Just like Terraform, binary path is only validated to make sure it is accessible, not executable.
- If validation fails, it returns an error instead of silently failing, which is probably better if you set the path explicitly.

Whether these changes are appropriate is open to debate. I would be happy to discuss it here.
If there are any other matters that need to be discussed in advance regarding this issue, please feel free to let me know. Thank you.