### PR TITLE
Bump terraform-schema to `1800e4c`

### DIFF
--- a/.changes/unreleased/BUG FIXES-20240823-102914.yaml
+++ b/.changes/unreleased/BUG FIXES-20240823-102914.yaml
@@ -1,0 +1,6 @@
+kind: BUG FIXES
+body: Fix type for provider references in component blocks
+time: 2024-08-23T10:29:14.023346+02:00
+custom:
+    Issue: "391"
+    Repository: terraform-schema

--- a/.changes/unreleased/ENHANCEMENTS-20240823-102940.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-20240823-102940.yaml
@@ -1,0 +1,6 @@
+kind: ENHANCEMENTS
+body: Support description attribute for orchestration rule block
+time: 2024-08-23T10:29:40.717478+02:00
+custom:
+    Issue: "393"
+    Repository: terraform-schema

--- a/.changes/unreleased/ENHANCEMENTS-20240823-103027.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-20240823-103027.yaml
@@ -1,0 +1,6 @@
+kind: ENHANCEMENTS
+body: Support locals in stack and deploy configs
+time: 2024-08-23T10:30:27.204226+02:00
+custom:
+    Issue: "395"
+    Repository: terraform-schema

--- a/.changes/unreleased/ENHANCEMENTS-20240823-103059.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-20240823-103059.yaml
@@ -1,0 +1,6 @@
+kind: ENHANCEMENTS
+body: Support depends_on attribute in component blocks
+time: 2024-08-23T10:30:59.844584+02:00
+custom:
+    Issue: "392"
+    Repository: terraform-schema

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/hashicorp/terraform-exec v0.21.0
 	github.com/hashicorp/terraform-json v0.22.1
 	github.com/hashicorp/terraform-registry-address v0.2.3
-	github.com/hashicorp/terraform-schema v0.0.0-20240819084908-27f3526335d0
+	github.com/hashicorp/terraform-schema v0.0.0-20240822075240-1800e4ce193c
 	github.com/mcuadros/go-defaults v1.2.0
 	github.com/mh-cbon/go-fmt-fail v0.0.0-20160815164508-67765b3fbcb5
 	github.com/mitchellh/cli v1.1.5

--- a/go.sum
+++ b/go.sum
@@ -229,8 +229,8 @@ github.com/hashicorp/terraform-json v0.22.1 h1:xft84GZR0QzjPVWs4lRUwvTcPnegqlyS7
 github.com/hashicorp/terraform-json v0.22.1/go.mod h1:JbWSQCLFSXFFhg42T7l9iJwdGXBYV8fmmD6o/ML4p3A=
 github.com/hashicorp/terraform-registry-address v0.2.3 h1:2TAiKJ1A3MAkZlH1YI/aTVcLZRu7JseiXNRHbOAyoTI=
 github.com/hashicorp/terraform-registry-address v0.2.3/go.mod h1:lFHA76T8jfQteVfT7caREqguFrW3c4MFSPhZB7HHgUM=
-github.com/hashicorp/terraform-schema v0.0.0-20240819084908-27f3526335d0 h1:OOg9n6z6hEFIbxAbSdJpb5k3+3M6D/GKckeXMbYI0Dk=
-github.com/hashicorp/terraform-schema v0.0.0-20240819084908-27f3526335d0/go.mod h1:Tc8mlcXI3ulpnC1/Ho4O5DeivcXGfezj0U+igIDE3iA=
+github.com/hashicorp/terraform-schema v0.0.0-20240822075240-1800e4ce193c h1:yyO3IXjZd0R1muo2yDp5x/9oYkv4w5OviH3QK/9H5F8=
+github.com/hashicorp/terraform-schema v0.0.0-20240822075240-1800e4ce193c/go.mod h1:Tc8mlcXI3ulpnC1/Ho4O5DeivcXGfezj0U+igIDE3iA=
 github.com/hashicorp/terraform-svchost v0.1.1 h1:EZZimZ1GxdqFRinZ1tpJwVxxt49xc/S52uzrw4x0jKQ=
 github.com/hashicorp/terraform-svchost v0.1.1/go.mod h1:mNsjQfZyf/Jhz35v6/0LWcv26+X7JPS+buii2c9/ctc=
 github.com/hexops/autogold v1.3.1 h1:YgxF9OHWbEIUjhDbpnLhgVsjUDsiHDTyDfy2lrfdlzo=


### PR DESCRIPTION
This PR updates `terraform-schema` to the latest main and ensures we have Changie entries for all PRs that landed in `terraform-schema` since the last release of Terraform LS.