### PR TITLE
fix(state): render nil job error as <nil> instead of %!s(<nil>)

### DIFF
--- a/.changes/unreleased/BUG FIXES-20260904-215310.yaml
+++ b/.changes/unreleased/BUG FIXES-20260904-215310.yaml
@@ -1,0 +1,6 @@
+kind: BUG FIXES
+body: Fixed job completion logs rendering a successful job's nil error as the literal text `%!s(<nil>)`
+time: 2026-09-04T21:53:10.587251+02:00
+custom:
+    Issue: "2175"
+    Repository: terraform-ls

--- a/internal/state/jobs.go
+++ b/internal/state/jobs.go
@@ -484,7 +484,7 @@ func (js *JobStore) FinishJob(id job.ID, jobErr error, deferredJobIds ...job.ID)
 		return fmt.Errorf("failed to copy a job: %w", err)
 	}
 
-	js.logger.Printf("JOBS: Finishing job %q: %q for %q (err = %s, deferredJobs: %q)",
+	js.logger.Printf("JOBS: Finishing job %q: %q for %q (err = %v, deferredJobs: %q)",
 		sj.ID, sj.Type, sj.Dir, jobErr, deferredJobIds)
 
 	err = js.removeJobFromDependsOn(txn, id)

--- a/internal/state/jobs_test.go
+++ b/internal/state/jobs_test.go
@@ -4,6 +4,7 @@
 package state
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -12,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -649,6 +651,63 @@ func TestJobStore_FinishJob_basic(t *testing.T) {
 	}
 	if diff := cmp.Diff(expectedQueuedIds, queuedIds); diff != "" {
 		t.Fatalf("unexpected queued jobs: %s", diff)
+	}
+}
+
+func TestJobStore_FinishJob_logging(t *testing.T) {
+	testCases := []struct {
+		name        string
+		jobErr      error
+		expectedErr string
+	}{
+		{
+			name:        "successful job",
+			jobErr:      nil,
+			expectedErr: "err = <nil>",
+		},
+		{
+			name:        "failed job",
+			jobErr:      errors.New("job went wrong"),
+			expectedErr: "err = job went wrong",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ss, err := NewStateStore()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			logBuf := &bytes.Buffer{}
+			ss.SetLogger(log.New(logBuf, "", 0))
+
+			ctx := context.Background()
+			ctx = lsctx.WithDocumentContext(ctx, lsctx.Document{})
+			id, err := ss.JobStore.EnqueueJob(ctx, job.Job{
+				Func: func(ctx context.Context) error {
+					return tc.jobErr
+				},
+				Dir:  document.DirHandleFromPath("/test-1"),
+				Type: "test-type",
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			err = ss.JobStore.FinishJob(id, tc.jobErr)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			logged := logBuf.String()
+			if strings.Contains(logged, "%!") {
+				t.Fatalf("log contains a formatting error: %s", logged)
+			}
+			if !strings.Contains(logged, tc.expectedErr) {
+				t.Fatalf("expected log to contain %q, given: %s", tc.expectedErr, logged)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
FinishJob formats jobErr with %s, but jobErr is nil for every job that succeeds, and Go renders a nil error under %s as the literal text "%!s(<nil>)". Switching to %v prints <nil> and leaves the message shape unchanged for the failure case.

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
