### PR TITLE
fix(logging): don't log StateNotChangedErr as an error

### DIFF
--- a/.changes/unreleased/BUG FIXES-20260904-220513.yaml
+++ b/.changes/unreleased/BUG FIXES-20260904-220513.yaml
@@ -1,0 +1,6 @@
+kind: BUG FIXES
+body: Stop logging the internal `state not changed` no-op sentinel as an error when loading metadata
+time: 2026-09-04T22:05:13.050158+02:00
+custom:
+    Issue: "2176"
+    Repository: terraform-ls

--- a/internal/features/modules/events.go
+++ b/internal/features/modules/events.go
@@ -272,7 +272,7 @@ func (f *ModulesFeature) decodeModule(ctx context.Context, dir document.DirHandl
 		IgnoreState: ignoreState,
 		Defer: func(ctx context.Context, jobErr error) (job.IDs, error) {
 			deferIds := make(job.IDs, 0)
-			if jobErr != nil {
+			if jobErr != nil && !errors.Is(jobErr, job.StateNotChangedErr{}) {
 				f.logger.Printf("loading module metadata returned error: %s", jobErr)
 			}
 

--- a/internal/features/policy/events.go
+++ b/internal/features/policy/events.go
@@ -5,6 +5,7 @@ package policy
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 
@@ -204,7 +205,7 @@ func (f *PolicyFeature) decodePolicy(ctx context.Context, dir document.DirHandle
 		IgnoreState: ignoreState,
 		Defer: func(ctx context.Context, jobErr error) (job.IDs, error) {
 			deferIds := make(job.IDs, 0)
-			if jobErr != nil {
+			if jobErr != nil && !errors.Is(jobErr, job.StateNotChangedErr{}) {
 				f.logger.Printf("loading policy metadata returned error: %s", jobErr)
 			}
 

--- a/internal/features/policytest/events.go
+++ b/internal/features/policytest/events.go
@@ -5,6 +5,7 @@ package policytest
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 
@@ -204,7 +205,7 @@ func (f *PolicyTestFeature) decodePolicyTest(ctx context.Context, dir document.D
 		IgnoreState: ignoreState,
 		Defer: func(ctx context.Context, jobErr error) (job.IDs, error) {
 			deferIds := make(job.IDs, 0)
-			if jobErr != nil {
+			if jobErr != nil && !errors.Is(jobErr, job.StateNotChangedErr{}) {
 				f.logger.Printf("loading policytest metadata returned error: %s", jobErr)
 			}
 

--- a/internal/features/search/events.go
+++ b/internal/features/search/events.go
@@ -5,6 +5,7 @@ package search
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 
@@ -196,7 +197,7 @@ func (f *SearchFeature) decodeSearch(ctx context.Context, dir document.DirHandle
 		Defer: func(ctx context.Context, jobErr error) (job.IDs, error) {
 			deferIds := make(job.IDs, 0)
 
-			if jobErr != nil {
+			if jobErr != nil && !errors.Is(jobErr, job.StateNotChangedErr{}) {
 				f.logger.Printf("loading module metadata returned error: %s", jobErr)
 			}
 

--- a/internal/features/stacks/events.go
+++ b/internal/features/stacks/events.go
@@ -5,6 +5,7 @@ package stacks
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 
@@ -212,7 +213,7 @@ func (f *StacksFeature) decodeStack(ctx context.Context, dir document.DirHandle,
 		Defer: func(ctx context.Context, jobErr error) (job.IDs, error) {
 			deferIds := make(job.IDs, 0)
 
-			if jobErr != nil {
+			if jobErr != nil && !errors.Is(jobErr, job.StateNotChangedErr{}) {
 				f.logger.Printf("loading module metadata returned error: %s", jobErr)
 			}
 

--- a/internal/features/tests/events.go
+++ b/internal/features/tests/events.go
@@ -5,6 +5,7 @@ package tests
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 
@@ -189,7 +190,7 @@ func (f *TestsFeature) decodeTest(ctx context.Context, dir document.DirHandle, i
 		IgnoreState: ignoreState,
 		Defer: func(ctx context.Context, jobErr error) (job.IDs, error) {
 			deferIds := make(job.IDs, 0)
-			if jobErr != nil {
+			if jobErr != nil && !errors.Is(jobErr, job.StateNotChangedErr{}) {
 				f.logger.Printf("loading module metadata returned error: %s", jobErr)
 			}
 

--- a/internal/job/ignore_state.go
+++ b/internal/job/ignore_state.go
@@ -31,3 +31,8 @@ type StateNotChangedErr struct {
 func (e StateNotChangedErr) Error() string {
 	return fmt.Sprintf("%s: state not changed", e.Dir.URI)
 }
+
+func (e StateNotChangedErr) Is(target error) bool {
+	_, ok := target.(StateNotChangedErr)
+	return ok
+}

--- a/internal/job/ignore_state_test.go
+++ b/internal/job/ignore_state_test.go
@@ -1,0 +1,64 @@
+// Copyright IBM Corp. 2020, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package job
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-ls/internal/document"
+)
+
+func TestStateNotChangedErr_Is(t *testing.T) {
+	fooErr := StateNotChangedErr{Dir: document.DirHandleFromPath("/foo")}
+	barErr := StateNotChangedErr{Dir: document.DirHandleFromPath("/bar")}
+
+	testCases := []struct {
+		name        string
+		err         error
+		target      error
+		expectMatch bool
+	}{
+		{
+			name:        "matches zero value regardless of directory",
+			err:         fooErr,
+			target:      StateNotChangedErr{},
+			expectMatch: true,
+		},
+		{
+			name:        "matches sentinel for a different directory",
+			err:         fooErr,
+			target:      barErr,
+			expectMatch: true,
+		},
+		{
+			name:        "matches sentinel for the same directory",
+			err:         fooErr,
+			target:      fooErr,
+			expectMatch: true,
+		},
+		{
+			name:        "matches when wrapped",
+			err:         fmt.Errorf("loading metadata: %w", fooErr),
+			target:      StateNotChangedErr{},
+			expectMatch: true,
+		},
+		{
+			name:        "does not match an unrelated error",
+			err:         errors.New("something actually went wrong"),
+			target:      StateNotChangedErr{},
+			expectMatch: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if match := errors.Is(tc.err, tc.target); match != tc.expectMatch {
+				t.Fatalf("expected errors.Is to return %t, given err=%q target=%q",
+					tc.expectMatch, tc.err, tc.target)
+			}
+		})
+	}
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -95,7 +95,7 @@ func (s *Scheduler) eval(ctx context.Context) {
 		jobErr := nextJob.Func(ctx)
 
 		if jobErr != nil {
-			if errors.Is(jobErr, job.StateNotChangedErr{Dir: nextJob.Dir}) {
+			if errors.Is(jobErr, job.StateNotChangedErr{}) {
 				span.SetStatus(codes.Ok, "state not changed")
 			} else {
 				span.RecordError(jobErr)


### PR DESCRIPTION
StateNotChangedErr is an idempotency sentinel returned by jobs that find their state already up to date. The scheduler already treats it as success, but the Defer callbacks that log job errors did not, so every no-op produced a "loading <x> metadata returned error" line.

Give StateNotChangedErr an Is method so callers can match the sentinel via errors.Is without knowing which directory raised it, and use that to skip logging in the six feature packages that share this pattern. The scheduler can now use the same plain form instead of reconstructing the sentinel with the job's directory.

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
