### PR TITLE
Remove release engineering team from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,6 @@
-* @hashicorp/tf-editor-experience-engineers
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# they will be requested for review when someone opens a
+# pull request.
 
-# release configuration
-/.release/                   @hashicorp/release-engineering @hashicorp/tf-editor-experience-engineers
-/.github/workflows/build.yml @hashicorp/release-engineering @hashicorp/tf-editor-experience-engineers
+* @hashicorp/tf-editor-experience-engineers


### PR DESCRIPTION
This team doesn't exist anymore and as far as I can tell we stopped attributing the `.release/` folder to an extra team.