### PR TITLE
Introduce a workflow that checks for changelog entries

### DIFF
--- a/.changes/unreleased/INTERNAL-20240710-172718.yaml
+++ b/.changes/unreleased/INTERNAL-20240710-172718.yaml
@@ -1,0 +1,6 @@
+kind: INTERNAL
+body: Introduce a workflow that checks for changelog entries
+time: 2024-07-10T17:27:18.567311+02:00
+custom:
+    Issue: "1759"
+    Repository: terraform-ls

--- a/.github/workflows/check-changelog.yml
+++ b/.github/workflows/check-changelog.yml
@@ -1,0 +1,36 @@
+# Checks if a file has been committed under the .changes/unreleased directory
+#
+# Skip PRs labeled with 'dependencies'
+
+on:
+  pull_request:
+    branches:
+      - main
+      - pre-release
+
+name: Check if changelog entry exists
+
+jobs:
+  changelog_existence:
+    name: Check if changelog entry exists
+    if: "!contains(github.event.pull_request.labels.*.name, 'dependencies')"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check if changelog file was added
+        # https://github.com/marketplace/actions/paths-changes-filter
+        # For each filter, it sets output variable named by the filter to the text:
+        #  'true' - if any of changed files matches any of filter rules
+        #  'false' - if none of changed files matches any of filter rules
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: changelog_check
+        with:
+          filters: |
+            exists:
+              - added|modified: '.changes/unreleased/**.yaml'
+
+      - name: Fail job if changelog entry is missing and required
+        if: steps.changelog_check.outputs.exists == 'false'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: core.setFailed('Changelog entry required to merge.')


### PR DESCRIPTION
This workflow checks for the adding or modification of files in the `.changie/unreleased` folder.

You can see it working for this PR
- The jobs fails for the first commit: https://github.com/hashicorp/terraform-ls/actions/runs/9876936239/job/27277296043?pr=1759
- After adding a changelog entry, it passes: https://github.com/hashicorp/terraform-ls/actions/runs/9877100325/job/27277866068?pr=1759