### PR TITLE
Load providers from submodule

### DIFF
--- a/internal/features/rootmodules/events.go
+++ b/internal/features/rootmodules/events.go
@@ -18,17 +18,17 @@ import (
 	"github.com/hashicorp/terraform-ls/internal/uri"
 )
 
-func (f *RootModulesFeature) discover(path string, files []string) error {
+func (f *RootModulesFeature) discover(path string, files []string) (*document.DirHandle, error) {
 	rawUri := uri.FromPath(path)
 	if uri, ok := datadir.ModuleUriFromDataDir(rawUri); ok {
 		f.logger.Printf("discovered root module in %s", uri)
 		dir := document.DirHandleFromURI(uri)
 		err := f.Store.AddIfNotExists(dir.Path())
 		if err != nil {
-			return err
+			return nil, err
 		}
 
-		return nil
+		return &dir, nil
 	}
 
 	for _, file := range files {
@@ -37,14 +37,15 @@ func (f *RootModulesFeature) discover(path string, files []string) error {
 
 			err := f.Store.AddIfNotExists(path)
 			if err != nil {
-				return err
+				return nil, err
 			}
 
-			break
+			dir := document.DirHandleFromPath(path)
+			return &dir, nil
 		}
 	}
 
-	return nil
+	return nil, nil
 }
 
 func (f *RootModulesFeature) didOpen(ctx context.Context, dir document.DirHandle) (job.IDs, error) {

--- a/internal/features/rootmodules/root_modules_feature.go
+++ b/internal/features/rootmodules/root_modules_feature.go
@@ -86,7 +86,10 @@ func (f *RootModulesFeature) Start(ctx context.Context) {
 			select {
 			case discover := <-discover:
 				// TODO? collect errors
-				f.discover(discover.Path, discover.Files)
+				dir, _ := f.discover(discover.Path, discover.Files)
+				if dir != nil {
+					f.didOpen(discover.Context, *dir)
+				}
 				discoverDone <- job.IDs{}
 			case didOpen := <-didOpen:
 				// TODO? collect errors

--- a/internal/features/rootmodules/root_modules_feature_test.go
+++ b/internal/features/rootmodules/root_modules_feature_test.go
@@ -4,11 +4,13 @@
 package rootmodules
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/go-version"
+	lsctx "github.com/hashicorp/terraform-ls/internal/context"
 	"github.com/hashicorp/terraform-ls/internal/eventbus"
 	"github.com/hashicorp/terraform-ls/internal/filesystem"
 	globalState "github.com/hashicorp/terraform-ls/internal/state"
@@ -120,5 +122,43 @@ func TestRootModulesFeature_TerraformVersion(t *testing.T) {
 				t.Fatalf("version mismatch for %q: %s", tc.path, diff)
 			}
 		})
+	}
+}
+
+func TestRootModulesFeature_DiscoverDidOpen(t *testing.T) {
+	gs, err := globalState.NewStateStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	eventBus := eventbus.NewEventBus()
+	fs := filesystem.NewFilesystem(gs.DocumentStore)
+
+	feature, err := NewRootModulesFeature(eventBus, gs, fs, exec.NewMockExecutor(nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rootPath := t.TempDir()
+	ctx := lsctx.WithDocumentContext(context.Background(), lsctx.Document{})
+
+	dir, err := feature.discover(rootPath, []string{".terraform.lock.hcl"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dir == nil {
+		t.Fatalf("expected discover to register root module %q", rootPath)
+	}
+
+	if _, err := feature.didOpen(ctx, *dir); err != nil {
+		t.Fatal(err)
+	}
+
+	ids, err := gs.JobStore.ListIncompleteJobsForDir(*dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ids) == 0 {
+		t.Fatalf("expected jobs for inited root module %q", rootPath)
 	}
 }

--- a/internal/walker/walker.go
+++ b/internal/walker/walker.go
@@ -188,8 +188,9 @@ func (w *Walker) walk(ctx context.Context, dir document.DirHandle) error {
 	}
 
 	w.eventBus.Discover(eventbus.DiscoverEvent{
-		Path:  dir.Path(),
-		Files: files,
+		Context: ctx,
+		Path:    dir.Path(),
+		Files:   files,
 	})
 
 	for _, dirEntry := range dirEntries {


### PR DESCRIPTION
When in a module with a "submodule" (i.e. a Terraform module beneath the root module that doesn't have an initialised workspace of its own), the language server fails to load the provider data when editing a submodule file directly. This prevents most language server features from working.

We fix this by calling `didOpen` on `Start`. This is effective as it emulates what happens when we are editing a root module file.

Closes: #2039