### PR TITLE
docs: Usage - Fix file extension

### DIFF
--- a/.changes/unreleased/BUG FIXES-20240924-105626.yaml
+++ b/.changes/unreleased/BUG FIXES-20240924-105626.yaml
@@ -1,0 +1,6 @@
+kind: BUG FIXES
+body: Fix typo in USAGE.md
+time: 2024-09-24T10:56:26.217913+02:00
+custom:
+    Issue: "1835"
+    Repository: terraform-ls

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -9,7 +9,7 @@ The following filetypes are supported by the Terraform Language Server:
 - `terraform` - standard `*.tf` config files
 - `terraform-vars` - variable files (`*.tfvars`)
 - `terraform-stack` - standard `*.tfstack.hcl` files
-- `terraform-deploy` - standard `*.tfstack.hcl` files
+- `terraform-deploy` - standard `*.tfdeploy.hcl` files
 
 _NOTE:_ Clients should be configured to follow the above language ID conventions
 and do **not** send `*.tf.json`, `*.tfvars.json` nor Packer HCL config


### PR DESCRIPTION
It looks like this was initially pointed out in the PR https://github.com/hashicorp/terraform-ls/pull/1802/files#r1726640328 but not addressed.
