### PR TITLE
(TFECO-8260) Add Heimdall metadata

### DIFF
--- a/.changes/unreleased/INTERNAL-20241120-134148.yaml
+++ b/.changes/unreleased/INTERNAL-20241120-134148.yaml
@@ -1,0 +1,6 @@
+kind: INTERNAL
+body: Add Heimdall metadata
+time: 2024-11-20T13:41:48.024126-05:00
+custom:
+    Issue: "1874"
+    Repository: terraform-ls

--- a/META.d/_summary.yml
+++ b/META.d/_summary.yml
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 schema: 1.1
 partition: tf-ecosystem
 category: tooling

--- a/META.d/_summary.yml
+++ b/META.d/_summary.yml
@@ -1,0 +1,8 @@
+schema: 1.1
+partition: tf-ecosystem
+category: tooling
+
+summary:
+  owner: team-tf-editor-experience
+  description: Terraform Language Server
+  visibility: external

--- a/META.d/data.yml
+++ b/META.d/data.yml
@@ -1,0 +1,3 @@
+data_summary:
+  gdpr:
+    exempt: true

--- a/META.d/data.yml
+++ b/META.d/data.yml
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 data_summary:
   gdpr:
     exempt: true


### PR DESCRIPTION
This change adds the metadata for the internal Heimdall service to the repository.
