### PR TITLE
Fix flaky `workspace/symbol` tests

### DIFF
--- a/.changes/unreleased/INTERNAL-20241128-173155.yaml
+++ b/.changes/unreleased/INTERNAL-20241128-173155.yaml
@@ -1,0 +1,6 @@
+kind: INTERNAL
+body: Fix flaky `workspace/symbol` tests
+time: 2024-11-28T17:31:55.311726+01:00
+custom:
+    Issue: "1880"
+    Repository: terraform-ls

--- a/internal/langserver/handlers/workspace_symbol_test.go
+++ b/internal/langserver/handlers/workspace_symbol_test.go
@@ -5,6 +5,8 @@ package handlers
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/hashicorp/terraform-ls/internal/langserver"
@@ -17,6 +19,15 @@ import (
 func TestLangServer_workspace_symbol_basic(t *testing.T) {
 	tmpDir := TempDir(t)
 	InitPluginCache(t, tmpDir.Path())
+
+	err := os.WriteFile(filepath.Join(tmpDir.Path(), "first.tf"), []byte("provider \"github\" {}\n"), 0o755)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = os.WriteFile(filepath.Join(tmpDir.Path(), "second.tf"), []byte("provider \"google\" {}\n"), 0o755)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	ss, err := state.NewStateStore()
 	if err != nil {
@@ -165,6 +176,15 @@ func TestLangServer_workspace_symbol_basic(t *testing.T) {
 func TestLangServer_workspace_symbol_missing(t *testing.T) {
 	tmpDir := TempDir(t)
 	InitPluginCache(t, tmpDir.Path())
+
+	err := os.WriteFile(filepath.Join(tmpDir.Path(), "first.tf"), []byte("provider \"github\" {}\n"), 0o755)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = os.WriteFile(filepath.Join(tmpDir.Path(), "second.tf"), []byte("provider \"google\" {}\n"), 0o755)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	ss, err := state.NewStateStore()
 	if err != nil {


### PR DESCRIPTION
In the `workspace/symbol` tests, we'll send multiple `didOpen` requests for files in the same directory. The first request will trigger parsing of the whole directory (which is empty on disk) and set the module state to "loaded". The second `didOpen` will then do nothing, as it will respect the state already marked as loaded.

Depending on the order of execution, sometimes both files are opened before the first parsing job runs, sometimes the job runs between the two calls, causing the test to fail.

By writing the files to disk first, we ensure that both are parsed by the first `didOpen` call.