### PR TITLE
deployments merge schemas

### DIFF
--- a/.changes/unreleased/ENHANCEMENTS-20240731-152949.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-20240731-152949.yaml
@@ -1,0 +1,6 @@
+kind: ENHANCEMENTS
+body: Merge deployment configuration schema with dynamic schema based on available variables
+time: 2024-07-31T15:29:49.214334+02:00
+custom:
+    Issue: "1780"
+    Repository: terraform-ls

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/hashicorp/terraform-exec v0.21.0
 	github.com/hashicorp/terraform-json v0.22.1
 	github.com/hashicorp/terraform-registry-address v0.2.3
-	github.com/hashicorp/terraform-schema v0.0.0-20240730123044-9fc1ce56945b
+	github.com/hashicorp/terraform-schema v0.0.0-20240731132239-de259563ac92
 	github.com/mcuadros/go-defaults v1.2.0
 	github.com/mh-cbon/go-fmt-fail v0.0.0-20160815164508-67765b3fbcb5
 	github.com/mitchellh/cli v1.1.5

--- a/go.sum
+++ b/go.sum
@@ -229,8 +229,8 @@ github.com/hashicorp/terraform-json v0.22.1 h1:xft84GZR0QzjPVWs4lRUwvTcPnegqlyS7
 github.com/hashicorp/terraform-json v0.22.1/go.mod h1:JbWSQCLFSXFFhg42T7l9iJwdGXBYV8fmmD6o/ML4p3A=
 github.com/hashicorp/terraform-registry-address v0.2.3 h1:2TAiKJ1A3MAkZlH1YI/aTVcLZRu7JseiXNRHbOAyoTI=
 github.com/hashicorp/terraform-registry-address v0.2.3/go.mod h1:lFHA76T8jfQteVfT7caREqguFrW3c4MFSPhZB7HHgUM=
-github.com/hashicorp/terraform-schema v0.0.0-20240730123044-9fc1ce56945b h1:NlRWtn37AasCvxZH1OQjClxVEzG4C7qCNwi+2iXczVg=
-github.com/hashicorp/terraform-schema v0.0.0-20240730123044-9fc1ce56945b/go.mod h1:k86q3epNJLLo/iHmXVrdjLU84bprKTFW1vxuP4iG07M=
+github.com/hashicorp/terraform-schema v0.0.0-20240731132239-de259563ac92 h1:GghC8nByA4ZQaZ7kB2ijlPHefJ+zGyheB1itRWmsITE=
+github.com/hashicorp/terraform-schema v0.0.0-20240731132239-de259563ac92/go.mod h1:k86q3epNJLLo/iHmXVrdjLU84bprKTFW1vxuP4iG07M=
 github.com/hashicorp/terraform-svchost v0.1.1 h1:EZZimZ1GxdqFRinZ1tpJwVxxt49xc/S52uzrw4x0jKQ=
 github.com/hashicorp/terraform-svchost v0.1.1/go.mod h1:mNsjQfZyf/Jhz35v6/0LWcv26+X7JPS+buii2c9/ctc=
 github.com/hexops/autogold v1.3.1 h1:YgxF9OHWbEIUjhDbpnLhgVsjUDsiHDTyDfy2lrfdlzo=

--- a/internal/features/stacks/decoder/path_reader.go
+++ b/internal/features/stacks/decoder/path_reader.go
@@ -125,8 +125,24 @@ func deployPathContext(record *state.StackRecord) (*decoder.PathContext, error) 
 		return nil, err
 	}
 
+	sm := stackschema.NewDeploySchemaMerger(schema)
+
+	meta := &tfstack.Meta{
+		Path:                 record.Path(),
+		ProviderRequirements: record.Meta.ProviderRequirements,
+		Components:           record.Meta.Components,
+		Variables:            record.Meta.Variables,
+		Outputs:              record.Meta.Outputs,
+		Filenames:            record.Meta.Filenames,
+	}
+
+	mergedSchema, err := sm.SchemaForDeployment(meta)
+	if err != nil {
+		return nil, err
+	}
+
 	pathCtx := &decoder.PathContext{
-		Schema:           schema,
+		Schema:           mergedSchema,
 		ReferenceOrigins: make(reference.Origins, 0),
 		ReferenceTargets: make(reference.Targets, 0),
 		Files:            make(map[string]*hcl.File, 0),

--- a/internal/features/stacks/state/stack_record.go
+++ b/internal/features/stacks/state/stack_record.go
@@ -51,6 +51,8 @@ func (m *StackRecord) Copy() *StackRecord {
 		PreloadEmbeddedSchemaState: m.PreloadEmbeddedSchemaState,
 
 		Meta:             m.Meta.Copy(),
+		MetaErr:          m.MetaErr,
+		MetaState:        m.MetaState,
 		ParsingErr:       m.ParsingErr,
 		DiagnosticsState: m.DiagnosticsState.Copy(),
 


### PR DESCRIPTION
Uses the schema merger for stack deployment files to add completion and hover support for deployment blocks in deployment configuration.

![completions](https://github.com/user-attachments/assets/2ad1680b-af78-4e63-92ec-c03a3cb1bbbb)

