### PR TITLE
fix(logging): don't report shutdown cancellation as a failure

### DIFF
--- a/.changes/unreleased/BUG FIXES-20260904-221021.yaml
+++ b/.changes/unreleased/BUG FIXES-20260904-221021.yaml
@@ -1,0 +1,6 @@
+kind: BUG FIXES
+body: Stopped reporting ordinary shutdown cancellation as a notification or job failure in the logs
+time: 2026-09-04T22:10:21.658686+02:00
+custom:
+    Issue: "2177"
+    Repository: terraform-ls

--- a/internal/langserver/notifier/notifier.go
+++ b/internal/langserver/notifier/notifier.go
@@ -51,6 +51,9 @@ func (n *Notifier) Start(ctx context.Context) {
 
 			err := n.notify(ctx)
 			if err != nil {
+				if errors.Is(err, context.Canceled) {
+					continue
+				}
 				n.logger.Printf("failed to notify a change batch: %s", err)
 			}
 		}

--- a/internal/langserver/notifier/notifier_test.go
+++ b/internal/langserver/notifier/notifier_test.go
@@ -4,10 +4,12 @@
 package notifier
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io/ioutil"
 	"log"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -37,6 +39,74 @@ func TestNotifier(t *testing.T) {
 
 	wg.Wait()
 }
+
+func TestNotifier_cancellationIsNotLoggedAsFailure(t *testing.T) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+
+	logBuf := &bytes.Buffer{}
+	var mu sync.Mutex
+	safeWriter := writerFunc(func(p []byte) (int, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		return logBuf.Write(p)
+	})
+
+	awaiting := make(chan struct{}, 1)
+	stopped := make(chan struct{}, 1)
+	notifier := NewNotifier(cancellingChangeStore{
+		awaiting: awaiting,
+		stopped:  stopped,
+	}, []Hook{})
+	notifier.SetLogger(log.New(safeWriter, "", 0))
+
+	notifier.Start(ctx)
+
+	select {
+	case <-awaiting:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the notifier to await a change batch")
+	}
+	cancelFunc()
+
+	select {
+	case <-stopped:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the notifier to stop")
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	mu.Lock()
+	logged := logBuf.String()
+	mu.Unlock()
+
+	if strings.Contains(logged, "failed to notify") {
+		t.Fatalf("shutdown reported as a failure: %s", logged)
+	}
+}
+
+type cancellingChangeStore struct {
+	awaiting chan struct{}
+	stopped  chan struct{}
+}
+
+func (cs cancellingChangeStore) AwaitNextChangeBatch(ctx context.Context) (state.ChangeBatch, error) {
+	signal(cs.awaiting)
+	<-ctx.Done()
+	signal(cs.stopped)
+	return state.ChangeBatch{}, ctx.Err()
+}
+
+func signal(ch chan struct{}) {
+	select {
+	case ch <- struct{}{}:
+	default:
+	}
+}
+
+type writerFunc func(p []byte) (int, error)
+
+func (w writerFunc) Write(p []byte) (int, error) { return w(p) }
 
 type mockModuleStore struct {
 	returned bool

--- a/internal/state/jobs.go
+++ b/internal/state/jobs.go
@@ -398,14 +398,16 @@ func (js *JobStore) WaitForJobs(ctx context.Context, ids ...job.ID) error {
 		for _, id := range ids {
 			ids, err := js.waitForJobId(ctx, id)
 			if err != nil {
-				js.logger.Printf("error waiting for job %q: %s", id, err)
+				if !errors.Is(err, context.Canceled) {
+					js.logger.Printf("error waiting for job %q: %s", id, err)
+				}
 				return
 			}
 			deferredJobIds = append(deferredJobIds, ids...)
 		}
 
 		err := js.WaitForJobs(ctx, deferredJobIds...)
-		if err != nil {
+		if err != nil && !errors.Is(err, context.Canceled) {
 			js.logger.Printf("error waiting for %d deferred jobs: %s", len(deferredJobIds), err)
 		}
 	}()


### PR DESCRIPTION
Cancelling the server's context is how shutdown works, but three places logged the resulting context.Canceled as though something had gone wrong:

  failed to notify a change batch: context canceled
  error waiting for job "N": context canceled
  error waiting for 20 deferred jobs: context canceled

The notifier case is also redundant, since the loop immediately logs "stopping notifier" on the next iteration.

Skip the message when the error is context.Canceled. Genuine failures are still logged.

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
