### PR TITLE
(TF-18286) Add jobs to load Stack metadata

### DIFF
--- a/.changes/unreleased/ENHANCEMENTS-20240716-094842.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-20240716-094842.yaml
@@ -1,0 +1,6 @@
+kind: ENHANCEMENTS
+body: Parse and load Stack and Deploy metadata
+time: 2024-07-16T09:48:42.389816-04:00
+custom:
+    Issue: "1761"
+    Repository: terraform-ls

--- a/internal/features/stacks/ast/stacks.go
+++ b/internal/features/stacks/ast/stacks.go
@@ -79,6 +79,14 @@ func (sf Files) Copy() Files {
 	return m
 }
 
+func (mf Files) AsMap() map[string]*hcl.File {
+	m := make(map[string]*hcl.File, len(mf))
+	for name, file := range mf {
+		m[name.String()] = file // TODO: is this right?
+	}
+	return m
+}
+
 type Diagnostics map[Filename]hcl.Diagnostics
 
 func (sd Diagnostics) Copy() Diagnostics {

--- a/internal/features/stacks/events.go
+++ b/internal/features/stacks/events.go
@@ -191,7 +191,7 @@ func (f *StacksFeature) decodeStack(ctx context.Context, dir document.DirHandle,
 		Func: func(ctx context.Context) error {
 			return jobs.LoadStackMetadata(ctx, f.store, path)
 		},
-		Type:        operation.OpTypeLoadModuleMetadata.String(),
+		Type:        operation.OpTypeLoadStackMetadata.String(),
 		DependsOn:   job.IDs{parseId},
 		IgnoreState: ignoreState,
 	})
@@ -201,7 +201,6 @@ func (f *StacksFeature) decodeStack(ctx context.Context, dir document.DirHandle,
 	ids = append(ids, metaId)
 
 	// TODO: Implement the following functions where appropriate to stacks
-	// Future: LoadModuleMetadata(ctx, f.Store, path)
 	// Future: decodeDeclaredModuleCalls(ctx, dir, ignoreState)
 	// TODO: PreloadEmbeddedSchema(ctx, f.logger, schemas.FS,
 	// Future: DecodeReferenceTargets(ctx, f.Store, f.rootFeature, path)

--- a/internal/features/stacks/events.go
+++ b/internal/features/stacks/events.go
@@ -186,6 +186,20 @@ func (f *StacksFeature) decodeStack(ctx context.Context, dir document.DirHandle,
 	}
 	ids = append(ids, parseId)
 
+	metaId, err := f.stateStore.JobStore.EnqueueJob(ctx, job.Job{
+		Dir: dir,
+		Func: func(ctx context.Context) error {
+			return jobs.LoadStackMetadata(ctx, f.store, path)
+		},
+		Type:        operation.OpTypeLoadModuleMetadata.String(),
+		DependsOn:   job.IDs{parseId},
+		IgnoreState: ignoreState,
+	})
+	if err != nil {
+		return ids, err
+	}
+	ids = append(ids, metaId)
+
 	// TODO: Implement the following functions where appropriate to stacks
 	// Future: LoadModuleMetadata(ctx, f.Store, path)
 	// Future: decodeDeclaredModuleCalls(ctx, dir, ignoreState)

--- a/internal/features/stacks/jobs/metadata.go
+++ b/internal/features/stacks/jobs/metadata.go
@@ -15,7 +15,7 @@ import (
 
 // LoadStackMetadata loads data about the stack in a version-independent
 // way that enables us to decode the rest of the configuration,
-// e.g. by knowing provider versions, Terraform Core constraint etc.
+// e.g. by knowing provider versions, etc.
 func LoadStackMetadata(ctx context.Context, stackStore *state.StackStore, stackPath string) error {
 	stack, err := stackStore.StackRecordByPath(stackPath)
 	if err != nil {
@@ -39,20 +39,6 @@ func LoadStackMetadata(ctx context.Context, stackStore *state.StackStore, stackP
 	if len(diags) > 0 {
 		mErr = diags
 	}
-
-	// providerRequirements := make(map[tfaddr.Provider]version.Constraints, len(meta.ProviderRequirements))
-	// for pAddr, pvc := range meta.ProviderRequirements {
-	// 	// TODO: check pAddr for migrations via Registry API?
-	// 	providerRequirements[pAddr] = pvc
-	// }
-	// meta.ProviderRequirements = providerRequirements
-
-	// providerRefs := make(map[tfmodule.ProviderRef]tfaddr.Provider, len(meta.ProviderReferences))
-	// for localRef, pAddr := range meta.ProviderReferences {
-	// 	// TODO: check pAddr for migrations via Registry API?
-	// 	providerRefs[localRef] = pAddr
-	// }
-	// meta.ProviderReferences = providerRefs
 
 	sErr := stackStore.UpdateMetadata(stackPath, meta, mErr)
 	if sErr != nil {

--- a/internal/features/stacks/jobs/metadata.go
+++ b/internal/features/stacks/jobs/metadata.go
@@ -1,0 +1,63 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package jobs
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-ls/internal/document"
+	"github.com/hashicorp/terraform-ls/internal/features/stacks/state"
+	"github.com/hashicorp/terraform-ls/internal/job"
+	"github.com/hashicorp/terraform-ls/internal/terraform/module/operation"
+	earlydecoder "github.com/hashicorp/terraform-schema/earlydecoder/stacks"
+)
+
+// LoadStackMetadata loads data about the stack in a version-independent
+// way that enables us to decode the rest of the configuration,
+// e.g. by knowing provider versions, Terraform Core constraint etc.
+func LoadStackMetadata(ctx context.Context, stackStore *state.StackStore, stackPath string) error {
+	stack, err := stackStore.StackRecordByPath(stackPath)
+	if err != nil {
+		return err
+	}
+
+	// TODO: Avoid parsing if upstream (parsing) job reported no changes
+
+	// Avoid parsing if it is already in progress or already known
+	if stack.MetaState != operation.OpStateUnknown && !job.IgnoreState(ctx) {
+		return job.StateNotChangedErr{Dir: document.DirHandleFromPath(stackPath)}
+	}
+
+	err = stackStore.SetMetaState(stackPath, operation.OpStateLoading)
+	if err != nil {
+		return err
+	}
+
+	var mErr error
+	meta, diags := earlydecoder.LoadStack(stack.Path(), stack.ParsedFiles.AsMap())
+	if len(diags) > 0 {
+		mErr = diags
+	}
+
+	// providerRequirements := make(map[tfaddr.Provider]version.Constraints, len(meta.ProviderRequirements))
+	// for pAddr, pvc := range meta.ProviderRequirements {
+	// 	// TODO: check pAddr for migrations via Registry API?
+	// 	providerRequirements[pAddr] = pvc
+	// }
+	// meta.ProviderRequirements = providerRequirements
+
+	// providerRefs := make(map[tfmodule.ProviderRef]tfaddr.Provider, len(meta.ProviderReferences))
+	// for localRef, pAddr := range meta.ProviderReferences {
+	// 	// TODO: check pAddr for migrations via Registry API?
+	// 	providerRefs[localRef] = pAddr
+	// }
+	// meta.ProviderReferences = providerRefs
+
+	sErr := stackStore.UpdateMetadata(stackPath, meta, mErr)
+	if sErr != nil {
+		return sErr
+	}
+
+	return mErr
+}

--- a/internal/features/stacks/state/stack_meta.go
+++ b/internal/features/stacks/state/stack_meta.go
@@ -19,11 +19,35 @@ type StackMetadata struct {
 
 func (sm StackMetadata) Copy() StackMetadata {
 	newSm := StackMetadata{
-		Filenames:            sm.Filenames,
-		Components:           sm.Components,
-		Variables:            sm.Variables,
-		Outputs:              sm.Outputs,
-		ProviderRequirements: sm.ProviderRequirements,
+		Filenames: sm.Filenames,
+	}
+
+	if sm.Components != nil {
+		newSm.Components = make(map[string]tfstack.Component, len(sm.Components))
+		for k, v := range sm.Components {
+			newSm.Components[k] = v
+		}
+	}
+
+	if sm.Variables != nil {
+		newSm.Variables = make(map[string]tfstack.Variable, len(sm.Variables))
+		for k, v := range sm.Variables {
+			newSm.Variables[k] = v
+		}
+	}
+
+	if sm.Outputs != nil {
+		newSm.Outputs = make(map[string]tfstack.Output, len(sm.Outputs))
+		for k, v := range sm.Outputs {
+			newSm.Outputs[k] = v
+		}
+	}
+
+	if sm.ProviderRequirements != nil {
+		newSm.ProviderRequirements = make(map[string]tfstack.ProviderRequirement, len(sm.ProviderRequirements))
+		for k, v := range sm.ProviderRequirements {
+			newSm.ProviderRequirements[k] = v
+		}
 	}
 
 	return newSm

--- a/internal/features/stacks/state/stack_meta.go
+++ b/internal/features/stacks/state/stack_meta.go
@@ -7,19 +7,23 @@ import (
 	tfstack "github.com/hashicorp/terraform-schema/stack"
 )
 
-// StackMetadata contains the result of the early decoding of a module,
+// StackMetadata contains the result of the early decoding of a Stack,
 // it will be used obtain the correct provider and related module schemas
 type StackMetadata struct {
-	Filenames  []string
-	Components map[string]tfstack.Component
-	Variables  map[string]tfstack.Variable
-	Outputs    map[string]tfstack.Output
+	Filenames            []string
+	Components           map[string]tfstack.Component
+	Variables            map[string]tfstack.Variable
+	Outputs              map[string]tfstack.Output
+	ProviderRequirements map[string]tfstack.ProviderRequirement
 }
 
 func (sm StackMetadata) Copy() StackMetadata {
 	newSm := StackMetadata{
-		// version.Constraints is practically immutable once parsed
-		Filenames: sm.Filenames,
+		Filenames:            sm.Filenames,
+		Components:           sm.Components,
+		Variables:            sm.Variables,
+		Outputs:              sm.Outputs,
+		ProviderRequirements: sm.ProviderRequirements,
 	}
 
 	return newSm

--- a/internal/features/stacks/state/stack_meta.go
+++ b/internal/features/stacks/state/stack_meta.go
@@ -3,10 +3,17 @@
 
 package state
 
+import (
+	tfstack "github.com/hashicorp/terraform-schema/stack"
+)
+
 // StackMetadata contains the result of the early decoding of a module,
 // it will be used obtain the correct provider and related module schemas
 type StackMetadata struct {
-	Filenames []string
+	Filenames  []string
+	Components map[string]tfstack.Component
+	Variables  map[string]tfstack.Variable
+	Outputs    map[string]tfstack.Output
 }
 
 func (sm StackMetadata) Copy() StackMetadata {

--- a/internal/features/stacks/state/stack_record.go
+++ b/internal/features/stacks/state/stack_record.go
@@ -16,7 +16,9 @@ import (
 type StackRecord struct {
 	path string
 
-	Meta StackMetadata
+	Meta      StackMetadata
+	MetaErr   error
+	MetaState operation.OpState
 
 	// ParsedFiles is a map of all the parsed files for the stack,
 	// including Stack and Deploy files.

--- a/internal/features/stacks/state/stack_store.go
+++ b/internal/features/stacks/state/stack_store.go
@@ -285,26 +285,27 @@ func (s *StackStore) UpdateMetadata(path string, meta *tfstack.Meta, mErr error)
 	})
 	defer txn.Abort()
 
-	oldMod, err := stackByPath(txn, path)
+	oldRecord, err := stackByPath(txn, path)
 	if err != nil {
 		return err
 	}
 
-	mod := oldMod.Copy()
-	mod.Meta = StackMetadata{
-		Components: meta.Components,
-		Variables:  meta.Variables,
-		Outputs:    meta.Outputs,
-		Filenames:  meta.Filenames,
+	record := oldRecord.Copy()
+	record.Meta = StackMetadata{
+		Components:           meta.Components,
+		Variables:            meta.Variables,
+		Outputs:              meta.Outputs,
+		Filenames:            meta.Filenames,
+		ProviderRequirements: meta.ProviderRequirements,
 	}
-	mod.MetaErr = mErr
+	record.MetaErr = mErr
 
-	err = txn.Insert(s.tableName, mod)
+	err = txn.Insert(s.tableName, record)
 	if err != nil {
 		return err
 	}
 
-	err = s.queueRecordChange(oldMod, mod)
+	err = s.queueRecordChange(oldRecord, record)
 	if err != nil {
 		return err
 	}

--- a/internal/features/stacks/state/stack_store.go
+++ b/internal/features/stacks/state/stack_store.go
@@ -13,6 +13,7 @@ import (
 	globalState "github.com/hashicorp/terraform-ls/internal/state"
 	globalAst "github.com/hashicorp/terraform-ls/internal/terraform/ast"
 	"github.com/hashicorp/terraform-ls/internal/terraform/module/operation"
+	tfstack "github.com/hashicorp/terraform-schema/stack"
 )
 
 type StackStore struct {
@@ -250,6 +251,60 @@ func (s *StackStore) SetTerraformVersionState(path string, state operation.OpSta
 
 	stack.RequiredTerraformVersionState = state
 	err = txn.Insert(s.tableName, stack)
+	if err != nil {
+		return err
+	}
+
+	txn.Commit()
+	return nil
+}
+
+func (s *StackStore) SetMetaState(path string, state operation.OpState) error {
+	txn := s.db.Txn(true)
+	defer txn.Abort()
+
+	stack, err := stackCopyByPath(txn, path)
+	if err != nil {
+		return err
+	}
+
+	stack.MetaState = state
+	err = txn.Insert(s.tableName, stack)
+	if err != nil {
+		return err
+	}
+
+	txn.Commit()
+	return nil
+}
+
+func (s *StackStore) UpdateMetadata(path string, meta *tfstack.Meta, mErr error) error {
+	txn := s.db.Txn(true)
+	txn.Defer(func() {
+		s.SetMetaState(path, operation.OpStateLoaded)
+	})
+	defer txn.Abort()
+
+	oldMod, err := stackByPath(txn, path)
+	if err != nil {
+		return err
+	}
+
+	mod := oldMod.Copy()
+	mod.Meta = StackMetadata{
+		Components: meta.Components,
+		Variables:  meta.Variables,
+		Outputs:    meta.Outputs,
+		Filenames:  meta.Filenames,
+	}
+	mod.MetaErr = mErr
+
+	err = txn.Insert(s.tableName, mod)
+	if err != nil {
+		return err
+	}
+
+	err = s.queueRecordChange(oldMod, mod)
 	if err != nil {
 		return err
 	}

--- a/internal/terraform/module/operation/op_type_string.go
+++ b/internal/terraform/module/operation/op_type_string.go
@@ -27,12 +27,13 @@ func _() {
 	_ = x[OpTypeReferenceValidation-16]
 	_ = x[OpTypeTerraformValidate-17]
 	_ = x[OpTypeParseStackConfiguration-18]
-	_ = x[OpTypeLoadStackRequiredTerraformVersion-19]
+	_ = x[OpTypeLoadStackMetadata-19]
+	_ = x[OpTypeLoadStackRequiredTerraformVersion-20]
 }
 
-const _OpType_name = "OpTypeUnknownOpTypeGetTerraformVersionOpTypeGetInstalledTerraformVersionOpTypeObtainSchemaOpTypeParseModuleConfigurationOpTypeParseVariablesOpTypeParseModuleManifestOpTypeLoadModuleMetadataOpTypeDecodeReferenceTargetsOpTypeDecodeReferenceOriginsOpTypeDecodeVarsReferencesOpTypeGetModuleDataFromRegistryOpTypeParseProviderVersionsOpTypePreloadEmbeddedSchemaOpTypeSchemaModuleValidationOpTypeSchemaVarsValidationOpTypeReferenceValidationOpTypeTerraformValidateOpTypeParseStackConfigurationOpTypeLoadStackRequiredTerraformVersion"
+const _OpType_name = "OpTypeUnknownOpTypeGetTerraformVersionOpTypeGetInstalledTerraformVersionOpTypeObtainSchemaOpTypeParseModuleConfigurationOpTypeParseVariablesOpTypeParseModuleManifestOpTypeLoadModuleMetadataOpTypeDecodeReferenceTargetsOpTypeDecodeReferenceOriginsOpTypeDecodeVarsReferencesOpTypeGetModuleDataFromRegistryOpTypeParseProviderVersionsOpTypePreloadEmbeddedSchemaOpTypeSchemaModuleValidationOpTypeSchemaVarsValidationOpTypeReferenceValidationOpTypeTerraformValidateOpTypeParseStackConfigurationOpTypeLoadStackMetadataOpTypeLoadStackRequiredTerraformVersion"
 
-var _OpType_index = [...]uint16{0, 13, 38, 72, 90, 120, 140, 165, 189, 217, 245, 271, 302, 329, 356, 384, 410, 435, 458, 487, 526}
+var _OpType_index = [...]uint16{0, 13, 38, 72, 90, 120, 140, 165, 189, 217, 245, 271, 302, 329, 356, 384, 410, 435, 458, 487, 510, 549}
 
 func (i OpType) String() string {
 	if i >= OpType(len(_OpType_index)-1) {

--- a/internal/terraform/module/operation/operation.go
+++ b/internal/terraform/module/operation/operation.go
@@ -36,5 +36,6 @@ const (
 	OpTypeReferenceValidation
 	OpTypeTerraformValidate
 	OpTypeParseStackConfiguration
+	OpTypeLoadStackMetadata
 	OpTypeLoadStackRequiredTerraformVersion
 )


### PR DESCRIPTION
This commit adds a job to load the metadata for a stack. This metadata is used to decode the some of the configuration early before we have all the information we need to decode the full configuration. This is a first step towards decoding the full configuration of a stack.
