### PR TITLE
Fix incorrect validation for heterogeneous list

### DIFF
--- a/.changes/unreleased/BUG FIXES-20241203-144106.yaml
+++ b/.changes/unreleased/BUG FIXES-20241203-144106.yaml
@@ -1,0 +1,6 @@
+kind: BUG FIXES
+body: Fix incorrect validation for heterogeneous list
+time: 2024-12-03T14:41:06.889146+01:00
+custom:
+    Issue: "1884"
+    Repository: terraform-ls

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/go-version v1.7.0
 	github.com/hashicorp/hc-install v0.9.0
-	github.com/hashicorp/hcl-lang v0.0.0-20241115124434-9d252ff73a68
+	github.com/hashicorp/hcl-lang v0.0.0-20241203131115-8d59b17219fd
 	github.com/hashicorp/hcl/v2 v2.23.0
 	github.com/hashicorp/terraform-exec v0.21.0
 	github.com/hashicorp/terraform-json v0.23.0

--- a/go.sum
+++ b/go.sum
@@ -228,8 +228,8 @@ github.com/hashicorp/hc-install v0.9.0 h1:2dIk8LcvANwtv3QZLckxcjyF5w8KVtiMxu6G6e
 github.com/hashicorp/hc-install v0.9.0/go.mod h1:+6vOP+mf3tuGgMApVYtmsnDoKWMDcFXeTxCACYZ8SFg=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/hashicorp/hcl-lang v0.0.0-20241115124434-9d252ff73a68 h1:AhKd5zK/+uiSRCmjpyQqZ8nSDBwiIz2fF5D4nXIYdys=
-github.com/hashicorp/hcl-lang v0.0.0-20241115124434-9d252ff73a68/go.mod h1:3HWmoYgqN9HnX3GXCIPbfjLNT48F/0dqY5SP8V9cmIs=
+github.com/hashicorp/hcl-lang v0.0.0-20241203131115-8d59b17219fd h1:Ap3K7uO+Dnd2ZSl5vQvIh63Z/QWaI5eTgRYfdYtaxH8=
+github.com/hashicorp/hcl-lang v0.0.0-20241203131115-8d59b17219fd/go.mod h1:5NUxE6UGpjm8iW/pY70BJWunDMkc73d7HTtvefU8B/c=
 github.com/hashicorp/hcl/v2 v2.23.0 h1:Fphj1/gCylPxHutVSEOf2fBOh1VE4AuLV7+kbJf3qos=
 github.com/hashicorp/hcl/v2 v2.23.0/go.mod h1:62ZYHrXgPoX8xBnzl8QzbWq4dyDsDtfCRgIq1rbJEvA=
 github.com/hashicorp/terraform-exec v0.21.0 h1:uNkLAe95ey5Uux6KJdua6+cv8asgILFVWkd/RG0D2XQ=


### PR DESCRIPTION
This PR brings in the following changes from hcl-lang:
* https://github.com/hashicorp/hcl-lang/pull/432

The local `a` is a tuple with specific element types. The for-expression has an empty tuple as a constraint, which doesn't match the specific element types. We now short-circuit the convertible check and always mark empty tuples as matching.

## UX Before
![CleanShot 2024-12-03 at 14 44 10@2x](https://github.com/user-attachments/assets/275525a3-ded8-4ac2-a843-8954fcaca789)

## UX After
![CleanShot 2024-12-03 at 14 44 27@2x](https://github.com/user-attachments/assets/66de70d3-1ebe-49d7-960b-2eca394f559f)


Fixes https://github.com/hashicorp/vscode-terraform/issues/1708