### PR TITLE
feat: store early decoded deploy config and bump terraform-schema

### DIFF
--- a/.changes/unreleased/ENHANCEMENTS-20240816-134804.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-20240816-134804.yaml
@@ -1,0 +1,6 @@
+kind: ENHANCEMENTS
+body: Early decode deployment config to support references to store blocks
+time: 2024-08-16T13:48:04.258277+02:00
+custom:
+    Issue: "390"
+    Repository: terraform-schema

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/hashicorp/terraform-exec v0.21.0
 	github.com/hashicorp/terraform-json v0.22.1
 	github.com/hashicorp/terraform-registry-address v0.2.3
-	github.com/hashicorp/terraform-schema v0.0.0-20240815154350-b24c4f7b5a39
+	github.com/hashicorp/terraform-schema v0.0.0-20240819084908-27f3526335d0
 	github.com/mcuadros/go-defaults v1.2.0
 	github.com/mh-cbon/go-fmt-fail v0.0.0-20160815164508-67765b3fbcb5
 	github.com/mitchellh/cli v1.1.5

--- a/go.sum
+++ b/go.sum
@@ -229,8 +229,8 @@ github.com/hashicorp/terraform-json v0.22.1 h1:xft84GZR0QzjPVWs4lRUwvTcPnegqlyS7
 github.com/hashicorp/terraform-json v0.22.1/go.mod h1:JbWSQCLFSXFFhg42T7l9iJwdGXBYV8fmmD6o/ML4p3A=
 github.com/hashicorp/terraform-registry-address v0.2.3 h1:2TAiKJ1A3MAkZlH1YI/aTVcLZRu7JseiXNRHbOAyoTI=
 github.com/hashicorp/terraform-registry-address v0.2.3/go.mod h1:lFHA76T8jfQteVfT7caREqguFrW3c4MFSPhZB7HHgUM=
-github.com/hashicorp/terraform-schema v0.0.0-20240815154350-b24c4f7b5a39 h1:5N90p3PaMtyAuwXtTJPtdtKPxOfx7FIC/7zAzuvLfWs=
-github.com/hashicorp/terraform-schema v0.0.0-20240815154350-b24c4f7b5a39/go.mod h1:Tc8mlcXI3ulpnC1/Ho4O5DeivcXGfezj0U+igIDE3iA=
+github.com/hashicorp/terraform-schema v0.0.0-20240819084908-27f3526335d0 h1:OOg9n6z6hEFIbxAbSdJpb5k3+3M6D/GKckeXMbYI0Dk=
+github.com/hashicorp/terraform-schema v0.0.0-20240819084908-27f3526335d0/go.mod h1:Tc8mlcXI3ulpnC1/Ho4O5DeivcXGfezj0U+igIDE3iA=
 github.com/hashicorp/terraform-svchost v0.1.1 h1:EZZimZ1GxdqFRinZ1tpJwVxxt49xc/S52uzrw4x0jKQ=
 github.com/hashicorp/terraform-svchost v0.1.1/go.mod h1:mNsjQfZyf/Jhz35v6/0LWcv26+X7JPS+buii2c9/ctc=
 github.com/hexops/autogold v1.3.1 h1:YgxF9OHWbEIUjhDbpnLhgVsjUDsiHDTyDfy2lrfdlzo=

--- a/internal/features/stacks/decoder/path_reader.go
+++ b/internal/features/stacks/decoder/path_reader.go
@@ -89,6 +89,8 @@ func stackPathContext(record *state.StackRecord, stateReader CombinedReader) (*d
 		Variables:            record.Meta.Variables,
 		Outputs:              record.Meta.Outputs,
 		Filenames:            record.Meta.Filenames,
+		Deployments:          record.Meta.Deployments,
+		Stores:               record.Meta.Stores,
 	}
 
 	mergedSchema, err := sm.SchemaForStack(meta)
@@ -150,6 +152,8 @@ func deployPathContext(record *state.StackRecord) (*decoder.PathContext, error) 
 		Variables:            record.Meta.Variables,
 		Outputs:              record.Meta.Outputs,
 		Filenames:            record.Meta.Filenames,
+		Deployments:          record.Meta.Deployments,
+		Stores:               record.Meta.Stores,
 	}
 
 	mergedSchema, err := sm.SchemaForDeployment(meta)

--- a/internal/features/stacks/state/stack_meta.go
+++ b/internal/features/stacks/state/stack_meta.go
@@ -15,6 +15,9 @@ type StackMetadata struct {
 	Variables            map[string]tfstack.Variable
 	Outputs              map[string]tfstack.Output
 	ProviderRequirements map[string]tfstack.ProviderRequirement
+
+	Deployments map[string]tfstack.Deployment
+	Stores      map[string]tfstack.Store
 }
 
 func (sm StackMetadata) Copy() StackMetadata {
@@ -47,6 +50,20 @@ func (sm StackMetadata) Copy() StackMetadata {
 		newSm.ProviderRequirements = make(map[string]tfstack.ProviderRequirement, len(sm.ProviderRequirements))
 		for k, v := range sm.ProviderRequirements {
 			newSm.ProviderRequirements[k] = v
+		}
+	}
+
+	if sm.Deployments != nil {
+		newSm.Deployments = make(map[string]tfstack.Deployment, len(sm.Deployments))
+		for k, v := range sm.Deployments {
+			newSm.Deployments[k] = v
+		}
+	}
+
+	if sm.Stores != nil {
+		newSm.Stores = make(map[string]tfstack.Store, len(sm.Stores))
+		for k, v := range sm.Stores {
+			newSm.Stores[k] = v
 		}
 	}
 

--- a/internal/features/stacks/state/stack_store.go
+++ b/internal/features/stacks/state/stack_store.go
@@ -301,6 +301,8 @@ func (s *StackStore) UpdateMetadata(path string, meta *tfstack.Meta, mErr error)
 		Outputs:              meta.Outputs,
 		Filenames:            meta.Filenames,
 		ProviderRequirements: meta.ProviderRequirements,
+		Deployments:          meta.Deployments,
+		Stores:               meta.Stores,
 	}
 	record.MetaErr = mErr
 


### PR DESCRIPTION
Depends on https://github.com/hashicorp/terraform-schema/pull/390 to be merged and this PR to be updated with the squashed commit hash (_edit: done_)

![store_references](https://github.com/user-attachments/assets/6d2cf2fe-f5ea-40ef-af21-a5f8a9917e29)
