### PR TITLE
Fix flaky initialize handler tests

### DIFF
--- a/.changes/unreleased/INTERNAL-20241202-134258.yaml
+++ b/.changes/unreleased/INTERNAL-20241202-134258.yaml
@@ -1,0 +1,6 @@
+kind: INTERNAL
+body: Fix flaky initialize handler tests
+time: 2024-12-02T13:42:58.677986+01:00
+custom:
+    Issue: "1883"
+    Repository: terraform-ls

--- a/internal/features/modules/modules_feature.go
+++ b/internal/features/modules/modules_feature.go
@@ -73,7 +73,8 @@ func (f *ModulesFeature) Start(ctx context.Context) {
 	ctx, cancelFunc := context.WithCancel(ctx)
 	f.stopFunc = cancelFunc
 
-	discover := f.eventbus.OnDiscover("feature.modules", nil)
+	discoverDone := make(chan job.IDs, 10)
+	discover := f.eventbus.OnDiscover("feature.modules", discoverDone)
 
 	didOpenDone := make(chan job.IDs, 10)
 	didOpen := f.eventbus.OnDidOpen("feature.modules", didOpenDone)
@@ -90,6 +91,7 @@ func (f *ModulesFeature) Start(ctx context.Context) {
 			case discover := <-discover:
 				// TODO? collect errors
 				f.discover(discover.Path, discover.Files)
+				discoverDone <- job.IDs{}
 			case didOpen := <-didOpen:
 				// TODO? collect errors
 				spawnedIds, _ := f.didOpen(didOpen.Context, didOpen.Dir, didOpen.LanguageID)

--- a/internal/features/rootmodules/root_modules_feature.go
+++ b/internal/features/rootmodules/root_modules_feature.go
@@ -69,7 +69,8 @@ func (f *RootModulesFeature) Start(ctx context.Context) {
 	ctx, cancelFunc := context.WithCancel(ctx)
 	f.stopFunc = cancelFunc
 
-	discover := f.eventbus.OnDiscover("feature.rootmodules", nil)
+	discoverDone := make(chan job.IDs, 10)
+	discover := f.eventbus.OnDiscover("feature.rootmodules", discoverDone)
 
 	didOpenDone := make(chan job.IDs, 10)
 	didOpen := f.eventbus.OnDidOpen("feature.rootmodules", didOpenDone)
@@ -86,6 +87,7 @@ func (f *RootModulesFeature) Start(ctx context.Context) {
 			case discover := <-discover:
 				// TODO? collect errors
 				f.discover(discover.Path, discover.Files)
+				discoverDone <- job.IDs{}
 			case didOpen := <-didOpen:
 				// TODO? collect errors
 				spawnedIds, _ := f.didOpen(didOpen.Context, didOpen.Dir)

--- a/internal/langserver/handlers/initialize_test.go
+++ b/internal/langserver/handlers/initialize_test.go
@@ -545,7 +545,11 @@ func TestInitialize_differentWorkspaceLayouts(t *testing.T) {
 			ls.Call(t, &langserver.CallRequest{
 				Method: "initialize",
 				ReqParams: fmt.Sprintf(`{
-				"capabilities": {},
+				"capabilities": {
+					"workspace": {
+						"workspaceFolders": true
+					}
+				},
 				"rootUri": %q,
 				"processId": 12345,
 				"workspaceFolders": [


### PR DESCRIPTION
This is PR `#2` of the "reducing CI flakiness" project.

We now wait for all directories found to be persisted in state during the workspace walk. This ensures that later operations will have access to the complete state.

### UX Before
<img width="1105" alt="image" src="https://github.com/user-attachments/assets/92218ab2-9cb9-4f1c-b410-660eb8164c72">

---

Related
* https://github.com/hashicorp/terraform-ls/pull/1880