### PR TITLE
Decode declared modules for all kind of installed modules

### DIFF
--- a/.changes/unreleased/ENHANCEMENTS-20240712-120348.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-20240712-120348.yaml
@@ -1,0 +1,6 @@
+kind: ENHANCEMENTS
+body: Enable completion for all locally installed remote modules
+time: 2024-07-12T12:03:48.33405+02:00
+custom:
+    Issue: "1760"
+    Repository: terraform-ls

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/hashicorp/terraform-exec v0.21.0
 	github.com/hashicorp/terraform-json v0.22.1
 	github.com/hashicorp/terraform-registry-address v0.2.3
-	github.com/hashicorp/terraform-schema v0.0.0-20240705124631-2b8abc4e4619
+	github.com/hashicorp/terraform-schema v0.0.0-20240712095857-6b121d850a0f
 	github.com/mcuadros/go-defaults v1.2.0
 	github.com/mh-cbon/go-fmt-fail v0.0.0-20160815164508-67765b3fbcb5
 	github.com/mitchellh/cli v1.1.5

--- a/go.sum
+++ b/go.sum
@@ -229,8 +229,8 @@ github.com/hashicorp/terraform-json v0.22.1 h1:xft84GZR0QzjPVWs4lRUwvTcPnegqlyS7
 github.com/hashicorp/terraform-json v0.22.1/go.mod h1:JbWSQCLFSXFFhg42T7l9iJwdGXBYV8fmmD6o/ML4p3A=
 github.com/hashicorp/terraform-registry-address v0.2.3 h1:2TAiKJ1A3MAkZlH1YI/aTVcLZRu7JseiXNRHbOAyoTI=
 github.com/hashicorp/terraform-registry-address v0.2.3/go.mod h1:lFHA76T8jfQteVfT7caREqguFrW3c4MFSPhZB7HHgUM=
-github.com/hashicorp/terraform-schema v0.0.0-20240705124631-2b8abc4e4619 h1:4FTKovXqTafesi5NGi5XudAUDHAae5yHqnp23fR/WRA=
-github.com/hashicorp/terraform-schema v0.0.0-20240705124631-2b8abc4e4619/go.mod h1:ar787Bv/qD6tlnjtzH8fQ1Yi6c/B5LsnpFlO8c92Atg=
+github.com/hashicorp/terraform-schema v0.0.0-20240712095857-6b121d850a0f h1:gwHfuCSPO/myZHMDgNyvbHue6fvTK7sV2dWVBt2J8XI=
+github.com/hashicorp/terraform-schema v0.0.0-20240712095857-6b121d850a0f/go.mod h1:ar787Bv/qD6tlnjtzH8fQ1Yi6c/B5LsnpFlO8c92Atg=
 github.com/hashicorp/terraform-svchost v0.1.1 h1:EZZimZ1GxdqFRinZ1tpJwVxxt49xc/S52uzrw4x0jKQ=
 github.com/hashicorp/terraform-svchost v0.1.1/go.mod h1:mNsjQfZyf/Jhz35v6/0LWcv26+X7JPS+buii2c9/ctc=
 github.com/hexops/autogold v1.3.1 h1:YgxF9OHWbEIUjhDbpnLhgVsjUDsiHDTyDfy2lrfdlzo=

--- a/internal/features/modules/decoder/decoder_test.go
+++ b/internal/features/modules/decoder/decoder_test.go
@@ -37,6 +37,10 @@ func (r RootReaderMock) TerraformVersion(modPath string) *version.Version {
 	return nil
 }
 
+func (r RootReaderMock) InstalledModulePath(rootPath string, normalizedSource string) (string, bool) {
+	return "", false
+}
+
 func TestDecoder_CodeLensesForFile_concurrencyBug(t *testing.T) {
 	globalStore, err := globalState.NewStateStore()
 	if err != nil {

--- a/internal/features/modules/decoder/path_reader.go
+++ b/internal/features/modules/decoder/path_reader.go
@@ -30,6 +30,7 @@ type StateReader interface {
 type RootReader interface {
 	InstalledModuleCalls(modPath string) (map[string]tfmod.InstalledModuleCall, error)
 	TerraformVersion(modPath string) *version.Version
+	InstalledModulePath(rootPath string, normalizedSource string) (string, bool)
 }
 
 type CombinedReader struct {

--- a/internal/features/modules/jobs/validation_test.go
+++ b/internal/features/modules/jobs/validation_test.go
@@ -28,6 +28,10 @@ func (r RootReaderMock) TerraformVersion(modPath string) *version.Version {
 	return nil
 }
 
+func (r RootReaderMock) InstalledModulePath(rootPath string, normalizedSource string) (string, bool) {
+	return "", false
+}
+
 func TestSchemaModuleValidation_FullModule(t *testing.T) {
 	ctx := context.Background()
 	gs, err := globalState.NewStateStore()

--- a/internal/features/modules/state/module_store.go
+++ b/internal/features/modules/state/module_store.go
@@ -171,11 +171,12 @@ func (s *ModuleStore) DeclaredModuleCalls(modPath string) (map[string]tfmod.Decl
 	declared := make(map[string]tfmod.DeclaredModuleCall)
 	for _, mc := range mod.Meta.ModuleCalls {
 		declared[mc.LocalName] = tfmod.DeclaredModuleCall{
-			LocalName:  mc.LocalName,
-			SourceAddr: mc.SourceAddr,
-			Version:    mc.Version,
-			InputNames: mc.InputNames,
-			RangePtr:   mc.RangePtr,
+			LocalName:     mc.LocalName,
+			RawSourceAddr: mc.RawSourceAddr,
+			SourceAddr:    mc.SourceAddr,
+			Version:       mc.Version,
+			InputNames:    mc.InputNames,
+			RangePtr:      mc.RangePtr,
 		}
 	}
 

--- a/internal/features/rootmodules/root_modules_feature.go
+++ b/internal/features/rootmodules/root_modules_feature.go
@@ -188,3 +188,22 @@ func (f *RootModulesFeature) Telemetry(path string) map[string]interface{} {
 
 	return properties
 }
+
+// InstalledModulePath checks the installed modules in the given root module
+// for the given normalized source address.
+//
+// If the module is installed, it returns the path to the module installation
+// directory on disk.
+func (f *RootModulesFeature) InstalledModulePath(rootPath string, normalizedSource string) (string, bool) {
+	record, err := f.Store.RootRecordByPath(rootPath)
+	if err != nil {
+		return "", false
+	}
+
+	dir, ok := record.InstalledModules[normalizedSource]
+	if !ok {
+		return "", false
+	}
+
+	return dir, true
+}

--- a/internal/features/rootmodules/state/installed_modules.go
+++ b/internal/features/rootmodules/state/installed_modules.go
@@ -1,0 +1,26 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package state
+
+import "github.com/hashicorp/terraform-ls/internal/terraform/datadir"
+
+// InstalledModules is a map of normalized source addresses from the
+// manifest to the path of the local directory where the module is installed
+type InstalledModules map[string]string
+
+func InstalledModulesFromManifest(manifest *datadir.ModuleManifest) InstalledModules {
+	if manifest == nil {
+		return nil
+	}
+
+	installedModules := make(InstalledModules, len(manifest.Records))
+
+	// TODO: To support multiple versions of the same module, we need to
+	// look into resolving the version constraints to a specific version.
+	for _, v := range manifest.Records {
+		installedModules[v.RawSourceAddr] = v.Dir
+	}
+
+	return installedModules
+}

--- a/internal/features/rootmodules/state/root_record.go
+++ b/internal/features/rootmodules/state/root_record.go
@@ -23,6 +23,10 @@ type RootRecord struct {
 	ModManifestErr   error
 	ModManifestState op.OpState
 
+	// InstalledModules is a map of normalized source addresses from the
+	// manifest to the path of the local directory where the module is installed
+	InstalledModules InstalledModules
+
 	TerraformVersion      *version.Version
 	TerraformVersionErr   error
 	TerraformVersionState op.OpState
@@ -56,10 +60,17 @@ func (m *RootRecord) Copy() *RootRecord {
 	}
 
 	if m.InstalledProviders != nil {
-		newRecord.InstalledProviders = make(InstalledProviders, 0)
+		newRecord.InstalledProviders = make(InstalledProviders, len(m.InstalledProviders))
 		for addr, pv := range m.InstalledProviders {
 			// version.Version is practically immutable once parsed
 			newRecord.InstalledProviders[addr] = pv
+		}
+	}
+
+	if m.InstalledModules != nil {
+		newRecord.InstalledModules = make(InstalledModules, len(m.InstalledModules))
+		for source, dir := range m.InstalledModules {
+			newRecord.InstalledModules[source] = dir
 		}
 	}
 

--- a/internal/features/rootmodules/state/root_store.go
+++ b/internal/features/rootmodules/state/root_store.go
@@ -258,6 +258,7 @@ func (s *RootStore) UpdateModManifest(path string, manifest *datadir.ModuleManif
 
 	record.ModManifest = manifest
 	record.ModManifestErr = mErr
+	record.InstalledModules = InstalledModulesFromManifest(manifest)
 
 	err = txn.Insert(s.tableName, record)
 	if err != nil {


### PR DESCRIPTION
* Requires https://github.com/hashicorp/terraform-schema/pull/366
* Closes https://github.com/hashicorp/vscode-terraform/issues/1440
* Closes https://github.com/hashicorp/vscode-terraform/issues/1280
* Closes https://github.com/hashicorp/terraform-ls/issues/1733
* Closes https://github.com/hashicorp/terraform-ls/issues/1604
---

This PR adds a missing piece from #1667: decoding declared module calls for locally installed modules (inside the `.terraform/` directory)

We do this by normalizing the value of the `source` attribute and matching it against entries in the module manifest. If we find a matching entry, we decode the contents of the folder. 

This not only re-enables it for registry modules, but also takes the approach a step further, allowing completion for (almost) any locally installed remote module (including submodules!).

## UX After
![CleanShot 2024-07-11 at 14 57 20](https://github.com/hashicorp/terraform-ls/assets/45985/6ac29477-c194-4bb3-a137-84169e574b00)
