### PR TITLE
Return null for definition when no reference origin is found

### DIFF
--- a/internal/langserver/handlers/go_to_ref_target.go
+++ b/internal/langserver/handlers/go_to_ref_target.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/hcl-lang/decoder"
 	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/reference"
 	ilsp "github.com/hashicorp/terraform-ls/internal/lsp"
 	lsp "github.com/hashicorp/terraform-ls/internal/protocol"
 )
@@ -20,6 +21,9 @@ func (svc *service) GoToDefinition(ctx context.Context, params lsp.TextDocumentP
 
 	targets, err := svc.goToReferenceTarget(ctx, params)
 	if err != nil {
+		if _, ok := err.(*reference.NoOriginFound); ok {
+			return nil, nil
+		}
 		return nil, err
 	}
 
@@ -34,6 +38,9 @@ func (svc *service) GoToDeclaration(ctx context.Context, params lsp.TextDocument
 
 	targets, err := svc.goToReferenceTarget(ctx, params)
 	if err != nil {
+		if _, ok := err.(*reference.NoOriginFound); ok {
+			return nil, nil
+		}
 		return nil, err
 	}
 

--- a/internal/langserver/handlers/go_to_ref_target_test.go
+++ b/internal/langserver/handlers/go_to_ref_target_test.go
@@ -120,6 +120,91 @@ output "foo" {
 		}`, tmpDir.URI))
 }
 
+func TestDefinition_noReferenceOrigin(t *testing.T) {
+	tmpDir := TempDir(t)
+
+	ss, err := state.NewStateStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	wc := walker.NewWalkerCollector()
+
+	ls := langserver.NewLangServerMock(t, NewMockSession(&MockSessionInput{
+		TerraformCalls: &exec.TerraformMockCalls{
+			PerWorkDir: map[string][]*mock.Call{
+				tmpDir.Path(): {
+					{
+						Method:        "Version",
+						Repeatability: 1,
+						Arguments: []interface{}{
+							mock.AnythingOfType(""),
+						},
+						ReturnArguments: []interface{}{
+							version.Must(version.NewVersion("0.12.0")),
+							nil,
+							nil,
+						},
+					},
+					{
+						Method:        "GetExecPath",
+						Repeatability: 1,
+						ReturnArguments: []interface{}{
+							"",
+						},
+					},
+				},
+			},
+		},
+		StateStore:      ss,
+		WalkerCollector: wc,
+	}))
+	stop := ls.Start(t)
+	defer stop()
+
+	ls.Call(t, &langserver.CallRequest{
+		Method: "initialize",
+		ReqParams: fmt.Sprintf(`{
+			"capabilities": {},
+			"rootUri": %q,
+			"processId": 12345
+	}`, tmpDir.URI)})
+	waitForWalkerPath(t, ss, wc, tmpDir)
+	ls.Notify(t, &langserver.CallRequest{
+		Method:    "initialized",
+		ReqParams: "{}",
+	})
+	ls.Call(t, &langserver.CallRequest{
+		Method: "textDocument/didOpen",
+		ReqParams: fmt.Sprintf(`{
+		"textDocument": {
+			"version": 0,
+			"languageId": "terraform",
+			"text": `+fmt.Sprintf("%q",
+			`# just a comment
+variable "test" {
+}`)+`,
+			"uri": "%s/main.tf"
+		}
+	}`, tmpDir.URI)})
+	waitForAllJobs(t, ss)
+
+	ls.CallAndExpectResponse(t, &langserver.CallRequest{
+		Method: "textDocument/definition",
+		ReqParams: fmt.Sprintf(`{
+			"textDocument": {
+				"uri": "%s/main.tf"
+			},
+			"position": {
+				"line": 0,
+				"character": 5
+			}
+		}`, tmpDir.URI)}, `{
+			"jsonrpc": "2.0",
+			"id": 3,
+			"result": null
+		}`)
+}
+
 func TestDefinition_withLinkToDefLessBlock(t *testing.T) {
 	tmpDir := TempDir(t)
 	InitPluginCache(t, tmpDir.Path())
@@ -615,6 +700,91 @@ output "foo" {
 				}
 			}]
 		}`, tmpDir.URI))
+}
+
+func TestDeclaration_noReferenceOrigin(t *testing.T) {
+	tmpDir := TempDir(t)
+
+	ss, err := state.NewStateStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	wc := walker.NewWalkerCollector()
+
+	ls := langserver.NewLangServerMock(t, NewMockSession(&MockSessionInput{
+		TerraformCalls: &exec.TerraformMockCalls{
+			PerWorkDir: map[string][]*mock.Call{
+				tmpDir.Path(): {
+					{
+						Method:        "Version",
+						Repeatability: 1,
+						Arguments: []interface{}{
+							mock.AnythingOfType(""),
+						},
+						ReturnArguments: []interface{}{
+							version.Must(version.NewVersion("0.12.0")),
+							nil,
+							nil,
+						},
+					},
+					{
+						Method:        "GetExecPath",
+						Repeatability: 1,
+						ReturnArguments: []interface{}{
+							"",
+						},
+					},
+				},
+			},
+		},
+		StateStore:      ss,
+		WalkerCollector: wc,
+	}))
+	stop := ls.Start(t)
+	defer stop()
+
+	ls.Call(t, &langserver.CallRequest{
+		Method: "initialize",
+		ReqParams: fmt.Sprintf(`{
+			"capabilities": {},
+			"rootUri": %q,
+			"processId": 12345
+	}`, tmpDir.URI)})
+	waitForWalkerPath(t, ss, wc, tmpDir)
+	ls.Notify(t, &langserver.CallRequest{
+		Method:    "initialized",
+		ReqParams: "{}",
+	})
+	ls.Call(t, &langserver.CallRequest{
+		Method: "textDocument/didOpen",
+		ReqParams: fmt.Sprintf(`{
+		"textDocument": {
+			"version": 0,
+			"languageId": "terraform",
+			"text": `+fmt.Sprintf("%q",
+			`# just a comment
+variable "test" {
+}`)+`,
+			"uri": "%s/main.tf"
+		}
+	}`, tmpDir.URI)})
+	waitForAllJobs(t, ss)
+
+	ls.CallAndExpectResponse(t, &langserver.CallRequest{
+		Method: "textDocument/declaration",
+		ReqParams: fmt.Sprintf(`{
+			"textDocument": {
+				"uri": "%s/main.tf"
+			},
+			"position": {
+				"line": 0,
+				"character": 5
+			}
+		}`, tmpDir.URI)}, `{
+			"jsonrpc": "2.0",
+			"id": 3,
+			"result": null
+		}`)
 }
 
 func TestDeclaration_withLinkSupport(t *testing.T) {


### PR DESCRIPTION
## Summary

`textDocument/definition` and `textDocument/declaration` were returning a JSON-RPC system error (`-32098`, `no reference origin found`) when the cursor was not on a reference origin. Per the LSP spec those methods return `Location | Location[] | LocationLink[] | null`, so “nothing here” should be a null result, not a failed request.

Map `reference.NoOriginFound` to a null result in both handlers.

## Test plan

- [x] `go test ./internal/langserver/handlers/ -run 'TestDefinition_noReferenceOrigin|TestDeclaration_noReferenceOrigin' -count=1`

Fixes #2178