### PR TITLE
feat: load embedded provider schemas for providers found in stacks files

### DIFF
--- a/.changes/unreleased/INTERNAL-20240717-115636.yaml
+++ b/.changes/unreleased/INTERNAL-20240717-115636.yaml
@@ -1,0 +1,6 @@
+kind: INTERNAL
+body: Load embedded provider schemas for providers found in stacks files into state
+time: 2024-07-17T11:56:36.184201+02:00
+custom:
+    Issue: "1763"
+    Repository: terraform-ls

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/hashicorp/terraform-exec v0.21.0
 	github.com/hashicorp/terraform-json v0.22.1
 	github.com/hashicorp/terraform-registry-address v0.2.3
-	github.com/hashicorp/terraform-schema v0.0.0-20240715103008-d7b11d826dc8
+	github.com/hashicorp/terraform-schema v0.0.0-20240717123934-4ae973d1b11b
 	github.com/mcuadros/go-defaults v1.2.0
 	github.com/mh-cbon/go-fmt-fail v0.0.0-20160815164508-67765b3fbcb5
 	github.com/mitchellh/cli v1.1.5

--- a/go.sum
+++ b/go.sum
@@ -229,8 +229,8 @@ github.com/hashicorp/terraform-json v0.22.1 h1:xft84GZR0QzjPVWs4lRUwvTcPnegqlyS7
 github.com/hashicorp/terraform-json v0.22.1/go.mod h1:JbWSQCLFSXFFhg42T7l9iJwdGXBYV8fmmD6o/ML4p3A=
 github.com/hashicorp/terraform-registry-address v0.2.3 h1:2TAiKJ1A3MAkZlH1YI/aTVcLZRu7JseiXNRHbOAyoTI=
 github.com/hashicorp/terraform-registry-address v0.2.3/go.mod h1:lFHA76T8jfQteVfT7caREqguFrW3c4MFSPhZB7HHgUM=
-github.com/hashicorp/terraform-schema v0.0.0-20240715103008-d7b11d826dc8 h1:5y1/KiaPi/Ib/ZAkaKS30EjARaKiK2isnTrpI5pe9lI=
-github.com/hashicorp/terraform-schema v0.0.0-20240715103008-d7b11d826dc8/go.mod h1:ar787Bv/qD6tlnjtzH8fQ1Yi6c/B5LsnpFlO8c92Atg=
+github.com/hashicorp/terraform-schema v0.0.0-20240717123934-4ae973d1b11b h1:CI+WVmvNp63uPudDQy6d66y3ad2n8bY+gyePuwMeT0E=
+github.com/hashicorp/terraform-schema v0.0.0-20240717123934-4ae973d1b11b/go.mod h1:ar787Bv/qD6tlnjtzH8fQ1Yi6c/B5LsnpFlO8c92Atg=
 github.com/hashicorp/terraform-svchost v0.1.1 h1:EZZimZ1GxdqFRinZ1tpJwVxxt49xc/S52uzrw4x0jKQ=
 github.com/hashicorp/terraform-svchost v0.1.1/go.mod h1:mNsjQfZyf/Jhz35v6/0LWcv26+X7JPS+buii2c9/ctc=
 github.com/hexops/autogold v1.3.1 h1:YgxF9OHWbEIUjhDbpnLhgVsjUDsiHDTyDfy2lrfdlzo=

--- a/internal/features/stacks/events.go
+++ b/internal/features/stacks/events.go
@@ -208,7 +208,7 @@ func (f *StacksFeature) decodeStack(ctx context.Context, dir document.DirHandle,
 				f.store, f.stateStore.ProviderSchemas, path)
 		},
 		DependsOn:   job.IDs{metaId},
-		Type:        operation.OpTypePreloadEmbeddedSchema.String(),
+		Type:        operation.OpTypeStacksPreloadEmbeddedSchema.String(),
 		IgnoreState: ignoreState,
 	})
 	if err != nil {

--- a/internal/features/stacks/jobs/schema.go
+++ b/internal/features/stacks/jobs/schema.go
@@ -1,0 +1,62 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package jobs
+
+import (
+	"context"
+	"io/fs"
+	"log"
+
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-ls/internal/document"
+	"github.com/hashicorp/terraform-ls/internal/features/stacks/state"
+	"github.com/hashicorp/terraform-ls/internal/job"
+	globalState "github.com/hashicorp/terraform-ls/internal/state"
+	"github.com/hashicorp/terraform-ls/internal/terraform/module/operation"
+	tfaddr "github.com/hashicorp/terraform-registry-address"
+)
+
+func PreloadEmbeddedSchema(ctx context.Context, logger *log.Logger, fs fs.ReadDirFS, stackStore *state.StackStore, schemaStore *globalState.ProviderSchemaStore, stackPath string) error {
+	record, err := stackStore.StackRecordByPath(stackPath)
+
+	if err != nil {
+		return err
+	}
+
+	// Avoid preloading schema if it is already in progress or already known
+	if record.PreloadEmbeddedSchemaState != operation.OpStateUnknown && !job.IgnoreState(ctx) {
+		return job.StateNotChangedErr{Dir: document.DirHandleFromPath(stackPath)}
+	}
+
+	err = stackStore.SetPreloadEmbeddedSchemaState(stackPath, operation.OpStateLoading)
+	if err != nil {
+		return err
+	}
+	defer stackStore.SetPreloadEmbeddedSchemaState(stackPath, operation.OpStateLoaded)
+
+	pReqs := make(map[tfaddr.Provider]version.Constraints, len(record.Meta.ProviderRequirements))
+	for _, req := range record.Meta.ProviderRequirements {
+		pReqs[req.Source] = req.VersionConstraints
+	}
+
+	missingReqs, err := schemaStore.MissingSchemas(pReqs)
+	if err != nil {
+		return err
+	}
+
+	if len(missingReqs) == 0 {
+		// avoid preloading any schemas if we already have all
+		return nil
+	}
+
+	for _, pAddr := range missingReqs {
+		err := globalState.PreloadSchemaForProviderAddr(ctx, pAddr, fs, schemaStore, logger)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+
+}

--- a/internal/features/stacks/jobs/version_test.go
+++ b/internal/features/stacks/jobs/version_test.go
@@ -22,7 +22,7 @@ func TestLoadTerraformVersion(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ss, err := state.NewStackStore(gs.ChangeStore)
+	ss, err := state.NewStackStore(gs.ChangeStore, gs.ProviderSchemas)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -87,7 +87,7 @@ func TestLoadTerraformVersion_invalid(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			ss, err := state.NewStackStore(gs.ChangeStore)
+			ss, err := state.NewStackStore(gs.ChangeStore, gs.ProviderSchemas)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/features/stacks/stacks_feature.go
+++ b/internal/features/stacks/stacks_feature.go
@@ -28,7 +28,7 @@ type StacksFeature struct {
 }
 
 func NewStacksFeature(bus *eventbus.EventBus, stateStore *globalState.StateStore, fs jobs.ReadOnlyFS) (*StacksFeature, error) {
-	store, err := state.NewStackStore(stateStore.ChangeStore)
+	store, err := state.NewStackStore(stateStore.ChangeStore, stateStore.ProviderSchemas)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/features/stacks/state/schema.go
+++ b/internal/features/stacks/state/schema.go
@@ -30,7 +30,7 @@ var dbSchema = &memdb.DBSchema{
 	},
 }
 
-func NewStackStore(changeStore *globalState.ChangeStore) (*StackStore, error) {
+func NewStackStore(changeStore *globalState.ChangeStore, providerSchemasStore *globalState.ProviderSchemaStore) (*StackStore, error) {
 	db, err := memdb.NewMemDB(dbSchema)
 	if err != nil {
 		return nil, err
@@ -39,9 +39,10 @@ func NewStackStore(changeStore *globalState.ChangeStore) (*StackStore, error) {
 	discardLogger := log.New(io.Discard, "", 0)
 
 	return &StackStore{
-		db:          db,
-		tableName:   stackTableName,
-		logger:      discardLogger,
-		changeStore: changeStore,
+		db:                   db,
+		tableName:            stackTableName,
+		logger:               discardLogger,
+		changeStore:          changeStore,
+		providerSchemasStore: providerSchemasStore,
 	}, nil
 }

--- a/internal/features/stacks/state/stack_record.go
+++ b/internal/features/stacks/state/stack_record.go
@@ -16,6 +16,10 @@ import (
 type StackRecord struct {
 	path string
 
+	// PreloadEmbeddedSchemaState tracks if we tried loading all provider
+	// schemas from our embedded schema data
+	PreloadEmbeddedSchemaState operation.OpState
+
 	Meta      StackMetadata
 	MetaErr   error
 	MetaState operation.OpState
@@ -42,10 +46,17 @@ func (m *StackRecord) Copy() *StackRecord {
 	}
 
 	newRecord := &StackRecord{
-		path:             m.path,
+		path: m.path,
+
+		PreloadEmbeddedSchemaState: m.PreloadEmbeddedSchemaState,
+
 		Meta:             m.Meta.Copy(),
 		ParsingErr:       m.ParsingErr,
 		DiagnosticsState: m.DiagnosticsState.Copy(),
+
+		RequiredTerraformVersion:      m.RequiredTerraformVersion,
+		RequiredTerraformVersionErr:   m.RequiredTerraformVersionErr,
+		RequiredTerraformVersionState: m.RequiredTerraformVersionState,
 	}
 
 	if m.ParsedFiles != nil {

--- a/internal/state/provider_schema.go
+++ b/internal/state/provider_schema.go
@@ -4,13 +4,26 @@
 package state
 
 import (
+	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
+	"io/fs"
+	"log"
 	"sort"
+	"time"
 
 	"github.com/hashicorp/go-memdb"
 	"github.com/hashicorp/go-version"
+	tfjson "github.com/hashicorp/terraform-json"
+	"github.com/hashicorp/terraform-ls/internal/schemas"
 	tfaddr "github.com/hashicorp/terraform-registry-address"
 	tfschema "github.com/hashicorp/terraform-schema/schema"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 )
 
 type ProviderSchema struct {
@@ -479,4 +492,117 @@ func (s *ProviderSchemaStore) ListSchemas() (*ProviderSchemaIterator, error) {
 	}
 
 	return &ProviderSchemaIterator{ri}, nil
+}
+
+func PreloadSchemaForProviderAddr(ctx context.Context, pAddr tfaddr.Provider, fs fs.ReadDirFS,
+	schemaStore *ProviderSchemaStore, logger *log.Logger) error {
+
+	startTime := time.Now()
+
+	if pAddr.IsLegacy() && pAddr.Type == "terraform" {
+		// The terraform provider is built into Terraform 0.11+
+		// and while it's possible, users typically don't declare
+		// entry in required_providers block for it.
+		pAddr = tfaddr.NewProvider(tfaddr.BuiltInProviderHost, tfaddr.BuiltInProviderNamespace, "terraform")
+	} else if pAddr.IsLegacy() {
+		// Since we use recent version of Terraform to generate
+		// embedded schemas, these will never contain legacy
+		// addresses.
+		//
+		// A legacy namespace may come from missing
+		// required_providers entry & implied requirement
+		// from the provider block or 0.12-style entry,
+		// such as { grafana = "1.0" }.
+		//
+		// Implying "hashicorp" namespace here mimics behaviour
+		// of all recent (0.14+) Terraform versions.
+		originalAddr := pAddr
+		pAddr.Namespace = "hashicorp"
+		logger.Printf("preloading schema for %s (implying %s)",
+			originalAddr.ForDisplay(), pAddr.ForDisplay())
+	}
+
+	ctx, rootSpan := otel.Tracer(tracerName).Start(ctx, "preloadProviderSchema",
+		trace.WithAttributes(attribute.KeyValue{
+			Key:   attribute.Key("ProviderAddress"),
+			Value: attribute.StringValue(pAddr.String()),
+		}))
+	defer rootSpan.End()
+
+	pSchemaFile, err := schemas.FindProviderSchemaFile(fs, pAddr)
+	if err != nil {
+		rootSpan.RecordError(err)
+		rootSpan.SetStatus(codes.Error, "schema file not found")
+		if errors.Is(err, schemas.SchemaNotAvailable{Addr: pAddr}) {
+			logger.Printf("preloaded schema not available for %s", pAddr)
+			return nil
+		}
+		return err
+	}
+
+	_, span := otel.Tracer(tracerName).Start(ctx, "readProviderSchemaFile",
+		trace.WithAttributes(attribute.KeyValue{
+			Key:   attribute.Key("ProviderAddress"),
+			Value: attribute.StringValue(pAddr.String()),
+		}))
+	b, err := io.ReadAll(pSchemaFile.File)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "schema file not readable")
+		return err
+	}
+	span.SetStatus(codes.Ok, "schema file read successfully")
+	span.End()
+
+	_, span = otel.Tracer(tracerName).Start(ctx, "decodeProviderSchemaData",
+		trace.WithAttributes(attribute.KeyValue{
+			Key:   attribute.Key("ProviderAddress"),
+			Value: attribute.StringValue(pAddr.String()),
+		}))
+	jsonSchemas := tfjson.ProviderSchemas{}
+	err = json.Unmarshal(b, &jsonSchemas)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "schema file not decodable")
+		return err
+	}
+	span.SetStatus(codes.Ok, "schema data decoded successfully")
+	span.End()
+
+	ps, ok := jsonSchemas.Schemas[pAddr.String()]
+	if !ok {
+		return fmt.Errorf("%q: no schema found in file", pAddr)
+	}
+
+	pSchema := tfschema.ProviderSchemaFromJson(ps, pAddr)
+	pSchema.SetProviderVersion(pAddr, pSchemaFile.Version)
+
+	_, span = otel.Tracer(tracerName).Start(ctx, "loadProviderSchemaDataIntoMemDb",
+		trace.WithAttributes(attribute.KeyValue{
+			Key:   attribute.Key("ProviderAddress"),
+			Value: attribute.StringValue(pAddr.String()),
+		}))
+	err = schemaStore.AddPreloadedSchema(pAddr, pSchemaFile.Version, pSchema)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "loading schema into mem-db failed")
+		span.End()
+		existsError := &AlreadyExistsError{}
+		if errors.As(err, &existsError) {
+			// This accounts for a possible race condition
+			// where we may be preloading the same schema
+			// for different providers at the same time
+			logger.Printf("schema for %s is already loaded", pAddr)
+			return nil
+		}
+		return err
+	}
+	span.SetStatus(codes.Ok, "schema loaded successfully")
+	span.End()
+
+	elapsedTime := time.Since(startTime)
+	logger.Printf("preloaded schema for %s %s in %s", pAddr, pSchemaFile.Version, elapsedTime)
+	rootSpan.SetStatus(codes.Ok, "schema loaded successfully")
+
+	return nil
 }

--- a/internal/terraform/module/operation/op_type_string.go
+++ b/internal/terraform/module/operation/op_type_string.go
@@ -22,18 +22,19 @@ func _() {
 	_ = x[OpTypeGetModuleDataFromRegistry-11]
 	_ = x[OpTypeParseProviderVersions-12]
 	_ = x[OpTypePreloadEmbeddedSchema-13]
-	_ = x[OpTypeSchemaModuleValidation-14]
-	_ = x[OpTypeSchemaVarsValidation-15]
-	_ = x[OpTypeReferenceValidation-16]
-	_ = x[OpTypeTerraformValidate-17]
-	_ = x[OpTypeParseStackConfiguration-18]
-	_ = x[OpTypeLoadStackMetadata-19]
-	_ = x[OpTypeLoadStackRequiredTerraformVersion-20]
+	_ = x[OpTypeStacksPreloadEmbeddedSchema-14]
+	_ = x[OpTypeSchemaModuleValidation-15]
+	_ = x[OpTypeSchemaVarsValidation-16]
+	_ = x[OpTypeReferenceValidation-17]
+	_ = x[OpTypeTerraformValidate-18]
+	_ = x[OpTypeParseStackConfiguration-19]
+	_ = x[OpTypeLoadStackMetadata-20]
+	_ = x[OpTypeLoadStackRequiredTerraformVersion-21]
 }
 
-const _OpType_name = "OpTypeUnknownOpTypeGetTerraformVersionOpTypeGetInstalledTerraformVersionOpTypeObtainSchemaOpTypeParseModuleConfigurationOpTypeParseVariablesOpTypeParseModuleManifestOpTypeLoadModuleMetadataOpTypeDecodeReferenceTargetsOpTypeDecodeReferenceOriginsOpTypeDecodeVarsReferencesOpTypeGetModuleDataFromRegistryOpTypeParseProviderVersionsOpTypePreloadEmbeddedSchemaOpTypeSchemaModuleValidationOpTypeSchemaVarsValidationOpTypeReferenceValidationOpTypeTerraformValidateOpTypeParseStackConfigurationOpTypeLoadStackMetadataOpTypeLoadStackRequiredTerraformVersion"
+const _OpType_name = "OpTypeUnknownOpTypeGetTerraformVersionOpTypeGetInstalledTerraformVersionOpTypeObtainSchemaOpTypeParseModuleConfigurationOpTypeParseVariablesOpTypeParseModuleManifestOpTypeLoadModuleMetadataOpTypeDecodeReferenceTargetsOpTypeDecodeReferenceOriginsOpTypeDecodeVarsReferencesOpTypeGetModuleDataFromRegistryOpTypeParseProviderVersionsOpTypePreloadEmbeddedSchemaOpTypeStacksPreloadEmbeddedSchemaOpTypeSchemaModuleValidationOpTypeSchemaVarsValidationOpTypeReferenceValidationOpTypeTerraformValidateOpTypeParseStackConfigurationOpTypeLoadStackMetadataOpTypeLoadStackRequiredTerraformVersion"
 
-var _OpType_index = [...]uint16{0, 13, 38, 72, 90, 120, 140, 165, 189, 217, 245, 271, 302, 329, 356, 384, 410, 435, 458, 487, 510, 549}
+var _OpType_index = [...]uint16{0, 13, 38, 72, 90, 120, 140, 165, 189, 217, 245, 271, 302, 329, 356, 389, 417, 443, 468, 491, 520, 543, 582}
 
 func (i OpType) String() string {
 	if i >= OpType(len(_OpType_index)-1) {

--- a/internal/terraform/module/operation/operation.go
+++ b/internal/terraform/module/operation/operation.go
@@ -31,6 +31,7 @@ const (
 	OpTypeGetModuleDataFromRegistry
 	OpTypeParseProviderVersions
 	OpTypePreloadEmbeddedSchema
+	OpTypeStacksPreloadEmbeddedSchema
 	OpTypeSchemaModuleValidation
 	OpTypeSchemaVarsValidation
 	OpTypeReferenceValidation


### PR DESCRIPTION
Depends on https://github.com/hashicorp/terraform-schema/pull/375

---

This PR adds a job to load provider schemas that are embedded into the language server binary into state after the early decoder parsed which providers where used in a given stacks project. We will be going to use this information in the schema merger to e.g. enhance provider blocks with their respective attributes within the `config` block to support hover and completions.