### PR TITLE
(TFECO-7524) chore: add Stacks Terraform version to telemetry

### DIFF
--- a/.changes/unreleased/INTERNAL-20240913-111349.yaml
+++ b/.changes/unreleased/INTERNAL-20240913-111349.yaml
@@ -1,0 +1,6 @@
+kind: INTERNAL
+body: Add Stacks Terraform version to telemetry
+time: 2024-09-13T11:13:49.570195+02:00
+custom:
+    Issue: "1828"
+    Repository: terraform-ls

--- a/internal/features/stacks/stacks_feature.go
+++ b/internal/features/stacks/stacks_feature.go
@@ -133,3 +133,20 @@ func (f *StacksFeature) Diagnostics(path string) diagnostics.Diagnostics {
 
 	return diags
 }
+
+func (f *StacksFeature) Telemetry(path string) map[string]interface{} {
+	properties := make(map[string]interface{})
+
+	record, err := f.store.StackRecordByPath(path)
+	if err != nil {
+		return properties
+	}
+
+	properties["stacks"] = true
+
+	if record.RequiredTerraformVersion != nil {
+		properties["stacksTfVersion"] = record.RequiredTerraformVersion.String()
+	}
+
+	return properties
+}

--- a/internal/langserver/handlers/hooks_module.go
+++ b/internal/langserver/handlers/hooks_module.go
@@ -37,7 +37,11 @@ func sendModuleTelemetry(features *Features, telemetrySender telemetry.Sender) n
 		// We assume there are no conflicting property keys
 		properties := features.Modules.Telemetry(path)
 		rootTelemetry := features.RootModules.Telemetry(path)
+		stacksTelemetry := features.Stacks.Telemetry(path)
 		for property, value := range rootTelemetry {
+			properties[property] = value
+		}
+		for property, value := range stacksTelemetry {
 			properties[property] = value
 		}
 


### PR DESCRIPTION
A minimal addition to the existing telemetry data that lets us measure usage of the new stacks feature.