### PR TITLE
Check for submodules when fetching schemas from the registry

### DIFF
--- a/.changes/unreleased/BUG FIXES-20240719-172514.yaml
+++ b/.changes/unreleased/BUG FIXES-20240719-172514.yaml
@@ -1,0 +1,6 @@
+kind: BUG FIXES
+body: "Check for submodules when fetching schemas from the registry"
+time: 2024-07-19T17:25:14.211785+02:00
+custom:
+    Issue: "1772"
+    Repository: terraform-ls

--- a/internal/features/modules/jobs/schema_mock_responses.go
+++ b/internal/features/modules/jobs/schema_mock_responses.go
@@ -261,7 +261,37 @@ var puppetModuleDataMockResponse = `{
       }
     ]
   },
-  "submodules": [],
+  "submodules": [
+    {
+      "path": "modules/ec",
+      "inputs": [
+        {
+          "name": "sub_autoscale",
+          "type": "string",
+          "description": "Enable autoscaling of elasticsearch",
+          "default": "\"true\"",
+          "required": false
+        },
+        {
+          "name": "sub_ec_stack_version",
+          "type": "string",
+          "description": "Version of Elastic Cloud stack to deploy",
+          "default": "\"\"",
+          "required": false
+        }
+      ],
+      "outputs": [
+        {
+          "name": "sub_elasticsearch_password",
+          "description": "elasticsearch password"
+        },
+        {
+          "name": "sub_deployment_id",
+          "description": "Elastic Cloud deployment ID"
+        }
+      ]
+    }
+  ],
   "examples": [],
   "providers": [
     "ec"

--- a/internal/features/modules/jobs/testdata/uninitialized-external-submodule/main.tf
+++ b/internal/features/modules/jobs/testdata/uninitialized-external-submodule/main.tf
@@ -1,0 +1,5 @@
+module "ec" {
+  source  = "puppetlabs/deployment/ec//modules/ec"
+  version = "0.0.8"
+
+}

--- a/internal/registry/module.go
+++ b/internal/registry/module.go
@@ -22,12 +22,19 @@ import (
 )
 
 type ModuleResponse struct {
-	Version     string     `json:"version"`
-	PublishedAt time.Time  `json:"published_at"`
-	Root        ModuleRoot `json:"root"`
+	Version     string      `json:"version"`
+	PublishedAt time.Time   `json:"published_at"`
+	Root        ModuleRoot  `json:"root"`
+	Submodules  []Submodule `json:"submodules"`
 }
 
 type ModuleRoot struct {
+	Inputs  []Input  `json:"inputs"`
+	Outputs []Output `json:"outputs"`
+}
+
+type Submodule struct {
+	Path    string   `json:"path"`
 	Inputs  []Input  `json:"inputs"`
 	Outputs []Output `json:"outputs"`
 }

--- a/internal/registry/module_test.go
+++ b/internal/registry/module_test.go
@@ -121,6 +121,7 @@ func TestGetModuleData(t *testing.T) {
 				},
 			},
 		},
+		Submodules: []Submodule{},
 	}
 	if diff := cmp.Diff(expectedData, data); diff != "" {
 		t.Fatalf("mismatched data: %s", diff)


### PR DESCRIPTION
Closes #1771 
Closes https://github.com/hashicorp/vscode-terraform/issues/1800

---

The registry client always used the Inputs and Outputs from the root module when fetching and storing a schema for a module with a registry address.
We now check if the source address contains a sub directory and use the Inputs and Outputs from the matching submodule.

## UX Before
![CleanShot 2024-07-19 at 17 26 25@2x](https://github.com/user-attachments/assets/ec19a7b9-a18f-47ac-a14a-5c09790e0f3f)

## UX After
![CleanShot 2024-07-19 at 17 26 48@2x](https://github.com/user-attachments/assets/fce1ed59-d75a-45c4-8ea0-a4fa8136237d)
