### PR TITLE
fix modules.json and terraform-sources.json overriding each other

### DIFF
--- a/.changes/unreleased/BUG FIXES-20241219-152506.yaml
+++ b/.changes/unreleased/BUG FIXES-20241219-152506.yaml
@@ -1,0 +1,6 @@
+kind: BUG FIXES
+body: Fix race when parsing locally installed module sources leading to empty completions
+time: 2024-12-19T15:25:06.951366+01:00
+custom:
+    Issue: "1903"
+    Repository: terraform-ls


### PR DESCRIPTION
#1836 added support for parsing `terraform-sources.json` files present in stacks projects. As the `modules.json` and the `terraform-sources.json` files are mutually exclusive and thus not expected to be present at the same time, that PR re-used the existing `InstalledModules` for simplicity. However, it thereby accidentally introduced a race between the two jobs looking for and parsing these files. In the case of https://github.com/hashicorp/vscode-terraform/issues/1915, the job parsing `terraform-sources.json` terminated second and overwrote `InstalledModules` with `nil` as no manifest file was found.

This PR adds a simple fix to only overwrite `InstalledModules` if it is not `nil` – this is just a short-term bandaid however, given it might lead to stale data. For a long-term fix, we should split `InstalledModules` into two fields instead.

Resolves https://github.com/hashicorp/vscode-terraform/issues/1915