### PR TITLE
feat: add documentLinks for resource and data types

### DIFF
--- a/internal/langserver/handlers/document_link.go
+++ b/internal/langserver/handlers/document_link.go
@@ -5,7 +5,14 @@ package handlers
 
 import (
 	"context"
+	"fmt"
+	"net/url"
+	"strings"
 
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/hashicorp/terraform-ls/internal/document"
 	ilsp "github.com/hashicorp/terraform-ls/internal/lsp"
 	lsp "github.com/hashicorp/terraform-ls/internal/protocol"
 )
@@ -42,5 +49,82 @@ func (svc *service) TextDocumentLink(ctx context.Context, params lsp.DocumentLin
 		return nil, err
 	}
 
+	// Add resource documentation links
+	resourceLinks, err := svc.generateResourceLinks(dh)
+	if err != nil {
+		// Don't fail the entire request if resource link generation fails
+		// Just continue with existing provider links
+	} else {
+		links = append(links, resourceLinks...)
+	}
+
 	return ilsp.Links(links, cc.TextDocument.DocumentLink), nil
+}
+
+// generateResourceLinks parses the Terraform file to find resource blocks
+// and generates documentation links for them
+func (svc *service) generateResourceLinks(dh document.Handle) ([]lang.Link, error) {
+	doc, err := svc.stateStore.DocumentStore.GetDocument(dh)
+	if err != nil {
+		return nil, err
+	}
+
+	f, diags := hclsyntax.ParseConfig(doc.Text, doc.Filename, hcl.InitialPos)
+	if diags.HasErrors() {
+		return nil, fmt.Errorf("failed to parse HCL: %s", diags.Error())
+	}
+
+	var links []lang.Link
+
+	for _, block := range f.Body.(*hclsyntax.Body).Blocks {
+		var urlPath string
+		var blockTypeDescription string
+
+		if block.Type == "resource" && len(block.Labels) >= 1 {
+			urlPath = "r"
+			blockTypeDescription = "resource"
+		} else if block.Type == "data" && len(block.Labels) >= 1 {
+			urlPath = "d"
+			blockTypeDescription = "data source"
+		} else {
+			continue // Skip other block types
+		}
+
+		resourceType := block.Labels[0]
+
+		// Extract provider name and resource name from resource type
+		// e.g., "azurerm_resource_group" -> provider: "azurerm", resource: "resource_group"
+		parts := strings.SplitN(resourceType, "_", 2)
+		if len(parts) != 2 {
+			continue // Skip malformed resource types
+		}
+
+		providerName := parts[0]
+		resourceName := parts[1]
+
+		// Generate documentation URL
+		docURL := fmt.Sprintf("https://www.terraform.io/docs/providers/%s/%s/%s.html", providerName, urlPath, resourceName)
+
+		// Add UTM parameters similar to existing provider links
+		u, err := url.Parse(docURL)
+		if err != nil {
+			continue
+		}
+
+		q := u.Query()
+		q.Set("utm_source", "terraform-ls")
+		q.Set("utm_content", "documentLink")
+		u.RawQuery = q.Encode()
+
+		// Create link for the resource type (first label)
+		if len(block.LabelRanges) > 0 {
+			links = append(links, lang.Link{
+				URI:     u.String(),
+				Tooltip: fmt.Sprintf("View documentation for %s %s", blockTypeDescription, resourceType),
+				Range:   block.LabelRanges[0],
+			})
+		}
+	}
+
+	return links, nil
 }


### PR DESCRIPTION
auto-generates document links for registry.terraform.io based on naming conventions.

closes #190

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
