### PR TITLE
feat: add document links for resources and data sources

### DIFF
--- a/internal/langserver/handlers/document_link.go
+++ b/internal/langserver/handlers/document_link.go
@@ -5,9 +5,18 @@ package handlers
 
 import (
 	"context"
+	"fmt"
+	"net/url"
+	"strings"
 
+	version "github.com/hashicorp/go-version"
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/hashicorp/terraform-ls/internal/document"
 	ilsp "github.com/hashicorp/terraform-ls/internal/lsp"
 	lsp "github.com/hashicorp/terraform-ls/internal/protocol"
+	tfaddr "github.com/hashicorp/terraform-registry-address"
 )
 
 func (svc *service) TextDocumentLink(ctx context.Context, params lsp.DocumentLinkParams) ([]lsp.DocumentLink, error) {
@@ -42,5 +51,170 @@ func (svc *service) TextDocumentLink(ctx context.Context, params lsp.DocumentLin
 		return nil, err
 	}
 
+	docLinks, err := svc.generateDocLinks(dh)
+	if err == nil {
+		links = append(links, docLinks...)
+	}
+
 	return ilsp.Links(links, cc.TextDocument.DocumentLink), nil
+}
+
+// generateDocLinks parses the Terraform file to find resource and data blocks and generates documentation links for their type labels.
+func (svc *service) generateDocLinks(dh document.Handle) ([]lang.Link, error) {
+	doc, err := svc.stateStore.DocumentStore.GetDocument(dh)
+	if err != nil {
+		return nil, err
+	}
+
+	f, diagnostics := hclsyntax.ParseConfig(doc.Text, doc.Filename, hcl.InitialPos)
+	if diagnostics.HasErrors() {
+		return nil, fmt.Errorf("failed to parse HCL: %s", diagnostics.Error())
+	}
+
+	var links []lang.Link
+
+	for _, block := range f.Body.(*hclsyntax.Body).Blocks {
+		var docPath, blockTypeDescription string
+
+		if block.Type == "resource" && len(block.Labels) >= 1 {
+			docPath, blockTypeDescription = "resources", "resource"
+		} else if block.Type == "data" && len(block.Labels) >= 1 {
+			docPath, blockTypeDescription = "data-sources", "data source"
+		} else {
+			continue // Skip other block types.
+		}
+
+		resourceType := block.Labels[0]
+
+		// Extract provider name and resource name from the resource type.
+		// e.g. "azurerm_resource_group" -> provider: "azurerm", resource: "resource_group"
+		parts := strings.SplitN(resourceType, "_", 2)
+		if len(parts) != 2 {
+			continue // Skip malformed resource types.
+		}
+
+		providerAddr, ver := svc.installedProviderForType(dh.Dir.Path(), parts[0])
+		docURL, err := buildResourceDocURL(providerAddr, ver, docPath, parts[1])
+		if err != nil {
+			continue
+		}
+
+		// Create link for the resource type (first label).
+		if len(block.LabelRanges) > 0 {
+			links = append(links, lang.Link{
+				URI:     docURL,
+				Tooltip: fmt.Sprintf("View documentation for %s %s", blockTypeDescription, resourceType),
+				Range:   block.LabelRanges[0],
+			})
+		}
+	}
+
+	return links, nil
+}
+
+// resourceDocURLAtPos returns the documentation URL and resource type if the given position
+// falls within the first label of a resource or data block, otherwise returns empty strings.
+func (svc *service) resourceDocURLAtPos(dh document.Handle, pos hcl.Pos) (docURL, resourceType string) {
+	doc, err := svc.stateStore.DocumentStore.GetDocument(dh)
+	if err != nil {
+		return "", ""
+	}
+
+	f, diagnostics := hclsyntax.ParseConfig(doc.Text, doc.Filename, hcl.InitialPos)
+	if diagnostics.HasErrors() {
+		return "", ""
+	}
+
+	for _, block := range f.Body.(*hclsyntax.Body).Blocks {
+		var docPath string
+
+		if block.Type == "resource" && len(block.Labels) >= 1 {
+			docPath = "resources"
+		} else if block.Type == "data" && len(block.Labels) >= 1 {
+			docPath = "data-sources"
+		} else {
+			continue
+		}
+
+		if len(block.LabelRanges) == 0 {
+			continue
+		}
+
+		lr := block.LabelRanges[0]
+		if pos.Byte < lr.Start.Byte || pos.Byte >= lr.End.Byte {
+			continue
+		}
+
+		resourceType = block.Labels[0]
+		parts := strings.SplitN(resourceType, "_", 2)
+		if len(parts) != 2 {
+			continue
+		}
+
+		providerAddr, ver := svc.installedProviderForType(dh.Dir.Path(), parts[0])
+		docURL, err = buildResourceDocURL(providerAddr, ver, docPath, parts[1])
+		if err != nil {
+			return "", ""
+		}
+
+		return docURL, resourceType
+	}
+
+	return "", ""
+}
+
+// installedProviderForType returns the installed provider address and version for the given
+// provider type (e.g. "aws"), or a partial address with only Type set when not found.
+func (svc *service) installedProviderForType(modPath, providerType string) (tfaddr.Provider, *version.Version) {
+	if svc.features == nil || svc.features.RootModules == nil {
+		return tfaddr.Provider{Type: providerType}, nil
+	}
+
+	installedProviders, err := svc.features.RootModules.InstalledProviders(modPath)
+	if err != nil {
+		return tfaddr.Provider{Type: providerType}, nil
+	}
+
+	for provider, ver := range installedProviders {
+		if provider.Type == providerType {
+			return provider, ver
+		}
+	}
+
+	return tfaddr.Provider{Type: providerType}, nil
+}
+
+// buildResourceDocURL constructs a versioned Terraform Registry documentation URL with UTM parameters.
+// Falls back to the legacy terraform.io URL format when provider namespace is unavailable.
+func buildResourceDocURL(providerAddr tfaddr.Provider, ver *version.Version, docPath, resourceName string) (string, error) {
+	var rawURL string
+
+	switch {
+	case providerAddr.Namespace != "" && ver != nil:
+		rawURL = fmt.Sprintf("https://registry.terraform.io/providers/%s/%s/%s/docs/%s/%s",
+			providerAddr.Namespace, providerAddr.Type, ver.String(), docPath, resourceName)
+	case providerAddr.Namespace != "":
+		rawURL = fmt.Sprintf("https://registry.terraform.io/providers/%s/%s/latest/docs/%s/%s",
+			providerAddr.Namespace, providerAddr.Type, docPath, resourceName)
+	default:
+		// Fallback: provider not installed or lock file absent — use legacy URL.
+		urlPath := "r"
+		if docPath == "data-sources" {
+			urlPath = "d"
+		}
+		rawURL = fmt.Sprintf("https://www.terraform.io/docs/providers/%s/%s/%s.html",
+			providerAddr.Type, urlPath, resourceName)
+	}
+
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return "", err
+	}
+
+	q := u.Query()
+	q.Set("utm_source", "terraform-ls")
+	q.Set("utm_content", "documentLink")
+	u.RawQuery = q.Encode()
+
+	return u.String(), nil
 }

--- a/internal/langserver/handlers/document_link_test.go
+++ b/internal/langserver/handlers/document_link_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/go-version"
@@ -131,4 +132,200 @@ func TestDocumentLink_withValidData(t *testing.T) {
 				}
 			]
 		}`)
+}
+
+func TestDocumentLink_withResourceAndDataSource(t *testing.T) {
+	tmpDir := TempDir(t)
+	InitPluginCache(t, tmpDir.Path())
+
+	terraformConfig := `
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "aws_instance" "web" {
+  ami 		    = "ami-0c55b159cbfafe1d0"
+  instance_type = "t2.micro"
+}
+
+resource "google_compute_instance" "default" {
+  name         = "test"
+  machine_type = "e2-medium"
+  zone         = "us-central1-a"
+}
+
+data "azurerm_client_config" "current" {}
+
+data "aws_ami" "ubuntu" {
+  most_recent = true
+  owners 	  = ["099720109477"]
+}
+
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+`
+	err := os.WriteFile(filepath.Join(tmpDir.Path(), "main.tf"), []byte(terraformConfig), 0o755)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var testSchema tfjson.ProviderSchemas
+	err = json.Unmarshal([]byte(testModuleSchemaOutput), &testSchema)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ss, err := state.NewStateStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	wc := walker.NewWalkerCollector()
+
+	ls := langserver.NewLangServerMock(t, NewMockSession(&MockSessionInput{
+		TerraformCalls: &exec.TerraformMockCalls{
+			PerWorkDir: map[string][]*mock.Call{
+				tmpDir.Path(): {
+					{
+						Method:        "Version",
+						Repeatability: 1,
+						Arguments: []interface{}{
+							mock.AnythingOfType(""),
+						},
+						ReturnArguments: []interface{}{
+							version.Must(version.NewVersion("0.12.1")),
+							nil,
+							nil,
+						},
+					},
+					{
+						Method:        "GetExecPath",
+						Repeatability: 1,
+						ReturnArguments: []interface{}{
+							"",
+						},
+					},
+					{
+						Method:        "ProviderSchemas",
+						Repeatability: 1,
+						Arguments: []interface{}{
+							mock.AnythingOfType(""),
+						},
+						ReturnArguments: []interface{}{
+							&testSchema,
+							nil,
+						},
+					},
+				},
+			},
+		},
+		StateStore:      ss,
+		WalkerCollector: wc,
+	}))
+	stop := ls.Start(t)
+	defer stop()
+
+	ls.Call(t, &langserver.CallRequest{
+		Method: "initialize",
+		ReqParams: fmt.Sprintf(`{
+		"capabilities": {},
+		"rootUri": %q,
+		"processId": 12345
+	}`, tmpDir.URI)})
+	waitForWalkerPath(t, ss, wc, tmpDir)
+	ls.Notify(t, &langserver.CallRequest{
+		Method:    "initialized",
+		ReqParams: "{}",
+	})
+	ls.Call(t, &langserver.CallRequest{
+		Method: "textDocument/didOpen",
+		ReqParams: fmt.Sprintf(`{
+		"textDocument": {
+			"version": 0,
+			"languageId": "terraform",
+			"text": %q,
+			"uri": "%s/main.tf"
+		}
+	}`, terraformConfig, tmpDir.URI)})
+	waitForAllJobs(t, ss)
+
+	// Test that resource links are included in the response.
+	resp := ls.Call(t, &langserver.CallRequest{
+		Method: "textDocument/documentLink",
+		ReqParams: fmt.Sprintf(`{
+			"textDocument": {
+				"uri": "%s/main.tf"
+			}
+		}`, tmpDir.URI)})
+
+	// Parse the response to check that resource links are present.
+	var links []struct {
+		Range struct {
+			Start struct {
+				Line      int `json:"line"`
+				Character int `json:"character"`
+			} `json:"start"`
+			End struct {
+				Line      int `json:"line"`
+				Character int `json:"character"`
+			} `json:"end"`
+		} `json:"range"`
+		Target string `json:"target"`
+	}
+
+	err = json.Unmarshal(resp.Result, &links)
+	if err != nil {
+		t.Fatalf("Failed to parse response: %v", err)
+	}
+
+	// Check that we have resource and data source links.
+	var foundAzureResourceLink, foundAzureDataLink = false, false
+	var foundAwsResourceLink, foundAwsDataLink = false, false
+	var foundGoogleResourceLink, foundGoogleDataLink = false, false
+
+	for _, link := range links {
+		if strings.Contains(link.Target, "azurerm/r/resource_group.html") {
+			foundAzureResourceLink = true
+		}
+		if strings.Contains(link.Target, "azurerm/d/client_config.html") {
+			foundAzureDataLink = true
+		}
+		if strings.Contains(link.Target, "aws/r/instance.html") {
+			foundAwsResourceLink = true
+		}
+		if strings.Contains(link.Target, "aws/d/ami.html") {
+			foundAwsDataLink = true
+		}
+		if strings.Contains(link.Target, "google/r/compute_instance.html") {
+			foundGoogleResourceLink = true
+		}
+		if strings.Contains(link.Target, "google/d/compute_image.html") {
+			foundGoogleDataLink = true
+		}
+	}
+
+	if !foundAzureResourceLink {
+		t.Error("Expected to find Azure resource group documentation link")
+	}
+	if !foundAzureDataLink {
+		t.Error("Expected to find Azure client config data source documentation link")
+	}
+	if !foundAwsResourceLink {
+		t.Error("Expected to find AWS instance documentation link")
+	}
+	if !foundAwsDataLink {
+		t.Error("Expected to find AWS AMI data source documentation link")
+	}
+	if !foundGoogleResourceLink {
+		t.Error("Expected to find Google compute instance documentation link")
+	}
+	if !foundGoogleDataLink {
+		t.Error("Expected to find Google compute image data source documentation link")
+	}
 }

--- a/internal/langserver/handlers/hover.go
+++ b/internal/langserver/handlers/hover.go
@@ -5,6 +5,7 @@ package handlers
 
 import (
 	"context"
+	"fmt"
 
 	ilsp "github.com/hashicorp/terraform-ls/internal/lsp"
 	lsp "github.com/hashicorp/terraform-ls/internal/protocol"
@@ -43,6 +44,12 @@ func (svc *service) TextDocumentHover(ctx context.Context, params lsp.TextDocume
 	svc.logger.Printf("received hover data: %#v", hoverData)
 	if err != nil {
 		return nil, err
+	}
+
+	if hoverData != nil {
+		if docURL, resourceType := svc.resourceDocURLAtPos(dh, pos); docURL != "" {
+			hoverData.Content.Value += fmt.Sprintf("\n\n---\n\n[`%s` on registry.terraform.io](%s)", resourceType, docURL)
+		}
 	}
 
 	return ilsp.HoverData(hoverData, cc.TextDocument), nil

--- a/internal/langserver/handlers/hover_test.go
+++ b/internal/langserver/handlers/hover_test.go
@@ -263,3 +263,115 @@ func TestVarsHover_withValidData(t *testing.T) {
 			}
 		}`)
 }
+
+func TestHover_withDocumentationLink(t *testing.T) {
+	tmpDir := TempDir(t)
+	InitPluginCache(t, tmpDir.Path())
+
+	var testSchema tfjson.ProviderSchemas
+	err := json.Unmarshal([]byte(testModuleSchemaOutput), &testSchema)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ss, err := state.NewStateStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	wc := walker.NewWalkerCollector()
+
+	ls := langserver.NewLangServerMock(t, NewMockSession(&MockSessionInput{
+		TerraformCalls: &exec.TerraformMockCalls{
+			PerWorkDir: map[string][]*mock.Call{
+				tmpDir.Path(): {
+					{
+						Method:        "Version",
+						Repeatability: 1,
+						Arguments: []interface{}{
+							mock.AnythingOfType(""),
+						},
+						ReturnArguments: []interface{}{
+							version.Must(version.NewVersion("0.12.0")),
+							nil,
+							nil,
+						},
+					},
+					{
+						Method:        "GetExecPath",
+						Repeatability: 1,
+						ReturnArguments: []interface{}{
+							"",
+						},
+					},
+					{
+						Method:        "ProviderSchemas",
+						Repeatability: 1,
+						Arguments: []interface{}{
+							mock.AnythingOfType(""),
+						},
+						ReturnArguments: []interface{}{
+							&testSchema,
+							nil,
+						},
+					},
+				},
+			},
+		},
+		StateStore:      ss,
+		WalkerCollector: wc,
+	}))
+	stop := ls.Start(t)
+	defer stop()
+
+	ls.Call(t, &langserver.CallRequest{
+		Method: "initialize",
+		ReqParams: fmt.Sprintf(`{
+		"capabilities": {"textDocument": {"hover": {"contentFormat": ["markdown"]}}},
+		"rootUri": %q,
+		"processId": 12345
+	}`, tmpDir.URI)})
+	waitForWalkerPath(t, ss, wc, tmpDir)
+	ls.Notify(t, &langserver.CallRequest{
+		Method:    "initialized",
+		ReqParams: "{}",
+	})
+	ls.Call(t, &langserver.CallRequest{
+		Method: "textDocument/didOpen",
+		ReqParams: fmt.Sprintf(`{
+		"textDocument": {
+			"version": 0,
+			"languageId": "terraform",
+			"text": "resource \"test_resource_1\" \"example\" {\n}\n",
+			"uri": "%s/main.tf"
+		}
+	}`, tmpDir.URI)})
+	waitForAllJobs(t, ss)
+
+	// Position 12 on line 0 lands inside the "test_resource_1" type label.
+	// The response should include the decoder's hover content for the resource
+	// type plus a documentation link footer appended by the handler.
+	ls.CallAndExpectResponse(t, &langserver.CallRequest{
+		Method: "textDocument/hover",
+		ReqParams: fmt.Sprintf(`{
+			"textDocument": {
+				"uri": "%s/main.tf"
+			},
+			"position": {
+				"character": 12,
+				"line": 0
+			}
+		}`, tmpDir.URI)}, `{
+			"jsonrpc": "2.0",
+			"id": 3,
+			"result": {
+				"contents": {
+					"kind": "markdown",
+					"value": "`+"`test_resource_1`"+` test/test\n\nResource 1 description\n\n---\n\n[`+"`test_resource_1`"+` on registry.terraform.io](https://www.terraform.io/docs/providers/test/r/resource_1.html?utm_content=documentLink\u0026utm_source=terraform-ls)"
+				},
+				"range": {
+					"start": { "line": 0, "character": 9 },
+					"end":   { "line": 0, "character": 26 }
+				}
+			}
+		}`)
+}


### PR DESCRIPTION
Auto-generate documentation links for resources and data types to make them discoverable on [https://registry.terraform.io](https://registry.terraform.io). Also, the specified provider version is included in the URL.

Inspired by [2004](https://github.com/hashicorp/terraform-ls/pull/2004), which should be probably closed.

Tested:
```sh
go test ./internal/langserver/handlers/ -run TestDocumentLink_withResourceAndDataSource -v
go test ./internal/langserver/handlers/ -run TestHover_withDocumentationLink -v
```

Also, I'm not sure https://www.terraform.io/docs/providers/%s/%s/%s.html will be useful, but I'll leave it as is for now.

I didn't originally plan to change the hover handler, but without that change, the link in my Neovim popup footer doesn't show up at all.

Screenshots:
<img width="426" height="156" alt="image" src="https://github.com/user-attachments/assets/c01ea869-7586-4987-bc44-cdcf4c12d19c" />
<img width="1392" height="156" alt="image" src="https://github.com/user-attachments/assets/44948583-3ccb-4527-87b5-4d5f092e8d8d" />

Note: This contribution was developed with AI assistance. Closing as I've decided not to pursue this contribution.

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
