### PR TITLE
fix brew install command

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -16,7 +16,7 @@ You can install the language server manually using one of the many package manag
 You can install via [Homebrew](https://brew.sh)
 
 ```
-brew install hashicorp/tap/terraform-ls
+brew install terraform-ls
 ```
 
 This tap only contains stable releases (i.e. no pre-releases).


### PR DESCRIPTION
the current Installation document has an outdated command for macos installation.