### PR TITLE
Schedule module validation jobs after within Defer

### DIFF
--- a/.changes/unreleased/BUG FIXES-20240725-105238.yaml
+++ b/.changes/unreleased/BUG FIXES-20240725-105238.yaml
@@ -1,0 +1,6 @@
+kind: BUG FIXES
+body: Ensure validation runs after decoding the whole module to avoid stale diagnostics
+time: 2024-07-25T10:52:38.411762+02:00
+custom:
+    Issue: "1777"
+    Repository: terraform-ls

--- a/internal/state/jobs.go
+++ b/internal/state/jobs.go
@@ -381,6 +381,8 @@ func isDirOpen(txn *memdb.Txn, dirHandle document.DirHandle) bool {
 	return docObj != nil
 }
 
+// WaitForJobs waits for all jobs to be done. If a job has a defer function
+// that returns new job IDs, it waits for those jobs to be done as well.
 func (js *JobStore) WaitForJobs(ctx context.Context, ids ...job.ID) error {
 	if len(ids) == 0 {
 		return nil


### PR DESCRIPTION
Moving the scheduling of both validation jobs into the Defer function ensures that they run after we loaded the schema, reference targets, and reference origins.

Before validation would run right after loading the metadata for a module without waiting on any of the work that we do in Defer.

Closes https://github.com/hashicorp/vscode-terraform/issues/1806

## UX Before
![CleanShot 2024-07-29 at 15 53 36](https://github.com/user-attachments/assets/df8188e9-74a9-4135-a8cd-6d6ab2fdb2e9)


## UX After
![CleanShot 2024-07-29 at 15 54 41](https://github.com/user-attachments/assets/fcd75183-1d41-4f5c-baf0-d3277692039c)

