### PR TITLE
lsp: fix negative deltaStartChar in semanticTokens/full for multi-line tokens

### DIFF
--- a/internal/lsp/token_encoder.go
+++ b/internal/lsp/token_encoder.go
@@ -57,10 +57,22 @@ func (te *TokenEncoder) encodeTokenOfIndex(i int) []uint32 {
 	previousLine := 0
 	previousStartChar := 0
 	if i > 0 {
-		previousLine = te.Tokens[te.lastEncodedTokenIdx].Range.End.Line - 1
-		currentLine := te.Tokens[i].Range.End.Line - 1
+		prevToken := te.Tokens[te.lastEncodedTokenIdx]
+		previousLine = prevToken.Range.End.Line - 1
+		currentLine := token.Range.Start.Line - 1
 		if currentLine == previousLine {
-			previousStartChar = te.Tokens[te.lastEncodedTokenIdx].Range.Start.Column - 1
+			if prevToken.Range.Start.Line != prevToken.Range.End.Line {
+				// The previous token was emitted as multiple rows (see the
+				// multi-line branch below), so the last row we emitted for
+				// it is a continuation line, which always starts at column
+				// 0 - not at the overall token's Start.Column, which is on
+				// an earlier line. Using Start.Column here would produce a
+				// bogus (and potentially negative, i.e. underflowing the
+				// uint32 wire format) deltaStartChar for the next token.
+				previousStartChar = 0
+			} else {
+				previousStartChar = prevToken.Range.Start.Column - 1
+			}
 		}
 	}
 

--- a/internal/lsp/token_encoder_test.go
+++ b/internal/lsp/token_encoder_test.go
@@ -228,6 +228,82 @@ func TestTokenEncoder_deltaStartCharBug(t *testing.T) {
 	}
 }
 
+// TestTokenEncoder_multiLineTokenFollowedBySameLineToken is a regression
+// test for a case where a multi-line token (e.g. the literal text of a
+// heredoc between two interpolations) is immediately followed by another
+// token starting on the same line where the multi-line token ended (e.g.
+// the first token of the next interpolation's expression). The follow-up
+// token's deltaStartChar used to be computed relative to the *start* of
+// the multi-line token (which is on an earlier line, and can be at a much
+// larger column) instead of relative to column 0 of the continuation line
+// it actually ended on, producing a negative delta that underflows the
+// uint32 wire format used by textDocument/semanticTokens/full.
+//
+// See https://github.com/hashicorp/terraform-ls/issues/2137
+func TestTokenEncoder_multiLineTokenFollowedBySameLineToken(t *testing.T) {
+	bytes := []byte(`locals {
+  content = <<-EOT
+    --constraint "/usr/local/${local.key}"
+    ${join("\n", local.pkgs)}
+  EOT
+}
+`)
+	te := &TokenEncoder{
+		Lines: source.MakeSourceLines("test.tf", bytes),
+		Tokens: []lang.SemanticToken{
+			{
+				// The literal heredoc text between the two interpolations:
+				// starts right after `${local.key}` on line 3 (column 42)
+				// and continues onto line 4, ending right before `${join`
+				// (column 5).
+				Type: lang.TokenString,
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 3, Column: 42, Byte: 0},
+					End:      hcl.Pos{Line: 4, Column: 5, Byte: 0},
+				},
+			},
+			{
+				// "join", the first token of the second interpolation,
+				// starts on the same line the previous token ended on, but
+				// at a much smaller column.
+				Type: lang.TokenFunctionName,
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 4, Column: 5, Byte: 100},
+					End:      hcl.Pos{Line: 4, Column: 9, Byte: 104},
+				},
+			},
+		},
+		ClientCaps: protocol.SemanticTokensClientCapabilities{
+			TokenTypes:     serverTokenTypes.AsStrings(),
+			TokenModifiers: serverTokenModifiers.AsStrings(),
+		},
+	}
+	data := te.Encode()
+
+	// None of the emitted deltaStartChar values (index 1 of every group of
+	// 5) may be negative-wrapped into a huge uint32.
+	for i := 1; i < len(data); i += 5 {
+		if data[i] > uint32(len(bytes)) {
+			t.Fatalf("deltaStartChar at data[%d] = %d looks like an underflowed negative value.\nfull data: %#v", i, data[i], data)
+		}
+	}
+
+	// The "join" token's deltaStartChar should be relative to column 0 of
+	// its own line (since the previous token's last emitted row was a
+	// continuation line), i.e. 4.
+	expectedData := []uint32{
+		2, 41, 42, 13, 0,
+		1, 0, 4, 13, 0,
+		0, 4, 4, 21, 0,
+	}
+	if diff := cmp.Diff(expectedData, data); diff != "" {
+		t.Fatalf("unexpected encoded data.\nexpected: %#v\ngiven:    %#v",
+			expectedData, data)
+	}
+}
+
 func TestTokenEncoder_tokenModifiers(t *testing.T) {
 	bytes := []byte(`myblock "mytype" {
   str_attr = "something"


### PR DESCRIPTION
## What's the bug

`textDocument/semanticTokens/full` can return a token with a negative `deltaStartChar` that wraps around the `uint32` wire format the LSP spec uses for relative token encoding, producing a huge value (e.g. `4294967261` = 2^32 - 35). This can hang naively-implemented LSP clients - Neovim's built-in client spins at 100% CPU in `vim.str_utfindex` until killed.

Reproduces with a heredoc containing two interpolations, where the literal text between them spans two lines, e.g.:

```hcl
locals {
  content = <<-EOT
    --constraint "/usr/local/${local.key}"
    ${join("\n", local.pkgs)}
  EOT
}
```

## Root cause

`TokenEncoder.encodeTokenOfIndex` (`internal/lsp/token_encoder.go`) computes the reference column used for the *next* token's `deltaStartChar` from the *start* column of the previously emitted token:

```go
previousLine = te.Tokens[te.lastEncodedTokenIdx].Range.End.Line - 1
currentLine := te.Tokens[i].Range.End.Line - 1
if currentLine == previousLine {
    previousStartChar = te.Tokens[te.lastEncodedTokenIdx].Range.Start.Column - 1
}
```

This is correct when the previous token is single-line. But when the previous token was multi-line, it gets emitted as multiple rows further down (the `else` branch), and the *last* emitted row is always a continuation line that starts at column 0 - not at the token's overall `Start.Column`, which is on an earlier line and can be at a much larger column.

In the repro above, the literal string token between the two interpolations spans from right after `${local.key}` on line 3 to right before `${join(...)}` on line 4. Its `Start.Column` (on line 3) is large; its last emitted row (line 4) actually starts at column 0. The next token (`join`, at a small column on line 4) then computes `deltaStartChar = smallColumn - largeColumn`, going negative and wrapping the `uint32`.

I also fixed a related bug in the same block: `currentLine` was compared against the *current* token's `End.Line` instead of its `Start.Line`. This only matters when the current token being encoded is itself multi-line and starts on the same line the previous token ended on - for single-line tokens `Start.Line == End.Line` so it was a no-op, which is why it hadn't surfaced with the same symptom.

## The fix

Track whether the previously emitted token was itself multi-line, and if so, use `0` (start of its continuation line) as the reference column instead of its overall `Start.Column`.

## Testing

- Added `TestTokenEncoder_multiLineTokenFollowedBySameLineToken` (`internal/lsp/token_encoder_test.go`), modeled directly on the reduction above (a multi-line token immediately followed by a same-line token). It asserts no `deltaStartChar` value looks like an underflowed negative, and checks the exact expected encoding.
- Verified by reverting just the `token_encoder.go` change and rerunning: the test fails with `deltaStartChar at data[11] = 4294967259`, the same underflow class as this issue (2^32 - 37 vs. the issue's 2^32 - 35).
- Also verified end-to-end against the *exact* `repro.tf` from this issue via the `textDocument/semanticTokens/full` handler (temporary local test, not included in this PR): on unmodified code it returns `0xffffffdd` = `4294967261` = 2^32 - 35 - an exact match for the value reported in this issue. With the fix, the same request returns a well-formed response with no oversized deltas.
- Ran the full `internal/lsp/...` and `internal/langserver/...` suites; all pass.

Fixes #2137