### PR TITLE
(TF-19244) feat: support a subset of functions in deployment configs

### DIFF
--- a/.changes/unreleased/ENHANCEMENTS-20240816-154910.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-20240816-154910.yaml
@@ -1,0 +1,6 @@
+kind: ENHANCEMENTS
+body: Support a subset of functions in deployment configurations
+time: 2024-08-16T15:49:10.404259+02:00
+custom:
+    Issue: "1799"
+    Repository: terraform-ls

--- a/internal/features/stacks/decoder/deploy_functions.go
+++ b/internal/features/stacks/decoder/deploy_functions.go
@@ -1,0 +1,81 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package decoder
+
+import (
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/hcl-lang/schema"
+)
+
+// source: https://github.com/hashicorp/tfc-agent/blob/fb9349a7d09985b206d32b218b36fa9ad2515478/core/components/stacks/lang/functions.go#L17
+var deployFunctionNames = []string{
+	"abs",
+	"can",
+	"ceil",
+	"chomp",
+	"coalescelist",
+	"compact",
+	"concat",
+	"contains",
+	"csvdecode",
+	"distinct",
+	"element",
+	"chunklist",
+	"flatten",
+	"floor",
+	"format",
+	"formatdate",
+	"formatlist",
+	"indent",
+	"join",
+	"jsondecode",
+	"jsonencode",
+	"keys",
+	"log",
+	"lower",
+	"max",
+	"merge",
+	"min",
+	"parseint",
+	"pow",
+	"range",
+	"regex",
+	"regexall",
+	"reverse",
+	"setintersection",
+	"setproduct",
+	"setsubtract",
+	"setunion",
+	"signum",
+	"slice",
+	"sort",
+	"split",
+	"strrev",
+	"substr",
+	"timeadd",
+	"title",
+	"trim",
+	"trimprefix",
+	"trimspace",
+	"trimsuffix",
+	"try",
+	"upper",
+	"values",
+	"yamldecode",
+	"yamlencode",
+	"zipmap",
+}
+
+func deployFunctionsForVersion(v *version.Version) map[string]schema.FunctionSignature {
+	fns := mustFunctionsForVersion(v)
+
+	deployFns := make(map[string]schema.FunctionSignature)
+	for _, name := range deployFunctionNames {
+		if fn, ok := fns[name]; ok {
+			deployFns[name] = *fn.Copy()
+		}
+	}
+
+	return deployFns
+}

--- a/internal/features/stacks/decoder/path_reader.go
+++ b/internal/features/stacks/decoder/path_reader.go
@@ -163,6 +163,7 @@ func deployPathContext(record *state.StackRecord) (*decoder.PathContext, error) 
 		ReferenceTargets: make(reference.Targets, 0),
 		Files:            make(map[string]*hcl.File, 0),
 		Validators:       stackValidators,
+		Functions:        deployFunctionsForVersion(version),
 	}
 
 	// TODO: Add reference origins and targets if needed


### PR DESCRIPTION
This adds support for a subset of the functions available in Terraform for deployment configuration.
![deploy_functions](https://github.com/user-attachments/assets/c477aa6b-0d81-4d54-a7c9-30c5ef75a429)

For example, `sum` is not supported currently:
<img width="557" alt="image" src="https://github.com/user-attachments/assets/ba96ebff-f969-4907-8e66-b122610ffe79">
