### PR TITLE
Minimal API changes to unblock PRs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/hashicorp/terraform-exec v0.21.0
 	github.com/hashicorp/terraform-json v0.23.0
 	github.com/hashicorp/terraform-registry-address v0.2.3
-	github.com/hashicorp/terraform-schema v0.0.0-20241029094833-06703fa106cc
+	github.com/hashicorp/terraform-schema v0.0.0-20241030161413-0438899ff948
 	github.com/mcuadros/go-defaults v1.2.0
 	github.com/mh-cbon/go-fmt-fail v0.0.0-20160815164508-67765b3fbcb5
 	github.com/mitchellh/cli v1.1.5

--- a/go.sum
+++ b/go.sum
@@ -233,8 +233,8 @@ github.com/hashicorp/terraform-json v0.23.0 h1:sniCkExU4iKtTADReHzACkk8fnpQXrdD2
 github.com/hashicorp/terraform-json v0.23.0/go.mod h1:MHdXbBAbSg0GvzuWazEGKAn/cyNfIB7mN6y7KJN6y2c=
 github.com/hashicorp/terraform-registry-address v0.2.3 h1:2TAiKJ1A3MAkZlH1YI/aTVcLZRu7JseiXNRHbOAyoTI=
 github.com/hashicorp/terraform-registry-address v0.2.3/go.mod h1:lFHA76T8jfQteVfT7caREqguFrW3c4MFSPhZB7HHgUM=
-github.com/hashicorp/terraform-schema v0.0.0-20241029094833-06703fa106cc h1:U65FhhW390MM/SfBebI3/Hyd3/BBv2Dy1s20cvRg82U=
-github.com/hashicorp/terraform-schema v0.0.0-20241029094833-06703fa106cc/go.mod h1:cA6LcD9EWWwgG3ZsZx+Fvyvgil6LYxTl3bknC8LF0B8=
+github.com/hashicorp/terraform-schema v0.0.0-20241030161413-0438899ff948 h1:2yw+7HPYOAEFafRpcw7BOtX9svWmXdc8sK5sSLZIjiI=
+github.com/hashicorp/terraform-schema v0.0.0-20241030161413-0438899ff948/go.mod h1:cA6LcD9EWWwgG3ZsZx+Fvyvgil6LYxTl3bknC8LF0B8=
 github.com/hashicorp/terraform-svchost v0.1.1 h1:EZZimZ1GxdqFRinZ1tpJwVxxt49xc/S52uzrw4x0jKQ=
 github.com/hashicorp/terraform-svchost v0.1.1/go.mod h1:mNsjQfZyf/Jhz35v6/0LWcv26+X7JPS+buii2c9/ctc=
 github.com/hexops/autogold v1.3.1 h1:YgxF9OHWbEIUjhDbpnLhgVsjUDsiHDTyDfy2lrfdlzo=

--- a/internal/features/stacks/decoder/path_reader.go
+++ b/internal/features/stacks/decoder/path_reader.go
@@ -26,6 +26,7 @@ import (
 type PathReader struct {
 	StateReader  StateReader
 	ModuleReader ModuleReader
+	RootReader   RootReader
 }
 
 var _ decoder.PathReader = &PathReader{}
@@ -33,6 +34,7 @@ var _ decoder.PathReader = &PathReader{}
 type CombinedReader struct {
 	ModuleReader
 	StateReader
+	RootReader
 }
 
 type StateReader interface {
@@ -47,6 +49,10 @@ type ModuleReader interface {
 	LocalModuleMeta(modPath string) (*tfmod.Meta, error)
 }
 
+type RootReader interface {
+	InstalledModulePath(rootPath string, normalizedSource string) (string, bool)
+}
+
 // PathContext returns a PathContext for the given path based on the language ID
 func (pr *PathReader) PathContext(path lang.Path) (*decoder.PathContext, error) {
 	record, err := pr.StateReader.StackRecordByPath(path.Path)
@@ -59,6 +65,7 @@ func (pr *PathReader) PathContext(path lang.Path) (*decoder.PathContext, error) 
 		return stackPathContext(record, CombinedReader{
 			StateReader:  pr.StateReader,
 			ModuleReader: pr.ModuleReader,
+			RootReader:   pr.RootReader,
 		})
 	case ilsp.Deploy.String():
 		return deployPathContext(record)

--- a/internal/features/stacks/events.go
+++ b/internal/features/stacks/events.go
@@ -249,7 +249,7 @@ func (f *StacksFeature) decodeStack(ctx context.Context, dir document.DirHandle,
 			refTargetsId, err := f.stateStore.JobStore.EnqueueJob(ctx, job.Job{
 				Dir: dir,
 				Func: func(ctx context.Context) error {
-					return jobs.DecodeReferenceTargets(ctx, f.store, f.moduleFeature, path)
+					return jobs.DecodeReferenceTargets(ctx, f.store, f.moduleFeature, f.rootFeature, path)
 				},
 				Type:        operation.OpTypeDecodeReferenceTargets.String(),
 				DependsOn:   append(componentIds, eSchemaId),
@@ -263,7 +263,7 @@ func (f *StacksFeature) decodeStack(ctx context.Context, dir document.DirHandle,
 			refOriginsId, err := f.stateStore.JobStore.EnqueueJob(ctx, job.Job{
 				Dir: dir,
 				Func: func(ctx context.Context) error {
-					return jobs.DecodeReferenceOrigins(ctx, f.store, f.moduleFeature, path)
+					return jobs.DecodeReferenceOrigins(ctx, f.store, f.moduleFeature, f.rootFeature, path)
 				},
 				Type:        operation.OpTypeDecodeReferenceOrigins.String(),
 				DependsOn:   append(componentIds, eSchemaId),
@@ -278,7 +278,7 @@ func (f *StacksFeature) decodeStack(ctx context.Context, dir document.DirHandle,
 				_, err := f.stateStore.JobStore.EnqueueJob(ctx, job.Job{
 					Dir: dir,
 					Func: func(ctx context.Context) error {
-						return jobs.SchemaStackValidation(ctx, f.store, f.moduleFeature, dir.Path())
+						return jobs.SchemaStackValidation(ctx, f.store, f.moduleFeature, f.rootFeature, dir.Path())
 					},
 					Type:        operation.OpTypeSchemaStackValidation.String(),
 					DependsOn:   job.IDs{refOriginsId, refTargetsId},
@@ -293,7 +293,7 @@ func (f *StacksFeature) decodeStack(ctx context.Context, dir document.DirHandle,
 				Dir: dir,
 				Func: func(ctx context.Context) error {
 
-					return jobs.ReferenceValidation(ctx, f.store, f.moduleFeature, dir.Path())
+					return jobs.ReferenceValidation(ctx, f.store, f.moduleFeature, f.rootFeature, dir.Path())
 				},
 				Type:        operation.OpTypeReferenceStackValidation.String(),
 				DependsOn:   job.IDs{refOriginsId, refTargetsId},

--- a/internal/features/stacks/jobs/references.go
+++ b/internal/features/stacks/jobs/references.go
@@ -26,7 +26,7 @@ import (
 // For example it tells us that variable block between certain LOC
 // can be referred to as var.foobar. This is useful e.g. during completion,
 // go-to-definition or go-to-references.
-func DecodeReferenceTargets(ctx context.Context, stackStore *state.StackStore, moduleReader sdecoder.ModuleReader, stackPath string) error {
+func DecodeReferenceTargets(ctx context.Context, stackStore *state.StackStore, moduleReader sdecoder.ModuleReader, rootFeature sdecoder.RootReader, stackPath string) error {
 	mod, err := stackStore.StackRecordByPath(stackPath)
 	if err != nil {
 		return err
@@ -47,6 +47,7 @@ func DecodeReferenceTargets(ctx context.Context, stackStore *state.StackStore, m
 	d := decoder.NewDecoder(&sdecoder.PathReader{
 		StateReader:  stackStore,
 		ModuleReader: moduleReader,
+		RootReader:   rootFeature,
 	})
 	d.SetContext(idecoder.DecoderContext(ctx))
 
@@ -95,7 +96,7 @@ func DecodeReferenceTargets(ctx context.Context, stackStore *state.StackStore, m
 // For example it tells us that there is a reference address var.foobar
 // at a particular LOC. This can be later matched with targets
 // (as obtained via [DecodeReferenceTargets]) during hover or go-to-definition.
-func DecodeReferenceOrigins(ctx context.Context, stackStore *state.StackStore, moduleReader sdecoder.ModuleReader, stackPath string) error {
+func DecodeReferenceOrigins(ctx context.Context, stackStore *state.StackStore, moduleReader sdecoder.ModuleReader, rootFeature sdecoder.RootReader, stackPath string) error {
 	mod, err := stackStore.StackRecordByPath(stackPath)
 	if err != nil {
 		return err
@@ -116,6 +117,7 @@ func DecodeReferenceOrigins(ctx context.Context, stackStore *state.StackStore, m
 	d := decoder.NewDecoder(&sdecoder.PathReader{
 		StateReader:  stackStore,
 		ModuleReader: moduleReader,
+		RootReader:   rootFeature,
 	})
 	d.SetContext(idecoder.DecoderContext(ctx))
 

--- a/internal/features/stacks/jobs/validation.go
+++ b/internal/features/stacks/jobs/validation.go
@@ -23,7 +23,7 @@ import (
 	"github.com/hashicorp/terraform-ls/internal/terraform/module/operation"
 )
 
-func SchemaStackValidation(ctx context.Context, stackStore *state.StackStore, moduleFeature stackDecoder.ModuleReader, stackPath string) error {
+func SchemaStackValidation(ctx context.Context, stackStore *state.StackStore, moduleFeature stackDecoder.ModuleReader, rootFeature stackDecoder.RootReader, stackPath string) error {
 	rpcContext := lsctx.DocumentContext(ctx)
 
 	record, err := stackStore.StackRecordByPath(stackPath)
@@ -44,6 +44,7 @@ func SchemaStackValidation(ctx context.Context, stackStore *state.StackStore, mo
 	d := decoder.NewDecoder(&stackDecoder.PathReader{
 		StateReader:  stackStore,
 		ModuleReader: moduleFeature,
+		RootReader:   rootFeature,
 	})
 	d.SetContext(idecoder.DecoderContext(ctx))
 
@@ -123,7 +124,7 @@ func SchemaStackValidation(ctx context.Context, stackStore *state.StackStore, mo
 //
 // It relies on [DecodeReferenceTargets] and [DecodeReferenceOrigins]
 // to supply both origins and targets to compare.
-func ReferenceValidation(ctx context.Context, stackStore *state.StackStore, moduleFeature stackDecoder.ModuleReader, stackPath string) error {
+func ReferenceValidation(ctx context.Context, stackStore *state.StackStore, moduleFeature stackDecoder.ModuleReader, rootFeature stackDecoder.RootReader, stackPath string) error {
 	record, err := stackStore.StackRecordByPath(stackPath)
 	if err != nil {
 		return err
@@ -142,6 +143,7 @@ func ReferenceValidation(ctx context.Context, stackStore *state.StackStore, modu
 	pathReader := &stackDecoder.PathReader{
 		StateReader:  stackStore,
 		ModuleReader: moduleFeature,
+		RootReader:   rootFeature,
 	}
 
 	stackDecoder, err := pathReader.PathContext(lang.Path{

--- a/internal/features/stacks/stacks_feature.go
+++ b/internal/features/stacks/stacks_feature.go
@@ -28,9 +28,10 @@ type StacksFeature struct {
 	stopFunc   context.CancelFunc
 
 	moduleFeature stackDecoder.ModuleReader
+	rootFeature   stackDecoder.RootReader
 }
 
-func NewStacksFeature(bus *eventbus.EventBus, stateStore *globalState.StateStore, fs jobs.ReadOnlyFS, moduleFeature stackDecoder.ModuleReader) (*StacksFeature, error) {
+func NewStacksFeature(bus *eventbus.EventBus, stateStore *globalState.StateStore, fs jobs.ReadOnlyFS, moduleFeature stackDecoder.ModuleReader, rootFeature stackDecoder.RootReader) (*StacksFeature, error) {
 	store, err := state.NewStackStore(stateStore.ChangeStore, stateStore.ProviderSchemas)
 	if err != nil {
 		return nil, err
@@ -45,6 +46,7 @@ func NewStacksFeature(bus *eventbus.EventBus, stateStore *globalState.StateStore
 		logger:        discardLogger,
 		stopFunc:      func() {},
 		moduleFeature: moduleFeature,
+		rootFeature:   rootFeature,
 	}, nil
 }
 
@@ -105,6 +107,7 @@ func (f *StacksFeature) PathContext(path lang.Path) (*decoder.PathContext, error
 	pathReader := &stackDecoder.PathReader{
 		StateReader:  f.store,
 		ModuleReader: f.moduleFeature,
+		RootReader:   f.rootFeature,
 	}
 
 	return pathReader.PathContext(path)
@@ -114,6 +117,7 @@ func (f *StacksFeature) Paths(ctx context.Context) []lang.Path {
 	pathReader := &stackDecoder.PathReader{
 		StateReader:  f.store,
 		ModuleReader: f.moduleFeature,
+		RootReader:   f.rootFeature,
 	}
 
 	return pathReader.Paths(ctx)

--- a/internal/langserver/handlers/service.go
+++ b/internal/langserver/handlers/service.go
@@ -538,7 +538,7 @@ func (svc *service) configureSessionDependencies(ctx context.Context, cfgOpts *s
 		variablesFeature.SetLogger(svc.logger)
 		variablesFeature.Start(svc.sessCtx)
 
-		stacksFeature, err := stacks.NewStacksFeature(svc.eventBus, svc.stateStore, svc.fs, modulesFeature)
+		stacksFeature, err := stacks.NewStacksFeature(svc.eventBus, svc.stateStore, svc.fs, modulesFeature, rootModulesFeature)
 		if err != nil {
 			return err
 		}

--- a/internal/langserver/handlers/session_mock_test.go
+++ b/internal/langserver/handlers/session_mock_test.go
@@ -163,7 +163,7 @@ func NewTestFeatures(eventBus *eventbus.EventBus, s *state.StateStore, fs *files
 		return nil, err
 	}
 
-	stacksFeature, err := fstacks.NewStacksFeature(eventBus, s, fs, modulesFeature)
+	stacksFeature, err := fstacks.NewStacksFeature(eventBus, s, fs, modulesFeature, rootModulesFeature)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR updates terraform-schema to `0438899ff948` which requires a new `InstalledModulePath` method. To comply with the updated interface, we need to pass the root feature to the stacks feature.

This should unblock 
* https://github.com/hashicorp/terraform-ls/pull/1850
* https://github.com/hashicorp/terraform-ls/pull/1854

So both can be reviewed and merged independently of https://github.com/hashicorp/terraform-ls/pull/1836.

To avoid this in the future, we should refrain from merging terraform-schema PRs that contain interface or struct changes until their terraform-ls counterpart has been reviewed & approved