### PR TITLE
(TFECO-7637) Raise HCL diagnostics

### DIFF
--- a/.changes/unreleased/ENHANCEMENTS-20241107-164703.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-20241107-164703.yaml
@@ -1,0 +1,6 @@
+kind: ENHANCEMENTS
+body: Raise HCL Diagnostics during early validation
+time: 2024-11-07T16:47:03.069677-05:00
+custom:
+    Issue: "1500"
+    Repository: terraform-ls

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/hashicorp/terraform-exec v0.21.0
 	github.com/hashicorp/terraform-json v0.23.0
 	github.com/hashicorp/terraform-registry-address v0.2.3
-	github.com/hashicorp/terraform-schema v0.0.0-20241030161413-0438899ff948
+	github.com/hashicorp/terraform-schema v0.0.0-20241113181710-ea3872fef6cf
 	github.com/mcuadros/go-defaults v1.2.0
 	github.com/mh-cbon/go-fmt-fail v0.0.0-20160815164508-67765b3fbcb5
 	github.com/mitchellh/cli v1.1.5

--- a/go.sum
+++ b/go.sum
@@ -233,8 +233,8 @@ github.com/hashicorp/terraform-json v0.23.0 h1:sniCkExU4iKtTADReHzACkk8fnpQXrdD2
 github.com/hashicorp/terraform-json v0.23.0/go.mod h1:MHdXbBAbSg0GvzuWazEGKAn/cyNfIB7mN6y7KJN6y2c=
 github.com/hashicorp/terraform-registry-address v0.2.3 h1:2TAiKJ1A3MAkZlH1YI/aTVcLZRu7JseiXNRHbOAyoTI=
 github.com/hashicorp/terraform-registry-address v0.2.3/go.mod h1:lFHA76T8jfQteVfT7caREqguFrW3c4MFSPhZB7HHgUM=
-github.com/hashicorp/terraform-schema v0.0.0-20241030161413-0438899ff948 h1:2yw+7HPYOAEFafRpcw7BOtX9svWmXdc8sK5sSLZIjiI=
-github.com/hashicorp/terraform-schema v0.0.0-20241030161413-0438899ff948/go.mod h1:cA6LcD9EWWwgG3ZsZx+Fvyvgil6LYxTl3bknC8LF0B8=
+github.com/hashicorp/terraform-schema v0.0.0-20241113181710-ea3872fef6cf h1:rUFHjz0LWE7jM98hz2p5MDGtHq9oA8ZbDCY28VjcZtg=
+github.com/hashicorp/terraform-schema v0.0.0-20241113181710-ea3872fef6cf/go.mod h1:hwYMiQp/tVcJtYfbNSxEEK+ilauXwwtZgpLXmeUBVGg=
 github.com/hashicorp/terraform-svchost v0.1.1 h1:EZZimZ1GxdqFRinZ1tpJwVxxt49xc/S52uzrw4x0jKQ=
 github.com/hashicorp/terraform-svchost v0.1.1/go.mod h1:mNsjQfZyf/Jhz35v6/0LWcv26+X7JPS+buii2c9/ctc=
 github.com/hexops/autogold v1.3.1 h1:YgxF9OHWbEIUjhDbpnLhgVsjUDsiHDTyDfy2lrfdlzo=

--- a/internal/langserver/handlers/initialize_test.go
+++ b/internal/langserver/handlers/initialize_test.go
@@ -567,6 +567,12 @@ func TestInitialize_differentWorkspaceLayouts(t *testing.T) {
 				t.Fatal(err)
 			}
 			if len(allModules) != len(tc.expectedModules) {
+				for _, mods := range tc.expectedModules {
+					t.Logf("expected module: %s", mods)
+				}
+				for _, mods := range allModules {
+					t.Logf("got module: %s", mods.Path())
+				}
 				t.Fatalf("expected %d modules, got %d", len(tc.expectedModules), len(allModules))
 			}
 			for _, path := range tc.expectedModules {


### PR DESCRIPTION
This change updates the stack metadata loading to merge the new diagnostics with the existing ones. This is necessary to ensure that we don't lose any diagnostics that were previously reported.

Needs https://github.com/hashicorp/terraform-schema/pull/412